### PR TITLE
Dark mode adjustments

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/MetadataPanel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/MetadataPanel.java
@@ -67,6 +67,7 @@ import dpf.sp.gpinf.indexer.search.ItemId;
 import dpf.sp.gpinf.indexer.search.MultiSearchResult;
 import dpf.sp.gpinf.indexer.search.QueryBuilder;
 import dpf.sp.gpinf.indexer.ui.controls.HintTextField;
+import dpf.sp.gpinf.indexer.ui.controls.HoverButton;
 import dpf.sp.gpinf.indexer.util.IconUtil;
 import dpf.sp.gpinf.indexer.util.LocalizedFormat;
 import dpf.sp.gpinf.indexer.util.StringUtil;
@@ -99,11 +100,11 @@ public class MetadataPanel extends JPanel
     JComboBox<String> groups;
     JComboBox<String> props = new JComboBox<String>();
     JSlider scale = new JSlider(JSlider.HORIZONTAL, 0, 1, 0);
-    JButton update = new JButton();
+    private final HoverButton update = new HoverButton();
     HintTextField listFilter = new HintTextField(
             "[" + Messages.getString("MetadataPanel.FilterValues") + "] " + (char) 0x2193);
-    JButton copyResultToClipboard = new JButton();
-    private final JButton reset = new JButton();
+    private final HoverButton copyResultToClipboard = new HoverButton();
+    private final HoverButton reset = new HoverButton();
     private final HintTextField propsFilter = new HintTextField(
             "[" + Messages.getString("MetadataPanel.FilterProps") + "] " + (char) 0x2191);
     
@@ -153,20 +154,16 @@ public class MetadataPanel extends JPanel
         update.setIcon(IconUtil.getIcon("refresh", RES_PATH, 16));
         update.setToolTipText(Messages.getString("MetadataPanel.Update"));
         update.setPreferredSize(new Dimension(20, 20));
-        update.setContentAreaFilled(false);
-        update.addMouseListener(new ButtonMouseListener(update));
+        update.addActionListener(this);
 
         copyResultToClipboard.setIcon(IconUtil.getIcon("copy", RES_PATH, 16));
         copyResultToClipboard.setToolTipText(Messages.getString("MetadataPanel.CopyClipboard"));
         copyResultToClipboard.setPreferredSize(new Dimension(20, 20));
-        copyResultToClipboard.setContentAreaFilled(false);
-        copyResultToClipboard.addMouseListener(new ButtonMouseListener(copyResultToClipboard));
+        copyResultToClipboard.addActionListener(this);
         
         reset.setIcon(IconUtil.getIcon("clear", RES_PATH, 16));
         reset.setToolTipText(Messages.getString("MetadataPanel.Clear"));
         reset.setPreferredSize(new Dimension(20, 20));
-        reset.setContentAreaFilled(false);
-        reset.addMouseListener(new ButtonMouseListener(reset));
         reset.addActionListener(this);
 
         list.setFixedCellHeight(18);
@@ -222,8 +219,6 @@ public class MetadataPanel extends JPanel
         l4.add(reset);
 
         listFilter.addActionListener(this);
-        copyResultToClipboard.addActionListener(this);
-        update.addActionListener(this);
 
         JPanel top = new JPanel();
         top.setLayout(new BoxLayout(top, BoxLayout.Y_AXIS));
@@ -1073,34 +1068,6 @@ public class MetadataPanel extends JPanel
 
     }
 
-    private class ButtonMouseListener extends MouseAdapter {
-        
-        private JButton button;
-        
-        private ButtonMouseListener(JButton button) {
-            this.button = button;
-        }
-        
-        @Override
-        public void mouseEntered(MouseEvent e){
-            button.setBorder(BorderFactory.createLineBorder(Color.GRAY, 1, true));
-        }
-        @Override
-        public void mouseExited(MouseEvent e){
-            button.setBorder(null);
-        }
-
-        @Override
-        public void mousePressed(MouseEvent e) {
-            button.setContentAreaFilled(true);
-        }
-
-        @Override
-        public void mouseReleased(MouseEvent e) {
-            button.setContentAreaFilled(false);
-        }
-    }
-    
     private void resetPanel() {
         if (groups.getSelectedItem() != null) {
             boolean empty = list.isSelectionEmpty();

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/themes/DarkTheme.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/themes/DarkTheme.java
@@ -35,6 +35,8 @@ public class DarkTheme extends Theme {
         put("Graph.defaultNode", Color.white);
         put("Graph.selectedNodeBox", Color.white);
         put("Graph.selectionBox", Color.white);
+        put("Tree.expandIcon", new Color(210, 210, 211));
+        put("Tree.expandIconSel", Color.white);
         
         putDock("stack.tab.text.selected.focused", Color.white);
     }

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/ui/controls/HoverButton.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/ui/controls/HoverButton.java
@@ -1,0 +1,88 @@
+package dpf.sp.gpinf.indexer.ui.controls;
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.UIManager;
+
+import dpf.sp.gpinf.indexer.util.UiUtil;
+
+/**
+ * A flat button with no background or border. 
+ * Border and background are only painted when the mouse is over it, 
+ * and with a brighter color when it is pressed. 
+ * It is "theme aware", so colors will change if a new theme is activated.
+ * Currently it only displays icons, but it could handle text.  
+ */
+public class HoverButton extends JButton {
+    private static final long serialVersionUID = 7827182813873015956L;
+    private boolean inside;
+    private boolean pressed;
+    private Color c1, c2, b1, b2;
+
+    @Override
+    public void updateUI() {
+        Color c = UIManager.getColor("control");
+        if (c == null)
+            c = Color.white;
+        Color t = UIManager.getColor("text");
+        if (t == null)
+            t = Color.black;
+        b1 = UiUtil.mix(c, t, 0.8);
+        b2 = UiUtil.mix(c, t, 0.6);
+        c1 = UiUtil.mix(c, Color.white, 0.8);
+        c2 = UiUtil.mix(c, Color.white, 0.6);
+        super.updateUI();
+    }
+
+    public void paint(Graphics g) {
+        if (pressed || inside) {
+            g.setColor(pressed ? c2 : c1);
+            g.fillRect(0, 0, getWidth(), getHeight());
+            g.setColor(pressed ? b2 : b1);
+            g.drawRoundRect(0, 0, getWidth() - 1, getHeight() - 1, 2, 2);
+        }
+        Icon icon = getIcon();
+        if (icon != null)
+            icon.paintIcon(this, g, (getWidth() - icon.getIconWidth()) / 2, (getHeight() - icon.getIconHeight()) / 2);
+
+    }
+
+    public HoverButton() {
+        setContentAreaFilled(false);
+        setFocusPainted(false);
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                inside = true;
+                repaint();
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                inside = false;
+                repaint();
+            }
+
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
+                    pressed = true;
+                    repaint();
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
+                    pressed = false;
+                    repaint();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
I found two minor details related to Dark mode #569, that could be improved:

- In the MetadataPanel, small buttons with icons have a special code to change their background/border when the mouse is over/pressed. It was not working properly when dark mode is selected. I moved the code to handle this from MetadataPanel to a new class (HoverButton), so it can be reused in other places. And this new implementation handles theme colors.
- Expand/collapse icon in trees (for non selected nodes) were hard to see in dark mode (black in a dark background). Because of Nimbus Look and Feel implementation, it was impossible to change it just setting UI properties (it would change other controls together). So I had to overwrite the implementation that paints these icons to make it theme aware.