### PR TITLE
Extract frames from animated images

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
@@ -98,6 +98,10 @@ public class GalleryModel extends AbstractTableModel {
         return ImageThumbTask.isImageType(MediaType.parse(mediaType));
     }
 
+    private boolean isAnimationImage(Document doc) {
+        return doc.get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
+    }
+
     private boolean isSupportedVideo(String mediaType) {
         return VideoThumbTask.isVideoType(MediaType.parse(mediaType));
     }
@@ -177,7 +181,7 @@ public class GalleryModel extends AbstractTableModel {
                     }
 
                     BytesRef bytesRef = doc.getBinaryValue(IndexItem.THUMB);
-                    if (bytesRef != null && (!isSupportedVideo(mediaType) || App.get().useVideoThumbsInGallery)) {
+                    if (bytesRef != null && ((isSupportedImage(mediaType) && !isAnimationImage(doc)) || App.get().useVideoThumbsInGallery)) {
                         byte[] thumb = bytesRef.bytes;
                         if (thumb.length > 0) {
                             image = ImageIO.read(new ByteArrayInputStream(thumb));
@@ -188,7 +192,7 @@ public class GalleryModel extends AbstractTableModel {
 
                     String hash = doc.get(IndexItem.HASH);
                     if (image == null && hash != null && !hash.isEmpty()) {
-                        image = getViewImage(docId, hash, !isSupportedImage(mediaType));
+                        image = getViewImage(docId, hash, isSupportedVideo(mediaType) || isAnimationImage(doc));
                         int resizeTolerance = 4;
                         if (image != null) {
                             if (image.getWidth() < thumbSize - resizeTolerance
@@ -301,7 +305,7 @@ public class GalleryModel extends AbstractTableModel {
                 try {
                     Document doc = App.get().appCase.getSearcher().doc(docId);
                     String mediaType = doc.get(IndexItem.CONTENTTYPE);
-                    if (isSupportedVideo(mediaType)) {
+                    if (isSupportedVideo(mediaType) || isAnimationImage(doc)) {
                         it.remove();
                     }
                 } catch (Exception e) {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/DIETask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/DIETask.java
@@ -209,7 +209,8 @@ public class DIETask extends AbstractTask {
 
         try {
             long t = System.currentTimeMillis();
-            if (isImageType(evidence.getMediaType())) {
+            boolean isAnimationImage = isAnimationImage(evidence);
+            if (isImageType(evidence.getMediaType()) && !isAnimationImage) {
                 if (evidence.getExtraAttribute(ImageThumbTask.THUMB_TIMEOUT) != null) return;
 
                 //For images call the detection method passing the thumb image
@@ -232,7 +233,7 @@ public class DIETask extends AbstractTask {
                 t = System.currentTimeMillis() - t;
                 totalImagesTime.addAndGet(t);
 
-            } else if (isVideoType(evidence.getMediaType())) {
+            } else if (isVideoType(evidence.getMediaType()) || isAnimationImage) {
                 Short prevResult = null;
                 synchronized (videoResults) {
                     prevResult = videoResults.get(evidence.getHash());
@@ -318,6 +319,15 @@ public class DIETask extends AbstractTask {
         return mediaType.getType().equals("image"); //$NON-NLS-1$
     }
     
+    /**
+     * Check if the item is a multiple frame image. Just works after VideoTahumbTask
+     * is executed.
+     */
+
+    private static boolean isAnimationImage(IItem item) {
+        return item.getMetadata().get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
+    }
+
     /**
      * Check if the evidence is a video.
      */

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -36,6 +36,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.metadata.XMP;
@@ -522,7 +523,7 @@ public class VideoThumbTask extends ThumbTask {
         } else if (mediaType.equals("image/png")) {
             byte[] b = new byte[128];
             try (BufferedInputStream is = evidence.getBufferedStream()) {
-                int read = is.read(b);
+                int read = IOUtils.read(is, b);
                 for (int i = 0; i <= read - 8; i++) {
                     if (b[i] == 'a' && b[i + 1] == 'c' && b[i + 2] == 'T' && b[i + 3] == 'L') {
                         numImages = ((b[i + 5] & 0xFF) << 16) | ((b[i + 6] & 0xFF) << 8) | (b[i + 7] & 0xFF);

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -496,7 +496,7 @@ public class VideoThumbTask extends ThumbTask {
                 reader = ImageIO.getImageReaders(iis).next();
                 reader.setInput(iis, false, true);
                 numImages = reader.getNumImages(true);
-            } catch (IOException e) {
+            } catch (Exception e) {
             } finally {
                 if (reader != null)
                     reader.dispose();
@@ -512,7 +512,7 @@ public class VideoThumbTask extends ThumbTask {
                         break;
                     }
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
             }
         }
         

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -57,6 +57,7 @@ import gpinf.video.VideoProcessResult;
 import gpinf.video.VideoThumbsMaker;
 import gpinf.video.VideoThumbsOutputConfig;
 import iped3.IItem;
+import iped3.util.ExtraProperties;
 import macee.core.Configurable;
 
 /**
@@ -161,7 +162,7 @@ public class VideoThumbTask extends ThumbTask {
      * Property to be set if the evidence is a animated image (i.e. contain multiple
      * frames). Only set if the number of frames is greater than one.
      */
-    private static final String propAnimationFrames = "AnimationFrames";
+    public static final String ANIMATION_FRAMES_PROP = ExtraProperties.IMAGE_META_PREFIX + "AnimationFrames";
     
     private ISO6709Converter iso6709Converter = new ISO6709Converter();
 
@@ -368,7 +369,7 @@ public class VideoThumbTask extends ThumbTask {
 
                 //Set the number of frames for animated images
                 int numFrames = 0;
-                String strFrames = evidence.getMetadata().get(propAnimationFrames);
+                String strFrames = evidence.getMetadata().get(ANIMATION_FRAMES_PROP);
                 if (strFrames != null) 
                     numFrames = Integer.parseInt(strFrames);
 
@@ -536,7 +537,7 @@ public class VideoThumbTask extends ThumbTask {
         
         if (numImages > 1) {
             // Set only for images with multiple animated frames
-            evidence.getMetadata().set(propAnimationFrames, String.valueOf(numImages));
+            evidence.getMetadata().set(ANIMATION_FRAMES_PROP, String.valueOf(numImages));
             return true;
         }
         return false;

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -156,7 +156,7 @@ public class VideoThumbTask extends ThumbTask {
      * Property to be set if the evidence is a animated image (i.e. contain multiple
      * frames). Only set if the number of frames is greater than one.
      */
-    private static final String propAnimatedFrames = "AnimatedFrames";
+    private static final String propAnimationFrames = "AnimationFrames";
     
     private ISO6709Converter iso6709Converter = new ISO6709Converter();
 
@@ -350,7 +350,7 @@ public class VideoThumbTask extends ThumbTask {
 
                 //Set the number of frames for animated images
                 int numFrames = 0;
-                String strFrames = evidence.getMetadata().get(propAnimatedFrames);
+                String strFrames = evidence.getMetadata().get(propAnimationFrames);
                 if (strFrames != null) 
                     numFrames = Integer.parseInt(strFrames);
 
@@ -514,7 +514,7 @@ public class VideoThumbTask extends ThumbTask {
         
         if (numImages > 1) {
             // Set only for images with multiple animated frames
-            evidence.getMetadata().set(propAnimatedFrames, String.valueOf(numImages));
+            evidence.getMetadata().set(propAnimationFrames, String.valueOf(numImages));
             return true;
         }
         return false;

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -357,6 +357,10 @@ public class VideoThumbTask extends ThumbTask {
                 long t = System.currentTimeMillis();
                 r = videoThumbsMaker.createThumbs(evidence.getTempFile(), tmpFolder, configs, numFrames);
                 t = System.currentTimeMillis() - t;
+                if (r != null && numFrames > 0) {
+                    //Clear video duration for animated images
+                    r.setVideoDuration(-1);
+                }
                 if (r.isSuccess() && (mainOutFile.exists() || mainTmpFile.renameTo(mainOutFile))) {
                     totalProcessed.incrementAndGet();
                 } else {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -415,7 +415,7 @@ public class VideoThumbTask extends ThumbTask {
                         File thumbFile = getThumbFile(evidence);
                         saveThumb(evidence, thumbFile);
                         t = System.currentTimeMillis() - t;
-                        totalTimeGallery.incrementAndGet();
+                        totalTimeGallery.addAndGet(t);
                         totalGallery.incrementAndGet();
                     }
                 } catch (Throwable e) {

--- a/iped-engine/src/main/java/gpinf/video/VideoThumbsMaker.java
+++ b/iped-engine/src/main/java/gpinf/video/VideoThumbsMaker.java
@@ -94,7 +94,7 @@ public class VideoThumbsMaker {
         boolean fixed = false;
         File lnk = null;
         String videoStream = null;
-        for (int step = numFrames == 0 ? 0 : 1; step <= 1; step++) {
+        for (int step = numFrames <= 0 ? 0 : 1; step <= 1; step++) {
             if (step == 1) {
                 int pos = cmds.indexOf("-demuxer"); //$NON-NLS-1$
                 if (pos < 0) {
@@ -181,7 +181,7 @@ public class VideoThumbsMaker {
 
         cmds = new ArrayList<String>();
         cmds.add(mplayer);
-        if (numFrames == 0) {
+        if (numFrames <= 0) {
             cmds.add("-demuxer"); //$NON-NLS-1$
             cmds.add("lavf"); //$NON-NLS-1$
         }
@@ -194,7 +194,7 @@ public class VideoThumbsMaker {
         cmds.add("-noaspect"); //$NON-NLS-1$
         cmds.add("-sws"); //$NON-NLS-1$
         cmds.add("1"); //$NON-NLS-1$
-        if (ignoreWaitKeyFrame != 1 && numFrames == 0) {
+        if (ignoreWaitKeyFrame != 1 && numFrames <= 0) {
             cmds.add("-lavdopts"); //$NON-NLS-1$
             cmds.add("wait_keyframe"); //$NON-NLS-1$
         }
@@ -238,14 +238,12 @@ public class VideoThumbsMaker {
                     cmds.remove(pos + 1);
                     cmds.remove(pos);
                     int frameStep = 0;
-                    if (numFrames == 0) {
+                    if (numFrames <= 0) {
                         float fps = Math.min(240, result.getFPS());
                         frameStep = (int) (fps * (result.getVideoDuration() - 1) * 0.001 / (maxThumbs + 2));
                     } else {
-                        frameStep = (int) (numFrames / (maxThumbs + 2));
+                        frameStep = numFrames / (maxThumbs + 2);
                     }
-                    System.err.println(">>>>frameStep="+frameStep);
-                    System.err.println(">>>>numFrames="+numFrames);
                     if (frameStep < 1) {
                         frameStep = 1;
                     } else if (frameStep > 600) {


### PR DESCRIPTION
This implements what was discussed in #763. 
Animated GIFs and APNGs support seems to be working fine and should be useful.

Testing with a couple of disk images from real cases I am working with, I found several images that I thought to be static images, including APNGs. 
Also find quite a few of these animated images in LED database.

@lfcnassif, I created a subcategory of images ("Animated Images"), but the current classification is somewhat based on the file location (Temporary Internet Images, Images in System Folders), and I found the result a bit confusing, as there could be animated images in these folders. 
I ended up rolling back, and didn't create any new category.
However, these animated images can be easily find using a filter by "image:AnimationFrames" property.
