### PR TITLE
Display albums in new columns - Fix #708

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/AlbumFolder.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/AlbumFolder.java
@@ -79,19 +79,20 @@ class AlbumFolder extends ShareazaEntity {
         }
     }
 
-    public void printTable(XHTMLContentHandler html, IItemSearcher searcher, Map<Integer, LibraryFile> fileByIndex, String path) throws SAXException {
-        if (path == null) {
-            path = "[ALBUM]/" + name; //$NON-NLS-1$
-        } else {
-            path = path + "/" + name; //$NON-NLS-1$
-        }
+    public void printTable(XHTMLContentHandler html, IItemSearcher searcher, Map<Integer, 
+            LibraryFile> fileByIndex, Map<Integer, List<String>> albunsForFiles) throws SAXException {
         for (AlbumFolder folder : albumFolders) {
-            folder.printTable(html, searcher, fileByIndex, path);
+            folder.printTable(html, searcher, fileByIndex, albunsForFiles);
         }
         for (int idx : albumFileIndexes) {
-            LibraryFile file = fileByIndex.get(idx);
-            if (file != null) {
-                file.printTableRow(html, path, searcher);
+            if (albunsForFiles.containsKey(idx)) {
+                // only print files that are only in Albuns (not in library folders)
+                // other files already printed
+                LibraryFile file = fileByIndex.get(idx);
+                if (file != null) {
+                    file.printTableRow(html, "", searcher, albunsForFiles);
+                    albunsForFiles.remove(file.getIndex());
+                }
             }
         }
     }
@@ -118,6 +119,26 @@ class AlbumFolder extends ShareazaEntity {
 
     public List<Integer> getAlbumFileIndexes() {
         return albumFileIndexes;
+    }
+    
+    public void collectAlbunsForFiles(Map<Integer, List<String>> albunsForFiles, String path) {
+        if (path == null) {
+            path = name;
+        } else {
+            path = path + "/" + name;
+        }
+        for (int idx : albumFileIndexes) {
+            List<String> albuns = albunsForFiles.get(idx);
+            if (albuns == null) {
+                albuns = new ArrayList<>();
+                albunsForFiles.put(idx, albuns);
+            }
+            albuns.add(path);
+        }
+        for (AlbumFolder folder : albumFolders) {
+            folder.collectAlbunsForFiles(albunsForFiles, path);
+        }
+        
     }
 
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFile.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFile.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.SAXException;
@@ -205,7 +206,8 @@ class LibraryFile extends ShareazaEntity {
         return "True".equals(getInheritedShared()); //$NON-NLS-1$
     }
 
-    public void printTableRow(XHTMLContentHandler html, String path, IItemSearcher searcher) throws SAXException {
+    public void printTableRow(XHTMLContentHandler html, String path, IItemSearcher searcher,
+            Map<Integer, List<String>> albunsForFiles) throws SAXException {
 
         hashSetHits.addAll(ChildPornHashLookup.lookupHash(md5));
         hashSetHits.addAll(ChildPornHashLookup.lookupHash(sha1));
@@ -217,11 +219,12 @@ class LibraryFile extends ShareazaEntity {
         if (!hashSetHits.isEmpty()) {
             attributes.addAttribute("", "class", "class", "CDATA", "r");
         }
-        html.startElement("tr", attributes);
+        html.startElement("tr", attributes); 
 
-        printTd(html, searcher, path, name, index, size, time, getInheritedShared(), virtualSize, virtualBase, sha1,
-                tiger, md5, ed2k, bth, verify, uri, metadataAuto, metadataTime, metadataModified, rating, comments,
-                shareTags, hitsTotal, uploadsTotal, cachedPreview, bogus);
+        printTd(html, searcher, path, name, albunsForFiles.get(index), index, size, time,
+                getInheritedShared(), virtualSize, virtualBase, sha1, tiger, md5, ed2k, bth, verify, uri,
+                metadataAuto, metadataTime, metadataModified, rating, comments, shareTags, hitsTotal,
+                uploadsTotal, cachedPreview, bogus);
 
         html.endElement("tr"); //$NON-NLS-1$
     }
@@ -232,9 +235,7 @@ class LibraryFile extends ShareazaEntity {
         for (Object o : tdtext) {
             html.startElement("td"); //$NON-NLS-1$
             if (o != null) {
-                if (col != 1) {
-                    html.characters(o.toString());
-                } else {
+                if (col == 1) {
                     IItemBase item = KnownMetParser.searchItemInCase(searcher, "md5", md5);
                     if (item != null) {
                         KnownMetParser.printNameWithLink(html, item, name);
@@ -242,6 +243,20 @@ class LibraryFile extends ShareazaEntity {
                     } else {
                         html.characters(name);
                     }
+                } else if (col == 2) {
+                    @SuppressWarnings("unchecked")
+                    List<String> albums = (List<String>) o;
+                    boolean first = true;
+                    for (String album : albums) {
+                        if (!first) {
+                            html.characters(" | ");
+                        }
+                        html.characters(album);
+                        first = false;
+                        
+                    }
+                } else {
+                    html.characters(o.toString());
                 }
             }
             html.endElement("td"); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFolder.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFolder.java
@@ -108,12 +108,13 @@ class LibraryFolder extends ShareazaEntity {
         }
     }
 
-    public void printTable(XHTMLContentHandler html, IItemSearcher searcher) throws SAXException {
+    public void printTable(XHTMLContentHandler html, IItemSearcher searcher, Map<Integer, List<String>> albunsForFiles) throws SAXException {
         for (LibraryFolder folder : folders) {
-            folder.printTable(html, searcher);
+            folder.printTable(html, searcher, albunsForFiles);
         }
         for (LibraryFile file : files) {
-            file.printTableRow(html, path, searcher);
+            file.printTableRow(html, path, searcher, albunsForFiles);
+            albunsForFiles.remove(file.getIndex());
         }
     }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFolders.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/LibraryFolders.java
@@ -20,6 +20,7 @@ package dpf.mg.udi.gpinf.shareazaparser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -64,10 +65,13 @@ class LibraryFolders extends ShareazaEntity {
     }
 
     public void printTable(XHTMLContentHandler html, IItemSearcher searcher) throws SAXException {
+        Map<Integer, List<String>> albunsForFiles = new HashMap<>();
+        albumRoot.collectAlbunsForFiles(albunsForFiles, null);
+
         for (LibraryFolder folder : folders) {
-            folder.printTable(html, searcher);
+            folder.printTable(html, searcher, albunsForFiles);
         }
-        albumRoot.printTable(html, searcher, indexToFile, null);
+        albumRoot.printTable(html, searcher, indexToFile, albunsForFiles);
     }
 
     public List<LibraryFolder> getLibraryFolders() {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
@@ -21,6 +21,7 @@ package dpf.mg.udi.gpinf.shareazaparser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -101,7 +102,7 @@ public class ShareazaLibraryDatParser extends AbstractParser {
 
         xhtml.startElement("table"); //$NON-NLS-1$
         xhtml.startElement("tr"); //$NON-NLS-1$
-        printTh(xhtml, "Path", "Name", "Index", "Size", "Time", "Shared", "VirtualSize", "VirtualBase", "SHA1", "Tiger", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$
+        printTh(xhtml, "Path", "Name", "Albums", "Index", "Size", "Time", "Shared", "VirtualSize", "VirtualBase", "SHA1", "Tiger", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$ //$NON-NLS-11$
                 "MD5", "ED2K", "BTH", "Verify", "URI", "MetadataAuto", "MetadataTime", "MetadataModified", "Rating", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
                 "Comments", "ShareTags", "HitsTotal", "UploadsTotal", "CachedPreview", "Bogus", "Found in Hash Alert Database", "Found in the Case"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
         xhtml.endElement("tr"); //$NON-NLS-1$
@@ -124,11 +125,7 @@ public class ShareazaLibraryDatParser extends AbstractParser {
         numRegistros += countLibraryFiles(library.getLibraryFolders().getAlbumRoot(), library.getLibraryFolders().getIndexToFile());
         metadata.set(ExtraProperties.P2P_REGISTRY_COUNT, String.valueOf(numRegistros));
 
-        int hashDBHits = 0;
-        for (LibraryFolder folder : library.getLibraryFolders().getLibraryFolders())
-            hashDBHits += countHashDBHits(folder);
-
-        hashDBHits += countHashDBHits(library.getLibraryFolders().getAlbumRoot(), library.getLibraryFolders().getIndexToFile());
+        int hashDBHits = countHashDBHits(library.getLibraryFolders());
 
         if (hashDBHits > 0)
             metadata.set(ExtraProperties.CSAM_HASH_HITS, Integer.toString(hashDBHits));
@@ -165,28 +162,43 @@ public class ShareazaLibraryDatParser extends AbstractParser {
         }
     }
 
-    private int countHashDBHits(LibraryFolder folder) {
+    private int countHashDBHits(LibraryFolders folders) {
+        Map<Integer, LibraryFile> indexToFile = folders.getIndexToFile();
+        int result = 0;
+        Set<Integer> indexesCounted = new HashSet<>();
+        for (LibraryFolder f : folders.getLibraryFolders())
+            result += countHashDBHits(f, indexesCounted);
+        countHashDBHits(folders.getAlbumRoot(), indexToFile, indexesCounted);
+
+        return result;
+    }
+    
+    private int countHashDBHits(LibraryFolder folder, Set<Integer> indexesCounted) {
         int result = 0;
         for (LibraryFolder f : folder.getLibraryFolders())
-            result += countHashDBHits(f);
+            result += countHashDBHits(f, indexesCounted);
 
         for (LibraryFile file : folder.getLibraryFiles())
-            if (file.isHashDBHit())
+            if (file.isHashDBHit() && !indexesCounted.contains(file.getIndex())) {
                 result++;
+                indexesCounted.add(file.getIndex());
+            }
 
         return result;
     }
 
-    private int countHashDBHits(AlbumFolder folder, Map<Integer, LibraryFile> indexToFile) {
+    private int countHashDBHits(AlbumFolder folder, Map<Integer, LibraryFile> indexToFile, Set<Integer> indexesCounted) {
         int result = 0;
         for (AlbumFolder f : folder.getAlbumFolders())
-            result += countHashDBHits(f, indexToFile);
+            result += countHashDBHits(f, indexToFile, indexesCounted);
 
         for (int idx : folder.getAlbumFileIndexes()) {
             LibraryFile file = indexToFile.get(idx);
             if (file != null) {
-                if (file.isHashDBHit())
+                if (file.isHashDBHit() && !indexesCounted.contains(idx)) {
                     result++;
+                    indexesCounted.add(idx);
+                }
             }
         }
         return result;

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
@@ -168,7 +168,7 @@ public class ShareazaLibraryDatParser extends AbstractParser {
         Set<Integer> indexesCounted = new HashSet<>();
         for (LibraryFolder f : folders.getLibraryFolders())
             result += countHashDBHits(f, indexesCounted);
-        countHashDBHits(folders.getAlbumRoot(), indexToFile, indexesCounted);
+        result += countHashDBHits(folders.getAlbumRoot(), indexToFile, indexesCounted);
 
         return result;
     }


### PR DESCRIPTION
Create a new column with the list of albums a file belongs to. If the
file is not in the filesystem (Library), only in albums, it will be
displayed with a blank path.
Only count childPornHashHit once per file.