### PR TITLE
An attempt to fix #471

### DIFF
--- a/iped-app/resources/config/conf/Log4j2ConfigurationFile.xml
+++ b/iped-app/resources/config/conf/Log4j2ConfigurationFile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration status="INFO" packages="gpinf.util.log">
 	<CustomLevels>
     	<CustomLevel name="MSG" intLevel="250" />
   	</CustomLevels>


### PR DESCRIPTION
The proposed change is an attempt to fix this issue.
I wasn't able to reproduce the problem after making the change in the Log4J configuration file (Log4j2ConfigurationFile.xml), but I am not sure if the issue is really gone.
The idea behind this change was to explicitly inform the package of PackageRegexpFilter class, so Log4j can always find it. 
Without this information, it tries to automatically find it, but it may fail depending on the order classes were built and loaded.