### PR TITLE
Assume image/jpeg if no content type informed in vcard. Fixes #133

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/resources/dpf/mg/udi/gpinf/vcardparser/hcard-template.html
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/dpf/mg/udi/gpinf/vcardparser/hcard-template.html
@@ -113,6 +113,8 @@
 						<#elseif photo.data??>
 							<#if photo.contentType??>
 								<#assign imgSrc=utils.base64(photo.contentType.mediaType, photo.data)>
+                            <#else>
+                                <#assign imgSrc=utils.base64("image/jpeg", photo.data)>
 							</#if>
 						</#if>
 						<#assign imgClass="photo">


### PR DESCRIPTION
Fixes #133 