### PR TITLE
Improved decoding of string tags in e-Mule MET files #811

### DIFF
--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -679,6 +679,11 @@
         <sub-class-of type="application/x-p2p"/>
         <glob pattern="known*.met"/>
     </mime-type>
+
+    <mime-type type="application/x-emule-part-met">
+        <sub-class-of type="application/x-p2p"/>
+        <glob pattern="*.part.met"/>
+    </mime-type>
     
     <mime-type type="application/x-emule-searches">
         <sub-class-of type="text/plain"/>

--- a/iped-app/resources/config/conf/MakePreviewConfig.txt
+++ b/iped-app/resources/config/conf/MakePreviewConfig.txt
@@ -10,4 +10,4 @@ supportedMimes = application/x-whatsapp-db; application/x-whatsapp-chatstorage; 
 supportedMimes = application/x-prefetch; text/x-vcard; application/x-bittorrent-resume-dat; application/x-bittorrent; application/x-emule-preferences-dat
 
 # List of mimetypes which parsers insert links to other case items into preview
-supportedMimesWithLinks = application/x-emule; application/x-ares-galaxy; application/x-shareaza-library-dat
+supportedMimesWithLinks = application/x-emule; application/x-emule-part-met; application/x-ares-galaxy; application/x-shareaza-library-dat

--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -294,6 +294,7 @@
         </parser>
         
         <parser class="dpf.sp.gpinf.indexer.parsers.KnownMetParser"></parser>
+        <parser class="dpf.sp.gpinf.indexer.parsers.PartMetParser"></parser>
         <parser class="gpinf.emule.PreferencesDatParser"></parser>
         <parser class="dpf.sp.gpinf.indexer.parsers.AresParser"></parser>
         <parser class="dpf.mg.udi.gpinf.shareazaparser.ShareazaSearchesDatParser"></parser>

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
@@ -17,6 +17,7 @@ import dpf.mg.udi.gpinf.whatsappextractor.WhatsAppParser;
 import dpf.mt.gpinf.skype.parser.SkypeParser;
 import dpf.sp.gpinf.indexer.parsers.AresParser;
 import dpf.sp.gpinf.indexer.parsers.KnownMetParser;
+import dpf.sp.gpinf.indexer.parsers.PartMetParser;
 import dpf.sp.gpinf.indexer.parsers.jdbc.SQLite3Parser;
 import dpf.sp.gpinf.indexer.parsers.ufed.UFEDChatParser;
 
@@ -55,6 +56,7 @@ public class MimeTypesProcessingOrder {
         mediaTypes.put(TelegramParser.TELEGRAM_DB_IOS, 2);
 
         mediaTypes.put(MediaType.parse(KnownMetParser.EMULE_MIME_TYPE), 1);
+        mediaTypes.put(MediaType.parse(PartMetParser.EMULE_PART_MET_MIME_TYPE), 1);
         mediaTypes.put(MediaType.parse(AresParser.ARES_MIME_TYPE), 1);
         mediaTypes.put(MediaType.parse(ShareazaLibraryDatParser.LIBRARY_DAT_MIME_TYPE), 1);
        

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/P2PBookmarker.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/P2PBookmarker.java
@@ -17,6 +17,7 @@ import dpf.mt.gpinf.skype.parser.SkypeParser;
 import dpf.sp.gpinf.indexer.localization.Messages;
 import dpf.sp.gpinf.indexer.parsers.AresParser;
 import dpf.sp.gpinf.indexer.parsers.KnownMetParser;
+import dpf.sp.gpinf.indexer.parsers.PartMetParser;
 import dpf.sp.gpinf.indexer.parsers.ufed.UFEDChatParser;
 import dpf.sp.gpinf.indexer.process.task.HashTask;
 import dpf.sp.gpinf.indexer.search.IPEDSearcher;
@@ -55,6 +56,7 @@ public class P2PBookmarker {
         HashMap<String, P2PProgram> p2pPrograms = new HashMap<String, P2PProgram>();
 
         p2pPrograms.put(KnownMetParser.EMULE_MIME_TYPE, new P2PProgram(HashTask.HASH.EDONKEY.toString(), "Emule")); //$NON-NLS-1$
+        p2pPrograms.put(PartMetParser.EMULE_PART_MET_MIME_TYPE, new P2PProgram(HashTask.HASH.EDONKEY.toString(), "Emule")); //$NON-NLS-1$
         p2pPrograms.put(AresParser.ARES_MIME_TYPE, new P2PProgram(HashTask.HASH.SHA1.toString(), "Ares")); //$NON-NLS-1$
         p2pPrograms.put(ShareazaLibraryDatParser.LIBRARY_DAT_MIME_TYPE,
                 new P2PProgram(HashTask.HASH.MD5.toString(), "Shareaza")); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
@@ -1,0 +1,165 @@
+package dpf.sp.gpinf.indexer.parsers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.HttpHeaders;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.AbstractParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.XHTMLContentHandler;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import dpf.sp.gpinf.indexer.parsers.util.ChildPornHashLookup;
+import dpf.sp.gpinf.indexer.parsers.util.Messages;
+import dpf.sp.gpinf.indexer.util.LocalizedFormat;
+import gpinf.emule.KnownMetEntry;
+import iped3.io.IItemBase;
+import iped3.search.IItemSearcher;
+import iped3.util.ExtraProperties;
+
+/**
+ * e-Mule "part.met" files parser. These files store information about files
+ * being downloaded, which in some case are not present in the main e-Mule
+ * control file (known.met).
+ * 
+ * @author Wladimir
+ */
+public class PartMetParser extends AbstractParser {
+    private static final long serialVersionUID = 6100522577461358577L;
+
+    public static final String EMULE_PART_MET_MIME_TYPE = "application/x-emule-part-met";
+    private static final Set<MediaType> SUPPORTED_TYPES = Collections
+            .singleton(MediaType.parse(EMULE_PART_MET_MIME_TYPE));
+
+    @Override
+    public Set<MediaType> getSupportedTypes(ParseContext context) {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
+            throws IOException, SAXException, TikaException {
+        final DecimalFormat nf = LocalizedFormat.getDecimalInstance("#,##0");
+        final DateFormat df = new SimpleDateFormat(Messages.getString("KnownMetParser.DataFormat"));
+        df.setTimeZone(TimeZone.getTimeZone("GMT+0"));
+
+        metadata.set(HttpHeaders.CONTENT_TYPE, EMULE_PART_MET_MIME_TYPE);
+        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+
+        // PART.MET files are very small, so 1 MB should be more than enough.
+        byte[] bytes = new byte[1 << 20];
+        IOUtils.read(stream, bytes);
+        int version = bytes[0] & 0xFF;
+        if (version != 224 && version != 225 && version != 226)
+            return;
+        KnownMetEntry e = new KnownMetEntry();
+        int ret = gpinf.emule.KnownMetParser.parseEntry(e, 1, bytes);
+        if (ret <= 0)
+            return;
+
+        IItemSearcher searcher = context.get(IItemSearcher.class);
+
+        XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
+        xhtml.startDocument();
+
+        xhtml.startElement("style");
+        xhtml.characters(
+                ".d { border-collapse: collapse; font-family: Arial, sans-serif; margin-right: 32px; margin-bottom: 32px; text-align: left; vertical-align: middle; } "
+                        + ".a { border: solid; border-width: thin; font-weight: bold; background-color:#CCCCEE; padding: 4px; } "
+                        + ".b { border: solid; border-width: thin; padding: 4px; } "
+                        + ".c { border: solid; border-width: thin; padding: 4px; font-family: monospace; font-size: larger; } ");
+        xhtml.endElement("style");
+        xhtml.newline();
+
+        xhtml.startElement("table", "class", "d");
+
+        int hashDBHits = 0;
+        HashSet<String> hashSets = new HashSet<String>();
+        hashSets.addAll(ChildPornHashLookup.lookupHash(KnownMetParser.EDONKEY, e.getHash()));
+        IItemBase item = KnownMetParser.searchItemInCase(searcher, KnownMetParser.EDONKEY, e.getHash());
+        if (item != null)
+            hashSets.addAll(ChildPornHashLookup.lookupHash(item.getHash()));
+        if (!hashSets.isEmpty())
+            hashDBHits++;
+
+        AttributesImpl attributes = new AttributesImpl();
+        if (e.getHash() != null && !e.getHash().isEmpty())
+            attributes.addAttribute("", "name", "name", "CDATA", e.getHash().toUpperCase());    
+        xhtml.startElement("tr", attributes);
+        xhtml.startElement("td", "class", "a");
+        xhtml.characters(Messages.getString("KnownMetParser.Name"));
+        xhtml.endElement("td");
+        xhtml.startElement("td", "class", "b");
+        if (item != null)
+            KnownMetParser.printNameWithLink(xhtml, item, e.getName());
+        else
+            xhtml.characters(e.getName());
+        xhtml.endElement("td");
+        xhtml.endElement("tr");
+        xhtml.newline();
+
+        addLine(xhtml, Messages.getString("KnownMetParser.Hash"), e.getHash(), "c");
+        addLine(xhtml, Messages.getString("KnownMetParser.LastModDate"), toFormatStr(df, e.getLastModified()));
+        addLine(xhtml, Messages.getString("KnownMetParser.LastPubDate"), toFormatStr(df, e.getLastPublishedKad()));
+        addLine(xhtml, Messages.getString("KnownMetParser.LastShareDate").replaceAll("-", ""), toFormatStr(df, e.getLastShared()));
+        addLine(xhtml, Messages.getString("KnownMetParser.Size"), toFormatStr(nf, e.getFileSize()));
+        addLine(xhtml, Messages.getString("KnownMetParser.Requests"), toFormatStr(nf, e.getTotalRequests()));
+        addLine(xhtml, Messages.getString("KnownMetParser.AcceptedRequests"), toFormatStr(nf, e.getAcceptedRequests()));
+        addLine(xhtml, Messages.getString("KnownMetParser.BytesSent"), toFormatStr(nf, e.getBytesTransfered()));
+        addLine(xhtml, Messages.getString("KnownMetParser.TempFile"), nvlStr(e.getPartName()));
+        addLine(xhtml, Messages.getString("KnownMetParser.FoundInPedoHashDB"),
+                hashSets.isEmpty() ? "" : hashSets.toString());
+        addLine(xhtml, Messages.getString("KnownMetParser.FoundInCase"),
+                item != null ? Messages.getString("KnownMetParser.Yes") : "");
+
+        if (hashDBHits > 0)
+            metadata.set(ExtraProperties.CSAM_HASH_HITS, Integer.toString(hashDBHits));
+
+        xhtml.endElement("table");
+        xhtml.endDocument();
+    }
+
+    private void addLine(XHTMLContentHandler xhtml, String key, String value, String valueClass) throws SAXException {
+        xhtml.startElement("tr");
+        xhtml.startElement("td", "class", "a");
+        xhtml.characters(key);
+        xhtml.endElement("td");
+        xhtml.startElement("td", "class", valueClass);
+        xhtml.characters(value);
+        xhtml.endElement("td");
+        xhtml.endElement("tr");
+        xhtml.newline();
+    }
+
+    private void addLine(XHTMLContentHandler xhtml, String key, String value) throws SAXException {
+        addLine(xhtml, key, value, "b");
+    }
+
+    private String nvlStr(String str) {
+        return str == null ? "-" : str;
+    }
+
+    private String toFormatStr(DateFormat df, Date date) {
+        return date == null ? "-" : df.format(date);
+    }
+
+    private String toFormatStr(NumberFormat nf, long v) {
+        return v == -1 ? "-" : nf.format(v);
+    }
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
@@ -73,6 +73,8 @@ public class PartMetParser extends AbstractParser {
         if (ret <= 0)
             return;
 
+        metadata.add(ExtraProperties.SHARED_HASHES, e.getHash());
+        
         IItemSearcher searcher = context.get(IItemSearcher.class);
 
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
@@ -130,7 +132,7 @@ public class PartMetParser extends AbstractParser {
 
         if (hashDBHits > 0)
             metadata.set(ExtraProperties.CSAM_HASH_HITS, Integer.toString(hashDBHits));
-
+        
         xhtml.endElement("table");
         xhtml.endDocument();
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
@@ -256,11 +256,75 @@ public class KnownMetParser {
         return sb.toString();
     }
 
-    private static final String toStr(byte[] b, int offset, int length) {
-        if (offset + length >= b.length)
+    public static final String toStr(byte[] b, int offset, int length) {
+        if (offset + length > b.length)
             return null;
-        if (toByte(b, offset) == 0xEF && toByte(b, offset + 1) == 0xBB && toByte(b, offset + 2) == 0xBF)
-            return new String(b, offset + 3, length - 3, Charset.forName("UTF-8")); //$NON-NLS-1$
-        return new String(b, offset, length, Charset.forName("ISO8859_1")); //$NON-NLS-1$
+        if (toByte(b, offset) == 0xEF && toByte(b, offset + 1) == 0xBB && toByte(b, offset + 2) == 0xBF) {
+            Charset utf8 = Charset.forName("UTF-8");
+            StringBuilder sb = new StringBuilder();
+            int last = offset + 3;
+            for (int i = offset + 3; i < offset + length; i++) {
+                int a0 = toByte(b, i);
+                if (a0 == 0xcc && toByte(b, i + 1) == 0x81 && i > offset + 3) {
+                    char a = (char) toByte(b, i - 1);
+                    char v = 0;
+                    if (a == 'a')
+                        v = 'á';
+                    else if (a == 'e')
+                        v = 'é';
+                    else if (a == 'i')
+                        v = 'í';
+                    else if (a == 'o')
+                        v = 'ó';
+                    else if (a == 'u')
+                        v = 'ú';
+                    else if (a == 'c')
+                        v = 'ç';
+                    else if (a == 'A')
+                        v = 'Á';
+                    else if (a == 'E')
+                        v = 'É';
+                    else if (a == 'I')
+                        v = 'Í';
+                    else if (a == 'O')
+                        v = 'Ó';
+                    else if (a == 'U')
+                        v = 'Ú';
+                    else if (a == 'C')
+                        v = 'Ç';
+                    if (v != 0) {
+                        sb.append(new String(b, last, i - last - 1, utf8));
+                        sb.append(v);
+                        i++;
+                        last = i + 1;
+                    }
+                } else if (a0 == 0xC3) {
+                    int ignore = 1;
+                    for (int j = i + 1; j < offset + length; j++) {
+                        int a2 = toByte(b, j + 1);
+                        if (a2 == 0xC2) {
+                            ignore++;
+                            continue;
+                        }
+                        int a1 = toByte(b, j);
+                        if (a1 == 0x82 || a1 == 0x83 || a1 == 0xC2 || a1 == 0xC3 || a1 == 0xC6 || a1 == 0x92
+                                || a1 == 0x3F) {
+                            ignore++;
+                            continue;
+                        }
+                        if (ignore >= 3) {
+                            sb.append(new String(b, last, i - last, utf8));
+                            sb.append(new String(new byte[] { (byte) a0, (byte) a1 }, utf8));
+                            i = j;
+                            last = i + 1;
+                        }
+                        break;
+                    }
+                }
+            }
+            sb.append(new String(b, last, offset + length - last, utf8));
+            return sb.toString();
+        }
+        return new String(b, offset, length, Charset.forName("ISO8859_1"));
     }
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
@@ -62,7 +62,7 @@ public class KnownMetParser {
         return l;
     }
 
-    private static int parseEntry(KnownMetEntry entry, int offset, byte[] b) {
+    public static int parseEntry(KnownMetEntry entry, int offset, byte[] b) {
         int pos = offset;
         long ms = toInt(b, pos) * 1000L;
         if (ms < dataMin || ms > dataMax)

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/TikaHtmlViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/TikaHtmlViewer.java
@@ -37,6 +37,7 @@ public class TikaHtmlViewer extends HtmlViewer {
                 || contentType.equals("application/x-sqlite3") //$NON-NLS-1$
                 || contentType.equals("application/sqlite-skype") //$NON-NLS-1$
                 || contentType.equals("application/x-emule") //$NON-NLS-1$
+                || contentType.equals("application/x-emule-part-met") //$NON-NLS-1$
                 || contentType.equals("application/x-ares-galaxy") //$NON-NLS-1$
                 || contentType.equals("application/x-shareaza-library-dat"); //$NON-NLS-1$
     }


### PR DESCRIPTION
As pointed out in #811, since the parser for known.met files was implemented, file names of some entries are not decoded properly, when they contain accents (and sometimes others special characters). 

Usually strings that contain non-ascii characters are encoded using UTF-8.
For some reason, part of the strings had same extra/strange bytes, which does not match any standard charset.
Interestingly, I found cases inside the same known.met file in which the same words are encoded in different ways, in distinct entries.

I could not find a general solution, but found a few "problematic patterns", inspecting the binary content of many known.met and *.part.met files.
The code now handle these "patterns", improving the decoded file names for most of the cases.

I ran a few tests with other tools that decode/view these files, and they also have trouble to decode most of these strings.