### PR TITLE
Fix gallery to show document thumbs if available (related to #767).

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
@@ -181,7 +181,7 @@ public class GalleryModel extends AbstractTableModel {
                     }
 
                     BytesRef bytesRef = doc.getBinaryValue(IndexItem.THUMB);
-                    if (bytesRef != null && ((isSupportedImage(mediaType) && !isAnimationImage(doc)) || App.get().useVideoThumbsInGallery)) {
+                    if (bytesRef != null && ((!isSupportedVideo(mediaType) && !isAnimationImage(doc)) || App.get().useVideoThumbsInGallery)) {
                         byte[] thumb = bytesRef.bytes;
                         if (thumb.length > 0) {
                             image = ImageIO.read(new ByteArrayInputStream(thumb));


### PR DESCRIPTION
Simple fix, as discussed in https://github.com/sepinf-inc/IPED/pull/767#issuecomment-955091808.