### PR TITLE
Fix font color in name column with hits in dark theme

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/App.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/App.java
@@ -70,6 +70,7 @@ import javax.swing.RowSorter.SortKey;
 import javax.swing.SortOrder;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -122,6 +123,7 @@ import dpf.sp.gpinf.indexer.ui.fileViewer.util.AppSearchParams;
 import dpf.sp.gpinf.indexer.ui.hitsViewer.HitsTable;
 import dpf.sp.gpinf.indexer.ui.hitsViewer.HitsTableModel;
 import dpf.sp.gpinf.indexer.util.IconUtil;
+import dpf.sp.gpinf.indexer.util.UiUtil;
 import dpf.sp.gpinf.indexer.util.Util;
 import iped3.IIPEDSource;
 import iped3.IItem;
@@ -771,6 +773,12 @@ public class App extends JFrame implements WindowListener, IMultiSearchResultPro
         termo.getEditor().getEditorComponent().addMouseListener(appletListener);
         termo.getComponent(0).addMouseListener(appletListener);
         new AutoCompletarColunas((JTextComponent) termo.getEditor().getEditorComponent());
+        
+        Color foreground = UIManager.getColor("Viewer.foreground"); //$NON-NLS-1$
+        if (foreground == null)
+            getParams().FONT_START_TAG = null;
+        else
+            getParams().FONT_START_TAG = "<font color=" + UiUtil.getHexRGB(foreground) + ">"; //$NON-NLS-1$ //$NON-NLS-2$
         
         if (refresh) {
             if (gallery != null) {

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
@@ -371,8 +371,10 @@ public class ResultTableListener implements ListSelectionListener, MouseListener
 
     private String getCell(JTable table, int row, int col) {
         String cell = table.getValueAt(row, col).toString();
-        return cell.replace("<html><nobr>", "").replace("</html>", "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                .replace(App.get().getParams().HIGHLIGHT_START_TAG, "")
+        if (App.get().getParams().FONT_START_TAG != null)
+            cell = cell.replace(App.get().getParams().FONT_START_TAG, ""); //$NON-NLS-1$
+        return cell.replace("<html><nobr>", "").replace("</html>", "") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                .replace(App.get().getParams().HIGHLIGHT_START_TAG, "") //$NON-NLS-1$
                 .replace(App.get().getParams().HIGHLIGHT_END_TAG, ""); //$NON-NLS-1$
     }
 

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableModel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableModel.java
@@ -330,7 +330,15 @@ public class ResultTableModel extends AbstractTableModel implements SearchResult
             } else if (field.equals(IndexItem.NAME)) {
                 TextFragment[] fragments = TextHighlighter.getHighlightedFrags(false, value, field, 0);
                 if (fragments[0].getScore() > 0) {
-                    value = "<html><nobr>" + fragments[0].toString() + "</html>"; //$NON-NLS-1$ //$NON-NLS-2$
+                    StringBuilder s = new StringBuilder();
+                    s.append("<html><nobr>"); //$NON-NLS-1$
+                    if (App.get().getParams().FONT_START_TAG != null)
+                        s.append(App.get().getParams().FONT_START_TAG);
+                    s.append(fragments[0].toString());
+                    if (App.get().getParams().FONT_START_TAG != null)
+                        s.append(App.get().getParams().HIGHLIGHT_END_TAG);
+                    s.append("</html>"); //$NON-NLS-1$
+                    value = s.toString();
                 }
             }
 

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/util/AppSearchParams.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/util/AppSearchParams.java
@@ -29,6 +29,7 @@ public class AppSearchParams {
     public Query query = null;
     public String HIGHLIGHT_START_TAG = null;
     public String HIGHLIGHT_END_TAG = null;
+    public String FONT_START_TAG = null;
     public Object autoParser = null;
     public JTabbedPane tabbedHits = null;
     public HitsTable hitsTable = null;


### PR DESCRIPTION
This is a minor issue related to the dark theme #569.
When there are hits in the item name column, the highlighted part is visible (in yellow), but the rest of the name becomes hard to read (black on dark background).
![image](https://user-images.githubusercontent.com/7217001/139588977-84adfefd-b8e3-42e4-a6a1-51bff5f3a841.png)
