### PR TITLE
Minor fix related to #522, avoiding multiple values.

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -473,7 +473,7 @@ public class MetadataUtil {
                 metadata.remove(oldName);
                 String newName = renameMap.get(oldName);
                 for (String val : values) {
-                    metadata.add(newName, val);
+                    metadata.set(newName, val);
                 }
             }
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -40,6 +40,19 @@ public class MetadataUtil {
 
     private static final Map<String, String> renameMap = getRenameMap();
 
+    private static final Set<String> singleValueKeys = getSingleValKeys();
+
+    private static Set<String> getSingleValKeys() {
+        Set<String> singleValueKeys = new HashSet<>();
+        singleValueKeys.add(ExtraProperties.IMAGE_META_PREFIX + "Make");
+        singleValueKeys.add(ExtraProperties.IMAGE_META_PREFIX + "Model");
+        singleValueKeys.add(ExtraProperties.IMAGE_META_PREFIX + "Width");
+        singleValueKeys.add(ExtraProperties.IMAGE_META_PREFIX + "Height");
+        singleValueKeys.add(ExtraProperties.VIDEO_META_PREFIX + "Width");
+        singleValueKeys.add(ExtraProperties.VIDEO_META_PREFIX + "Height");
+        return singleValueKeys;
+    }
+
     private static Map<String, String> getRenameMap() {
         Map<String, String> rename = new HashMap<String, String>();
         rename.put(ExtraProperties.IMAGE_META_PREFIX + TIFF.EQUIPMENT_MAKE.getName(), ExtraProperties.IMAGE_META_PREFIX + "Make");
@@ -182,6 +195,7 @@ public class MetadataUtil {
         prefixBasicMetadata(metadata);
         removeDuplicateValues(metadata);
         renameKeys(metadata);
+        removeExtraValsFromSingleValueKeys(metadata);
     }
 
     private static void removeDuplicateKeys(Metadata metadata) {
@@ -473,8 +487,18 @@ public class MetadataUtil {
                 metadata.remove(oldName);
                 String newName = renameMap.get(oldName);
                 for (String val : values) {
-                    metadata.set(newName, val);
+                    metadata.add(newName, val);
                 }
+            }
+        }
+    }
+
+    // currently keeps just last value, how to choose?
+    private static void removeExtraValsFromSingleValueKeys(Metadata metadata) {
+        for (String key : singleValueKeys) {
+            String[] values = metadata.getValues(key);
+            if (values != null && values.length > 1) {
+                metadata.set(key, values[values.length - 1]);
             }
         }
     }


### PR DESCRIPTION
@lfcnassif, testing other things here, I found that part of HEIC images had multiple values for "image:Width" and "image:Height".
This happens because drewnoakes/metadata-extractor library are getting wrong data for these fields in some cases.

An example:
```
HEIF Directory (4 tags)
    [HEIF] Width - 512 pixels
    [HEIF] Height - 512 pixels
```
While the correct dimension are:
```
Exif SubIFD Directory (29 tags)
    [Exif SubIFD] Exif Image Width - 9490 pixels
    [Exif SubIFD] Exif Image Height - 3782 pixels
```

The first directory (HEIF) is added to metadata without any prefix (just image:Width, not image:Heic:Width).

When I added the code to rename image related metadata (#522), I used `metadata.add()`, but I think `metadata.set()` would make more sense (these values should be unique anyway), and will avoid this kind of issue (having multiple values in these fields).