### PR TITLE
Attachment count and flag

### DIFF
--- a/iped-api/src/main/java/iped3/util/ExtraProperties.java
+++ b/iped-api/src/main/java/iped3/util/ExtraProperties.java
@@ -123,6 +123,6 @@ public class ExtraProperties {
     public static final String TIME_EVENT_GROUPS = "timeEventGroups";
 
     public static final List<String> EMAIL_BASIC_PROPS = Arrays.asList(MESSAGE_SUBJECT, MESSAGE_DATE.getName(),
-            MESSAGE_BODY, Message.MESSAGE_FROM, Message.MESSAGE_TO, Message.MESSAGE_CC, Message.MESSAGE_BCC, PST_ATTACH,
-            PST_EMAIL_HAS_ATTACHS);
+            MESSAGE_BODY, Message.MESSAGE_FROM, Message.MESSAGE_TO, Message.MESSAGE_CC, Message.MESSAGE_BCC,
+            Message.MESSAGE_RECIPIENT_ADDRESS, PST_ATTACH, PST_EMAIL_HAS_ATTACHS);
 }

--- a/iped-api/src/main/java/iped3/util/ExtraProperties.java
+++ b/iped-api/src/main/java/iped3/util/ExtraProperties.java
@@ -46,7 +46,7 @@ public class ExtraProperties {
 
     public static final String MESSAGE_IS_ATTACHMENT = Message.MESSAGE_PREFIX + "IsEmailAttachment"; //$NON-NLS-1$
 
-    public static final String MESSAGE_ATTACHMENT_COUNT = Message.MESSAGE_PREFIX + "AttachmentCount"; //$NON-NLS-1$
+    public static final Property MESSAGE_ATTACHMENT_COUNT = Property.internalInteger(Message.MESSAGE_PREFIX + "AttachmentCount"); //$NON-NLS-1$
 
     public static final String CSAM_HASH_HITS = "childPornHashHits"; //$NON-NLS-1$
 
@@ -124,5 +124,5 @@ public class ExtraProperties {
 
     public static final List<String> EMAIL_BASIC_PROPS = Arrays.asList(MESSAGE_SUBJECT, MESSAGE_DATE.getName(),
             MESSAGE_BODY, Message.MESSAGE_FROM, Message.MESSAGE_TO, Message.MESSAGE_CC, Message.MESSAGE_BCC,
-            Message.MESSAGE_RECIPIENT_ADDRESS, MESSAGE_IS_ATTACHMENT, MESSAGE_ATTACHMENT_COUNT);
+            Message.MESSAGE_RECIPIENT_ADDRESS, MESSAGE_IS_ATTACHMENT, MESSAGE_ATTACHMENT_COUNT.getName());
 }

--- a/iped-api/src/main/java/iped3/util/ExtraProperties.java
+++ b/iped-api/src/main/java/iped3/util/ExtraProperties.java
@@ -44,9 +44,9 @@ public class ExtraProperties {
 
     public static final String MESSAGE_BODY = MESSAGE_PREFIX + "Body"; //$NON-NLS-1$
 
-    public static final String PST_ATTACH = "pst_attachment"; //$NON-NLS-1$
+    public static final String MESSAGE_IS_ATTACHMENT = Message.MESSAGE_PREFIX + "IsEmailAttachment"; //$NON-NLS-1$
 
-    public static final String PST_EMAIL_HAS_ATTACHS = "pst_email_has_attachs"; //$NON-NLS-1$
+    public static final String MESSAGE_ATTACHMENT_COUNT = Message.MESSAGE_PREFIX + "AttachmentCount"; //$NON-NLS-1$
 
     public static final String CSAM_HASH_HITS = "childPornHashHits"; //$NON-NLS-1$
 
@@ -124,5 +124,5 @@ public class ExtraProperties {
 
     public static final List<String> EMAIL_BASIC_PROPS = Arrays.asList(MESSAGE_SUBJECT, MESSAGE_DATE.getName(),
             MESSAGE_BODY, Message.MESSAGE_FROM, Message.MESSAGE_TO, Message.MESSAGE_CC, Message.MESSAGE_BCC,
-            Message.MESSAGE_RECIPIENT_ADDRESS, PST_ATTACH, PST_EMAIL_HAS_ATTACHS);
+            Message.MESSAGE_RECIPIENT_ADDRESS, MESSAGE_IS_ATTACHMENT, MESSAGE_ATTACHMENT_COUNT);
 }

--- a/iped-api/src/main/java/iped3/util/MediaTypes.java
+++ b/iped-api/src/main/java/iped3/util/MediaTypes.java
@@ -19,6 +19,7 @@ public class MediaTypes {
     public static final MediaType UFED_DEVICE_INFO = MediaType.application("x-ufed-deviceinfo"); //$NON-NLS-1$
     public static final MediaType UNALLOCATED = MediaType.application("x-unallocated"); //$NON-NLS-1$
     public static final MediaType JBIG2 = MediaType.image("x-jbig2");
+    public static final MediaType OUTLOOK_MSG = MediaType.application("vnd.ms-outlook");
 
     public static final String UFED_MIME_PREFIX = "x-ufed-"; //$NON-NLS-1$
 

--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -258,6 +258,7 @@
             <mime-exclude>image/svg+xml</mime-exclude>
         </parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.RFC822Parser"></parser>
+        <parser class="dpf.sp.gpinf.indexer.parsers.MSGParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.MSAccessParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.MboxParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.IncrediMailParser"></parser>

--- a/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
+++ b/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
@@ -264,6 +264,7 @@
             <mime-exclude>image/svg+xml</mime-exclude>
         </parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.RFC822Parser"></parser>
+        <parser class="dpf.sp.gpinf.indexer.parsers.MSGParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.MSAccessParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.MboxParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.IncrediMailParser"></parser>

--- a/iped-engine/src/main/java/br/gov/pf/labld/graph/GraphTask.java
+++ b/iped-engine/src/main/java/br/gov/pf/labld/graph/GraphTask.java
@@ -251,7 +251,7 @@ public class GraphTask extends AbstractTask {
                 || MediaTypes.UFED_MESSAGE_MIME.equals(mediaType)) {
             return "message";
         }
-        if (mediaType.startsWith("message") || mediaType.equals("application/vnd.ms-outlook")) {
+        if (mediaType.startsWith("message") || MediaTypes.OUTLOOK_MSG.toString().equals(mediaType)) {
             return "email";
         }
         for (String contactMime : contactMimes) {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
@@ -1179,6 +1179,7 @@ public class UfedXmlReader extends DataSourceReader {
                         bw.write(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
                     }
                 }
+                email.getMetadata().set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(attachNames.length));
 
                 bw.write("<hr>"); //$NON-NLS-1$
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
@@ -1179,7 +1179,7 @@ public class UfedXmlReader extends DataSourceReader {
                         bw.write(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
                     }
                 }
-                email.getMetadata().set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(attachNames.length));
+                email.getMetadata().set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, attachNames.length);
 
                 bw.write("<hr>"); //$NON-NLS-1$
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
@@ -56,6 +56,7 @@ import dpf.sp.gpinf.indexer.config.ConfigurationManager;
 import dpf.sp.gpinf.indexer.config.ParsingTaskConfig;
 import dpf.sp.gpinf.indexer.localization.Messages;
 import dpf.sp.gpinf.indexer.parsers.ufed.UFEDChatParser;
+import dpf.sp.gpinf.indexer.parsers.util.MetadataUtil;
 import dpf.sp.gpinf.indexer.parsers.util.PhoneParsingConfig;
 import dpf.sp.gpinf.indexer.process.IndexItem;
 import dpf.sp.gpinf.indexer.process.task.ImageThumbTask;
@@ -1161,6 +1162,12 @@ public class UfedXmlReader extends DataSourceReader {
                         for (String value : values)
                             bw.write(" " + SimpleHTMLEncoder.htmlEncode(value)); //$NON-NLS-1$
                         bw.write("<br>"); //$NON-NLS-1$
+                    }
+                }
+
+                for (String prop : Arrays.asList(Message.MESSAGE_TO, Message.MESSAGE_CC, Message.MESSAGE_BCC)) {
+                    for (String val : email.getMetadata().getValues(prop)) {
+                        MetadataUtil.fillRecipientAddress(email.getMetadata(), val);
                     }
                 }
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
@@ -558,11 +558,21 @@ public class ParsingTask extends AbstractTask implements EmbeddedDocumentExtract
             subItem.setHash(metadata.get(BasicProps.HASH));
             metadata.remove(BasicProps.HASH);
 
-            if (metadata.get(ExtraProperties.PST_EMAIL_HAS_ATTACHS) != null)
+            String attachCount = metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
+            if (attachCount != null && Integer.valueOf(attachCount) > 0)
                 subItem.setHasChildren(true);
 
             // indica se o conteiner tem subitens (mais específico que filhos genéricos)
             evidence.setExtraAttribute(HAS_SUBITEM, "true"); //$NON-NLS-1$
+
+            // #745: MSG parser isn't ours, so we do this here to not override it
+            if (MediaTypes.OUTLOOK_MSG.equals(evidence.getMediaType())) {
+                metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
+                String count = evidence.getMetadata().get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
+                if (count == null) count = Integer.toString(0);
+                evidence.getMetadata().set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT,
+                        Integer.toString(Integer.parseInt(count) + 1));
+            }
 
             if (metadata.get(ExtraProperties.EMBEDDED_FOLDER) != null) {
                 metadata.remove(ExtraProperties.EMBEDDED_FOLDER);

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
@@ -565,15 +565,6 @@ public class ParsingTask extends AbstractTask implements EmbeddedDocumentExtract
             // indica se o conteiner tem subitens (mais específico que filhos genéricos)
             evidence.setExtraAttribute(HAS_SUBITEM, "true"); //$NON-NLS-1$
 
-            // #745: MSG parser isn't ours, so we do this here to not override it
-            if (MediaTypes.OUTLOOK_MSG.equals(evidence.getMediaType())) {
-                metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
-                String count = evidence.getMetadata().get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
-                if (count == null) count = Integer.toString(0);
-                evidence.getMetadata().set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT,
-                        Integer.toString(Integer.parseInt(count) + 1));
-            }
-
             if (metadata.get(ExtraProperties.EMBEDDED_FOLDER) != null) {
                 metadata.remove(ExtraProperties.EMBEDDED_FOLDER);
                 subItem.setIsDir(true);

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
@@ -558,8 +558,8 @@ public class ParsingTask extends AbstractTask implements EmbeddedDocumentExtract
             subItem.setHash(metadata.get(BasicProps.HASH));
             metadata.remove(BasicProps.HASH);
 
-            String attachCount = metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
-            if (attachCount != null && Integer.valueOf(attachCount) > 0)
+            Integer attachCount = metadata.getInt(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
+            if (attachCount != null && attachCount > 0)
                 subItem.setHasChildren(true);
 
             // indica se o conteiner tem subitens (mais específico que filhos genéricos)

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
@@ -464,8 +464,10 @@ public class LibpffPSTParser extends AbstractParser {
                 if (l.length > 1 && !l[1].trim().isEmpty()) {
                     if (l[0].trim().equals("Display name")) //$NON-NLS-1$
                         name = l[1].trim();
-                    if (l[0].trim().equals("Email address")) //$NON-NLS-1$
+                    if (l[0].trim().equals("Email address")) { //$NON-NLS-1$
                         addr = l[1].trim();
+                        MetadataUtil.fillRecipientAddress(metadata, addr);
+                    }
                     if (l[0].trim().equals("Recipient type")) { //$NON-NLS-1$
                         String type = l[1].trim();
                         name = OutlookPSTParser.formatNameAndAddress(name, addr);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
@@ -316,8 +316,8 @@ public class LibpffPSTParser extends AbstractParser {
             for (String attach : attachNames) {
                 preview.append(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
             }
-            metadata.set(ExtraProperties.PST_EMAIL_HAS_ATTACHS, "true"); //$NON-NLS-1$
         }
+        metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(attachNames.size()));
 
         preview.append("<hr>"); //$NON-NLS-1$
         preview.append("</div>\n"); //$NON-NLS-1$
@@ -588,7 +588,7 @@ public class LibpffPSTParser extends AbstractParser {
             metadata.set(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(++virtualId));
             metadata.set(ExtraProperties.PARENT_VIRTUAL_ID, String.valueOf(parent));
             metadata.set(Metadata.RESOURCE_NAME_KEY, name);
-            metadata.set(ExtraProperties.PST_ATTACH, "true"); //$NON-NLS-1$
+            metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
             if (deleted)
                 metadata.set(ExtraProperties.DELETED, "true"); //$NON-NLS-1$
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
@@ -317,7 +317,7 @@ public class LibpffPSTParser extends AbstractParser {
                 preview.append(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
             }
         }
-        metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(attachNames.size()));
+        metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, attachNames.size());
 
         preview.append("<hr>"); //$NON-NLS-1$
         preview.append("</div>\n"); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSGParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSGParser.java
@@ -42,7 +42,7 @@ public class MSGParser extends OfficeParser {
 
         } finally {
             if (delegate != null) {
-                metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(delegate.attachCount));
+                metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, delegate.attachCount);
                 context.set(EmbeddedDocumentExtractor.class, extractor);
             }
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSGParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSGParser.java
@@ -1,0 +1,77 @@
+package dpf.sp.gpinf.indexer.parsers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.microsoft.OfficeParser;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import iped3.util.ExtraProperties;
+
+public class MSGParser extends OfficeParser {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    public Set<MediaType> getSupportedTypes(ParseContext context) {
+        return Collections.singleton(POIFSDocumentType.OUTLOOK.getType());
+    }
+
+    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
+            throws IOException, SAXException, TikaException {
+
+        DelegatingExtractor delegate = null;
+        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class);
+        if (extractor != null) {
+            delegate = new DelegatingExtractor(extractor);
+            context.set(EmbeddedDocumentExtractor.class, delegate);
+        }
+
+        try {
+            super.parse(stream, handler, metadata, context);
+
+        } finally {
+            if (delegate != null) {
+                metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(delegate.attachCount));
+                context.set(EmbeddedDocumentExtractor.class, extractor);
+            }
+        }
+
+    }
+
+    private class DelegatingExtractor implements EmbeddedDocumentExtractor {
+
+        private EmbeddedDocumentExtractor delegate;
+        private int attachCount = 0;
+
+        private DelegatingExtractor(EmbeddedDocumentExtractor delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean shouldParseEmbedded(Metadata metadata) {
+            return delegate.shouldParseEmbedded(metadata);
+        }
+
+        @Override
+        public void parseEmbedded(InputStream stream, ContentHandler handler, Metadata metadata, boolean outputHtml)
+                throws SAXException, IOException {
+
+            metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
+            delegate.parseEmbedded(stream, handler, metadata, outputHtml);
+            attachCount++;
+        }
+
+    }
+
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
@@ -476,6 +476,7 @@ public class OutlookPSTParser extends AbstractParser {
                         if (!recipName.isEmpty()) {
                             recipients.add(recipName); // $NON-NLS-1$
                         }
+                        MetadataUtil.fillRecipientAddress(metadata, recip.getEmailAddress());
                     }
                 }
                 if (recipients.size() > 0) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
@@ -439,9 +439,6 @@ public class OutlookPSTParser extends AbstractParser {
             metadata.set(ExtraProperties.ITEM_VIRTUAL_ID, virtualId);
             metadata.set(ExtraProperties.PARENT_VIRTUAL_ID, parent);
 
-            if (email.hasAttachments())
-                metadata.set(ExtraProperties.PST_EMAIL_HAS_ATTACHS, "true"); //$NON-NLS-1$
-
             Charset charset = Charset.forName("UTF-8"); //$NON-NLS-1$
             StringBuilder preview = new StringBuilder();
             preview.append("<html>"); //$NON-NLS-1$
@@ -503,6 +500,7 @@ public class OutlookPSTParser extends AbstractParser {
                     preview.append(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
                 }
             }
+            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(email.getNumberOfAttachments()));
 
             preview.append("<hr>"); //$NON-NLS-1$
             preview.append("</div>\n"); //$NON-NLS-1$
@@ -666,7 +664,7 @@ public class OutlookPSTParser extends AbstractParser {
                     // attach.getLastModificationTime());
                     // metadata.set(ExtraProperties.EMBEDDED_PATH, path);
                     metadata.set(Metadata.CONTENT_TYPE, attach.getMimeTag());
-                    metadata.set(ExtraProperties.PST_ATTACH, "true"); //$NON-NLS-1$
+                    metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
 
                     metadata.set(ExtraProperties.ITEM_VIRTUAL_ID, parent + "_attach" + x);
                     metadata.set(ExtraProperties.PARENT_VIRTUAL_ID, parent);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
@@ -500,7 +500,7 @@ public class OutlookPSTParser extends AbstractParser {
                     preview.append(SimpleHTMLEncoder.htmlEncode(attach) + "<br>"); //$NON-NLS-1$
                 }
             }
-            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(email.getNumberOfAttachments()));
+            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, email.getNumberOfAttachments());
 
             preview.append("<hr>"); //$NON-NLS-1$
             preview.append("</div>\n"); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
@@ -412,12 +412,16 @@ public class RFC822Parser extends AbstractParser {
             if (toField.isValidField()) {
                 AddressList addressList = toField.getAddressList();
                 for (int i = 0; i < addressList.size(); ++i) {
-                    metadata.add(metadataField, decodeIfUtf8(getDisplayString(addressList.get(i))));
+                    String recipient = decodeIfUtf8(getDisplayString(addressList.get(i)));
+                    metadata.add(metadataField, recipient);
+                    MetadataUtil.fillRecipientAddress(metadata, recipient);
                 }
             } else {
                 String to = stripOutFieldPrefix(field, addressListType);
                 for (String eachTo : to.split(",")) { //$NON-NLS-1$
-                    metadata.add(metadataField, decodeIfUtf8(eachTo.trim()));
+                    String recipient = decodeIfUtf8(eachTo.trim());
+                    metadata.add(metadataField, recipient);
+                    MetadataUtil.fillRecipientAddress(metadata, recipient);
                 }
             }
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
@@ -136,6 +136,8 @@ public class RFC822Parser extends AbstractParser {
             } else {
                 throw new TikaException("Failed to parse an email message", e); //$NON-NLS-1$
             }
+        } finally {
+            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(mch.attachmentCount));
         }
     }
 
@@ -155,6 +157,7 @@ public class RFC822Parser extends AbstractParser {
         private boolean inPart = false, textBody, htmlBody, isAttach;
         private ParsingEmbeddedDocumentExtractor embeddedParser;
         private MimeStreamParser parser;
+        private int attachmentCount = 0;
 
         MailContentHandler(MimeStreamParser parser, XHTMLContentHandler xhtml, Metadata metadata, ParseContext context,
                 boolean strictParsing) {
@@ -209,8 +212,11 @@ public class RFC822Parser extends AbstractParser {
 
             try {
                 if (isAttach) {
-                    if (extractor.shouldParseEmbedded(submd))
+                    if (extractor.shouldParseEmbedded(submd)) {
+                        attachmentCount++;
+                        submd.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
                         extractor.parseEmbedded(is, handler, submd, true);
+                    }
                 } else {
                     if (metadata.get(ExtraProperties.MESSAGE_BODY) == null) {
                         BufferedInputStream bis = new BufferedInputStream(is, 1024 * 1024);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
@@ -137,7 +137,7 @@ public class RFC822Parser extends AbstractParser {
                 throw new TikaException("Failed to parse an email message", e); //$NON-NLS-1$
             }
         } finally {
-            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, Integer.toString(mch.attachmentCount));
+            metadata.set(ExtraProperties.MESSAGE_ATTACHMENT_COUNT, mch.attachmentCount);
         }
     }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -173,10 +173,10 @@ public class MetadataUtil {
         generalKeys.add(ExtraProperties.SHARED_HASHES);
         generalKeys.add(ExtraProperties.SHARED_ITEMS);
         generalKeys.add(ExtraProperties.LINKED_ITEMS);
-        generalKeys.add(ExtraProperties.MESSAGE_SUBJECT);
         generalKeys.add(ExtraProperties.CSAM_HASH_HITS);
-        generalKeys.add(ExtraProperties.PST_ATTACH);
-        generalKeys.add(ExtraProperties.PST_EMAIL_HAS_ATTACHS);
+        generalKeys.add(ExtraProperties.MESSAGE_SUBJECT);
+        generalKeys.add(ExtraProperties.MESSAGE_IS_ATTACHMENT);
+        generalKeys.add(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
         generalKeys.add(ExtraProperties.ITEM_VIRTUAL_ID);
         generalKeys.add(ExtraProperties.PARENT_VIRTUAL_ID);
         generalKeys.add(ExtraProperties.LOCATIONS);
@@ -381,7 +381,7 @@ public class MetadataUtil {
     }
 
     private static void normalizeMSGMetadata(Metadata metadata) {
-        if (!metadata.get(Metadata.CONTENT_TYPE).equals("application/vnd.ms-outlook")) //$NON-NLS-1$
+        if (!metadata.get(Metadata.CONTENT_TYPE).equals(MediaTypes.OUTLOOK_MSG.toString()))
             return;
 
         String subject = metadata.get(TikaCoreProperties.TITLE);
@@ -500,7 +500,7 @@ public class MetadataUtil {
         MediaType mediaType = MediaType.parse(contentType);
 
         if (contentType.startsWith("message") || //$NON-NLS-1$
-                contentType.equals("application/vnd.ms-outlook")) //$NON-NLS-1$
+                MediaTypes.OUTLOOK_MSG.toString().equals(contentType))
             return;
 
         while (mediaType != null) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -176,7 +176,7 @@ public class MetadataUtil {
         generalKeys.add(ExtraProperties.CSAM_HASH_HITS);
         generalKeys.add(ExtraProperties.MESSAGE_SUBJECT);
         generalKeys.add(ExtraProperties.MESSAGE_IS_ATTACHMENT);
-        generalKeys.add(ExtraProperties.MESSAGE_ATTACHMENT_COUNT);
+        generalKeys.add(ExtraProperties.MESSAGE_ATTACHMENT_COUNT.getName());
         generalKeys.add(ExtraProperties.ITEM_VIRTUAL_ID);
         generalKeys.add(ExtraProperties.PARENT_VIRTUAL_ID);
         generalKeys.add(ExtraProperties.LOCATIONS);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -13,6 +13,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.tika.metadata.IPTC;
@@ -52,6 +54,8 @@ public class MetadataUtil {
 
     private static final Set<String> RAW_MAIL_HEADERS = getRawMailHeaders();
 
+    private static Pattern emailPattern = Pattern.compile("[0-9a-zA-Z\\+\\.\\_\\%\\-\\#\\!]+\\@[0-9a-zA-Z\\-\\.]+");
+
     private static final Set<String> getBasicHeaders() {
         Collator collator = Collator.getInstance();
         collator.setStrength(Collator.PRIMARY);
@@ -76,6 +80,15 @@ public class MetadataUtil {
     public static boolean isToAddRawMailHeader(String header) {
         return !BASIC_MAIL_HEADERS.contains(header) && (RAW_MAIL_HEADERS.contains(header)
                 || (header.length() > 3 && header.toUpperCase().startsWith("X-")));
+    }
+
+    public static void fillRecipientAddress(Metadata metadata, String recipient) {
+        if (recipient != null) {
+            Matcher matcher = emailPattern.matcher(recipient);
+            while (matcher.find()) {
+                metadata.add(Message.MESSAGE_RECIPIENT_ADDRESS, matcher.group());
+            }
+        }
     }
 
     private static Map<String, String> getMetaCaseMap() {

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
@@ -10,7 +10,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,6 +46,7 @@ import dpf.sp.gpinf.indexer.util.FileContentSource;
 import dpf.sp.gpinf.indexer.util.IOUtil;
 import dpf.sp.gpinf.indexer.util.SimpleHTMLEncoder;
 import iped3.io.IStreamSource;
+import iped3.util.MediaTypes;
 
 /**
  *
@@ -77,7 +77,7 @@ public class MsgViewer extends HtmlViewer {
 
     @Override
     public boolean isSupportedType(String contentType) {
-        return contentType.equals("application/vnd.ms-outlook");
+        return MediaTypes.OUTLOOK_MSG.toString().equals(contentType);
     }
 
     @Override


### PR DESCRIPTION
Closes #744, closes #745 

Add new properties Message:AttachmentCount and Message:IsEmailAttachment to EML, MSG, PST, OST and UFDR extracted emails. Removes old pst_attachment and pst_email_has_attachs properties.