### PR TITLE
Save bookmarks shortcuts

### DIFF
--- a/iped-api/src/main/java/iped3/search/IMarcadores.java
+++ b/iped-api/src/main/java/iped3/search/IMarcadores.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.swing.KeyStroke;
+
 import iped3.IIPEDSource;
 
 /**
@@ -94,6 +96,10 @@ public interface IMarcadores extends Serializable {
 
     String getLabelComment(int labelId);
 
+    void setLabelKeyStroke(int labelId, KeyStroke key);
+
+    KeyStroke getLabelKeyStroke(int labelId);
+    
     int getLabelCount(int labelId);
     
     void setInReport(int labelId, boolean inReport);

--- a/iped-api/src/main/java/iped3/search/IMultiMarcadores.java
+++ b/iped-api/src/main/java/iped3/search/IMultiMarcadores.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.swing.KeyStroke;
+
 import iped3.IItemId;
 
 /**
@@ -72,6 +74,10 @@ public interface IMultiMarcadores extends Serializable {
 
     void saveState(File file) throws IOException;
 
+    void setLabelKeyStroke(String labelName, KeyStroke key);
+
+    KeyStroke getLabelKeyStroke(String labelName);
+    
     void selectAll();
 
     void setSelected(boolean value, IItemId item);

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
@@ -252,6 +252,7 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
             if (!bookmarks.contains(bk)) {
                 bookmarks.add(bk);
             }
+            bk.key = App.get().appCase.getMultiMarcadores().getLabelKeyStroke(label);
         }
         Iterator<BookmarkAndKey> iterator = bookmarks.iterator();
         while (iterator.hasNext()) {
@@ -549,6 +550,10 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
 
             keystrokeToBookmark.put(stroke, label);
             keystrokeToBookmark.put(getRemoveKey(stroke), label);
+
+            App.get().appCase.getMultiMarcadores().setLabelKeyStroke(label, stroke);
+            App.get().appCase.getMultiMarcadores().saveState();
+
         } else {
             String label = keystrokeToBookmark.get(stroke);
             if (label == null) {

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.text.Collator;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -91,6 +92,8 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
 
     private HashMap<KeyStroke, String> keystrokeToBookmark = new HashMap<>();
 
+    private final Collator collator;
+    
     private class BookmarkAndKey implements Comparable<BookmarkAndKey> {
         String bookmark;
         KeyStroke key;
@@ -113,8 +116,8 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
         }
 
         @Override
-        public int compareTo(BookmarkAndKey obj) {
-            return bookmark.compareToIgnoreCase(((BookmarkAndKey) obj).bookmark);
+        public int compareTo(BookmarkAndKey other) {
+            return collator.compare(bookmark, other.bookmark);
         }
     }
 
@@ -142,6 +145,9 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
 
     private GerenciadorMarcadores() {
 
+        collator = Collator.getInstance();
+        collator.setStrength(Collator.PRIMARY);
+        
         dialog.setTitle(Messages.getString("BookmarksManager.Title")); //$NON-NLS-1$
         dialog.setBounds(0, 0, 500, 500);
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/search/Marcadores.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/search/Marcadores.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import javax.swing.KeyStroke;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +59,7 @@ public class Marcadores implements Serializable, IMarcadores {
     private ArrayList<byte[]> labels;
     private TreeMap<Integer, String> labelNames = new TreeMap<Integer, String>();
     private TreeMap<Integer, String> labelComments = new TreeMap<Integer, String>();
+    private TreeMap<Integer, KeyStroke> labelKeyStrokes = new TreeMap<Integer, KeyStroke>();
     private Set<Integer> reportLabels = new TreeSet<Integer>();
 
     private int selectedItens = 0, totalItems, lastId;
@@ -255,6 +258,7 @@ public class Marcadores implements Serializable, IMarcadores {
 
         labelNames.put(labelId, labelName);
         labelComments.put(labelId, null);
+        labelKeyStrokes.put(labelId, null);
 
         return labelId;
     }
@@ -264,6 +268,7 @@ public class Marcadores implements Serializable, IMarcadores {
             return;
         labelNames.remove(label);
         labelComments.remove(label);
+        labelKeyStrokes.remove(label);
         reportLabels.remove(label);
 
         int labelOrder = label / labelBits;
@@ -298,6 +303,14 @@ public class Marcadores implements Serializable, IMarcadores {
 
     public String getLabelComment(int labelId) {
         return labelComments.get(labelId);
+    }
+
+    public void setLabelKeyStroke(int labelId, KeyStroke key) {
+        labelKeyStrokes.put(labelId, key);
+    }
+
+    public KeyStroke getLabelKeyStroke(int labelId) {
+        return labelKeyStrokes.get(labelId);
     }
 
     public void setInReport(int labelId, boolean inReport) {
@@ -449,6 +462,7 @@ public class Marcadores implements Serializable, IMarcadores {
         this.selectedItens = state.selectedItens;
         this.labelNames = state.labelNames;
         this.labelComments = state.labelComments;
+        this.labelKeyStrokes = state.labelKeyStrokes;
         this.reportLabels = state.reportLabels;
     }
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/search/MultiMarcadores.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/search/MultiMarcadores.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.swing.KeyStroke;
+
 import org.apache.commons.lang.ArrayUtils;
 
 import dpf.sp.gpinf.indexer.util.Util;
@@ -183,6 +185,20 @@ public class MultiMarcadores implements Serializable, IMultiMarcadores {
         return null;
     }
 
+    public void setLabelKeyStroke(String labelName, KeyStroke key) {
+        for (IMarcadores m : map.values())
+            m.setLabelKeyStroke(m.getLabelId(labelName), key);
+    }
+
+    public KeyStroke getLabelKeyStroke(String labelName) {
+        for (IMarcadores m : map.values()) {
+            KeyStroke key = m.getLabelKeyStroke(m.getLabelId(labelName));
+            if (key != null)
+                return key;
+        }
+        return null;
+    }
+    
     public int getLabelCount(String labelName) {
         int ret = 0;
         for (IMarcadores m : map.values()) {


### PR DESCRIPTION
Closes #724.
I followed the current implementation (as it is done for bookmark comments), except when generating a report, in which shortcut keys were intentionally not copied to the report.

Added an unrelated very minor change, also in `GerenciadorMarcadores` class, to use a collator when sorting bookmarks by name.
For example, a bookmark named "Áudio" was going to the end of the list, while in the bookmark tree (left panel) it uses a more intuitive order (ignoring accents, with a collator). 