### PR TITLE
Change Bitcoin SegWit address Regex to be more specific.

### DIFF
--- a/iped-app/resources/config/profiles/en/blind/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/blind/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/en/default/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/default/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/en/fastmode/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/fastmode/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/en/forensic/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/forensic/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/en/pedo/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/pedo/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/en/triage/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/en/triage/conf/RegexConfig.txt
@@ -39,7 +39,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 PHONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # The following bitcoin regexes where adapted from Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/blind/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/blind/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/default/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/default/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/fastmode/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/fastmode/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/forensic/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/forensic/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/pedo/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/pedo/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]

--- a/iped-app/resources/config/profiles/pt-BR/triage/conf/RegexConfig.txt
+++ b/iped-app/resources/config/profiles/pt-BR/triage/conf/RegexConfig.txt
@@ -52,7 +52,7 @@ SWIFT, 1 , 1 , false = [^A-Z][A-Z]{4}[A-Z]{2}[A-Z0-9]{2}[a-zA-Z0-9]{3}[^a-zA-Z0-
 
 TELEFONE = ((()|(Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.)([0-9]{4})([^0-9]|()))|(((Tel|Telefone|Phone)(:| |: )| )(\+55 |\+55|())(\([1-9]{2}\)|[1-9]{2})( |\-|())(9[0-9]{4}|[3-5][0-9]{3})( |\-|\.|())([0-9]{4})([^0-9]|()))
 				
-CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[a-z0-9]{20,87}[^0-9a-zA-Z])
+CRIPTOCOIN_BITCOIN_ADDRESS, 1, 1, false = ([^0-9a-zA-Z][13][a-km-zA-HJ-NP-Z1-9]{25,34}[^0-9a-zA-Z])|([^0-9a-zA-Z]bc1[ac-hj-np-z02-9]{11,71}[^0-9a-zA-Z])
 # As seguintes expressoes regulares sobre Bitcoins foram copiadas e adaptadas de Zollner, Stephan & Choo, Kim-Kwang Raymond & Le-Khac, Nhien-An. (2019). An Automated Live Forensic and Postmortem Analysis tool for Bitcoin on Windows Systems. IEEE Access. PP. 10.1109/ACCESS.2019.2948774.
 CRIPTOCOIN_BITCOIN_BIP38_ENC_PRIV_K, 1, 1, false = [^0-9a-zA-Z]6P[a-km-zA-HJ-NP-Z1-9]{56}[^0-9a-zA-Z]
 CRIPTOCOIN_BITCOIN_WIF_PRIV_K_UNC_PUB_K, 1, 1, false = [^0-9a-zA-Z]5[a-km-zA-HJ-NP-Z1-9]{50}[^0-9a-zA-Z]


### PR DESCRIPTION
According to [1], bitcoin SegWit addresses should be between 14 and 74
characters long, and contain only the following characters: [ac-hj-np-z02-9].
The current implementation works, as it has a more broad character set, and the false positives are excluded via checksum. But it doesn't hurt to be more specific.
Tested here with a bunch of files containing valid addresses, and all SegWit addresses were found correctly.
One more detail: it is possible to be even more specific, restricting the size of the address to only 42 or 62 characters. But the specification allows different sizes, that can be implemented in the future. So we chose allow all sizes in order to be future proof.

[1] https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki

