### PR TITLE
Closes #49

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFile.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFile.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 import dpf.sp.gpinf.indexer.parsers.KnownMetParser;
 import dpf.sp.gpinf.indexer.parsers.util.ChildPornHashLookup;
@@ -208,10 +209,15 @@ class LibraryFile extends ShareazaEntity {
 
         hashSetHits.addAll(ChildPornHashLookup.lookupHash(md5));
         hashSetHits.addAll(ChildPornHashLookup.lookupHash(sha1));
+
+        AttributesImpl attributes = new AttributesImpl();
+        if (md5 != null && !md5.isEmpty()) {
+            attributes.addAttribute("", "name", "name", "CDATA", md5.toUpperCase());
+        }
         if (!hashSetHits.isEmpty()) {
-            html.startElement("tr", "class", "r"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        } else
-            html.startElement("tr"); //$NON-NLS-1$
+            attributes.addAttribute("", "class", "class", "CDATA", "r");
+        }
+        html.startElement("tr", attributes);
 
         printTd(html, searcher, path, name, index, size, time, getInheritedShared(), virtualSize, virtualBase, sha1,
                 tiger, md5, ed2k, bth, verify, uri, metadataAuto, metadataTime, metadataModified, rating, comments,

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/AresParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/AresParser.java
@@ -40,6 +40,7 @@ import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 import dpf.sp.gpinf.indexer.parsers.util.ChildPornHashLookup;
 import dpf.sp.gpinf.indexer.parsers.util.Messages;
@@ -204,7 +205,12 @@ public class AresParser extends AbstractParser {
                 Arrays.fill(colClass, 8, 13, "z");
             }
 
-            xhtml.startElement("tr", "class", trClass); //$NON-NLS-1$ //$NON-NLS-2$
+            AttributesImpl attributes = new AttributesImpl();
+            attributes.addAttribute("", "class", "class", "CDATA", trClass);
+            if (e != null && e.getHash() != null && !e.getHash().isEmpty()) {
+                attributes.addAttribute("", "name", "name", "CDATA", e.getHash().toUpperCase());
+            }
+            xhtml.startElement("tr", attributes);
             for (int j = 0; j < cells.size(); j++) {
                 if (present[j]) {
                     xhtml.startElement("td", "class", colClass[j]); //$NON-NLS-1$ //$NON-NLS-2$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/KnownMetParser.java
@@ -205,7 +205,12 @@ public class KnownMetParser extends AbstractParser {
                 bytTrf += toSum(e.getBytesTransfered());
             }
 
-            xhtml.startElement("tr", "class", trClass); //$NON-NLS-1$ //$NON-NLS-2$
+            AttributesImpl attributes = new AttributesImpl();
+            attributes.addAttribute("", "class", "class", "CDATA", trClass);
+            if (e != null && e.getHash() != null && !e.getHash().isEmpty()) {
+                attributes.addAttribute("", "name", "name", "CDATA", e.getHash().toUpperCase());    
+            }
+            xhtml.startElement("tr", attributes);
             for (int j = 0; j < cells.size(); j++) {
                 xhtml.startElement("td", "class", colClass[j]); //$NON-NLS-1$ //$NON-NLS-2$
                 if (i < 0 || i >= l.size())


### PR DESCRIPTION
This creates a new "References" tab to list chats where a selected media file is found. When some chat is selected, the viewer scrolls to the media position. This also works to find P2P histories where a media file was shared and also scrolls to position in the selected P2P history.

If anyone could take a look at the changes in P2P parsers and test to make sure nothing was broken, I will cherry pick to 3.18.7.