### PR TITLE
Add regexes for bitcoin related private Keys.

### DIFF
--- a/iped-app/resources/config/profiles/en/blind/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/blind/conf/RegexConfig.txt
@@ -40,6 +40,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/en/default/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/default/conf/RegexConfig.txt
@@ -40,6 +40,13 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/en/fastmode/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/fastmode/conf/RegexConfig.txt
@@ -40,6 +40,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/en/forensic/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/forensic/conf/RegexConfig.txt
@@ -40,6 +40,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/en/pedo/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/pedo/conf/RegexConfig.txt
@@ -40,6 +40,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/en/triage/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/triage/conf/RegexConfig.txt
@@ -40,6 +40,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/blind/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/blind/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/default/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/default/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/fastmode/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/fastmode/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/forensic/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/forensic/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/pedo/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/pedo/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-app/resources/config/profiles/pt-BR/triage/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/triage/conf/RegexConfig.txt
@@ -53,6 +53,12 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
 CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+# As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
+CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K, 1, 1, false = [^0-9a-zA-Z][KL][a-km-zA-HJ-NP-Z1-9]{51}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY, 1, 1, false = [^0-9a-zA-Z]xprv[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
+CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY, 1, 1, false = [^0-9a-zA-Z]xpub[a-km-zA-HJ-NP-Z1-9]{107,108}[^0-9a-zA-Z]
 
 CRIPTOCOIN_MONERO, 1, 1, false = [^0-9a-zA-Z]4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}[^0-9a-zA-Z]
 

--- a/iped-engine/src/main/java/br/gov/pf/iped/regex/BitcoinAddressValidatorService.java
+++ b/iped-engine/src/main/java/br/gov/pf/iped/regex/BitcoinAddressValidatorService.java
@@ -27,7 +27,9 @@ public class BitcoinAddressValidatorService extends BasicAbstractRegexValidatorS
 
     @Override
     public List<String> getRegexNames() {
-        return Arrays.asList("CRIPTOCOIN_BITCOIN_ADDRESS");
+        return Arrays.asList("CRIPTOCOIN_BITCOIN_ADDRESS", "CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K",
+                "CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K", "CRIPTOCOIN_BITCOIN_WIF_PRIV_K_COMP_PUB_K",
+                "CRIPTOCOIN_BITCOIN_BIP32_HD_XPRV_KEY", "CRIPTOCOIN_BITCOIN_BIP32_HD_XPUB_KEY");
     }
 
     @Override
@@ -41,7 +43,23 @@ public class BitcoinAddressValidatorService extends BasicAbstractRegexValidatorS
         } else {
             try {
                 int addressHeader = getAddressHeader(addr);
-                return (addressHeader == 0 || addressHeader == 5);
+                switch (addr.charAt(0)) {
+                    case '1':
+                        return addressHeader == 0;
+                    case '3':
+                        return addressHeader == 5;
+                    case '5':
+                    case 'K':
+                    case 'L':
+                        return addressHeader == 128;
+                    default:
+                }
+
+                if (addr.startsWith("xpub")) {
+                    return addressHeader == 4 || addressHeader == 136 || addressHeader == 178 || addressHeader == 30;
+                } else if (addr.startsWith("xprv")) {
+                    return addressHeader == 4 || addressHeader == 136 || addressHeader == 173 || addressHeader == 228;
+                }
             } catch (Exception x) {
             }
         }


### PR DESCRIPTION
Added some regex and validation for bitcoin keys and wallet formats.

The regexes were adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond
& Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem
Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP.
10.1109/ACCESS.2019.2948774.

All these keys and addresses are encoded the same way as standard bitcoin addresses (Base58), so the validation was already implemented (except for the differend address headers).

In this PR, the following regexes were included:

    
    WIF private key (5[a-km-zA-HJ-NP-Z1-9]{50})
    WIF compressed private key ([KL][a-km-zA-HJ-NP-Z1-9]{51})
    Encrypted private key (6P[a-km-zA-HJ-NP-Z1-9]{56})
    Extended private key (xprv[a-km-zA-HJ-NP-Z1-9]{107,108})
    Extended public key (xpub[a-km-zA-HJ-NP-Z1-9]{107,108})

The "mini private key" was not included this time because it uses a different validation. It's planned for inclusion later.