### PR TITLE
Avoid starting too many Sleuthkit servers in robust mode. Fix #397

### DIFF
--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Manager.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Manager.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.logging.log4j.Level;
@@ -134,6 +135,8 @@ public class Manager {
     private Thread commitThread = null;
     AtomicLong partialCommitsTime = new AtomicLong();
 
+    private final AtomicBoolean initSleuthkitServers = new AtomicBoolean(false);
+    
     public static Manager getInstance() {
         return instance;
     }
@@ -294,7 +297,12 @@ public class Manager {
     }
 
     public void initSleuthkitServers(final String dbPath) throws InterruptedException {
-        SleuthkitClient.initSleuthkitServers(dbPath);
+        synchronized (initSleuthkitServers) {
+            if (!initSleuthkitServers.get()) {
+                SleuthkitClient.initSleuthkitServers(dbPath);
+                initSleuthkitServers.set(true);
+            }
+        }
     }
 
     private void shutDownSleuthkitServers() {


### PR DESCRIPTION
This pull request only makes sense if the described behavior in #397 was not intentional.