### PR TITLE
Fix copying items table cell content using CTRL+C (in master)

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
@@ -505,6 +505,7 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
         //and CTRL+C (copy selected table cell content).
         if (e.isControlDown() && (e.getKeyCode() == 'B' || e.getKeyCode() == 'C')) {
             showMessage(Messages.getString("BookmarksManager.KeyStrokeAlert4"));
+            e.consume();
             return;
         }
         
@@ -523,6 +524,7 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
         if (e.getKeyCode() == KeyEvent.VK_SPACE || e.getKeyCode() == 'R') {
             if (e.getSource() == list) {
                 showMessage(Messages.getString("BookmarksManager.KeyStrokeAlert4"));
+                e.consume();
             }
             return;
         }
@@ -532,14 +534,17 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
         if (e.getSource() == list) {
             if (list.getSelectedIndices().length != 1) {
                 showMessage(Messages.getString("BookmarksManager.KeyStrokeAlert1"));
+                e.consume();
                 return;
             }
             if ((e.getModifiers() & KeyEvent.ALT_MASK) != 0) {
                 showMessage(Messages.getString("BookmarksManager.KeyStrokeAlert2"));
+                e.consume();
                 return;
             }
             if (keystrokeToBookmark.containsKey(stroke)) {
                 showMessage(Messages.getString("BookmarksManager.KeyStrokeAlert3"));
+                e.consume();
                 return;
             }
             int index = list.getSelectedIndex();
@@ -560,7 +565,8 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
 
             App.get().appCase.getMultiMarcadores().setLabelKeyStroke(label, stroke);
             App.get().appCase.getMultiMarcadores().saveState();
-
+            e.consume();
+            
         } else {
             String label = keystrokeToBookmark.get(stroke);
             if (label == null) {
@@ -568,6 +574,7 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
             }
             ArrayList<IItemId> uniqueSelectedIds = getUniqueSelectedIds();
             bookmark(uniqueSelectedIds, Collections.singletonList(label), (e.getModifiers() & KeyEvent.ALT_MASK) == 0);
+            e.consume();
         }
 
     }

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GerenciadorMarcadores.java
@@ -496,6 +496,9 @@ public class GerenciadorMarcadores implements ActionListener, ListSelectionListe
 
     @Override
     public void keyPressed(KeyEvent e) {
+        if (e.isConsumed())
+            return;
+        
         if (e.getKeyCode() == KeyEvent.VK_SHIFT || e.getKeyCode() == KeyEvent.VK_CONTROL
                 || e.getKeyCode() == KeyEvent.VK_ALT) {
             return;

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
@@ -186,6 +186,8 @@ public class ResultTableListener implements ListSelectionListener, MouseListener
 
     @Override
     public void keyPressed(KeyEvent evt) {
+        if (evt.isConsumed())
+            return;
         if (App.get().resultsTable.getSelectedRow() == -1)
             return;
 

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/ResultTableListener.java
@@ -186,38 +186,34 @@ public class ResultTableListener implements ListSelectionListener, MouseListener
 
     @Override
     public void keyPressed(KeyEvent evt) {
-        if (App.get().resultsTable.getSelectedRow() == -1) {
+        if (App.get().resultsTable.getSelectedRow() == -1)
             return;
-        }
 
         if (evt.getKeyCode() == KeyEvent.VK_C && ((evt.getModifiers() & KeyEvent.CTRL_MASK) != 0)) {
-
             int selCol = App.get().resultsTable.getSelectedColumn();
-            if (selCol < 0) {
+            if (selCol < 0)
                 return;
-            }
             String value = getCell(App.get().resultsTable, App.get().resultsTable.getSelectedRow(), selCol);
             StringSelection selection = new StringSelection(value);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(selection, selection);
-
-        } else if (evt.getKeyCode() == KeyEvent.VK_SPACE)
+            clipboard.setContents(selection, null);
+            evt.consume();
+        } else if (evt.getKeyCode() == KeyEvent.VK_SPACE) {
             itemSelection();
-        else if (evt.getKeyCode() == KeyEvent.VK_R && ((evt.getModifiers() & KeyEvent.CTRL_MASK) != 0)) // Shortcut to
-                                                                                                        // Deep-Selection
-                                                                                                        // (Item plus
-                                                                                                        // sub-items)
+            evt.consume();
+        } else if (evt.getKeyCode() == KeyEvent.VK_R && ((evt.getModifiers() & KeyEvent.CTRL_MASK) != 0)) {
+            // Shortcut to Deep-Selection (Item plus sub-items)
             recursiveItemSelection(true);
-        else if (evt.getKeyCode() == KeyEvent.VK_R && ((evt.getModifiers() & KeyEvent.ALT_MASK) != 0)) // Shortcut to
-                                                                                                       // Deep-Selection
-                                                                                                       // (Item plus
-                                                                                                       // sub-items)
+            evt.consume();
+        } else if (evt.getKeyCode() == KeyEvent.VK_R && ((evt.getModifiers() & KeyEvent.ALT_MASK) != 0)) {
+            // Shortcut to Deep-Selection Remove (Item plus sub-items)
             recursiveItemSelection(false);
-        else if (evt.getKeyCode() == KeyEvent.VK_B && ((evt.getModifiers() & KeyEvent.CTRL_MASK) != 0)) // Shortcut to
-                                                                                                        // BookmarkManager
-                                                                                                        // Window
+            evt.consume();
+        } else if (evt.getKeyCode() == KeyEvent.VK_B && ((evt.getModifiers() & KeyEvent.CTRL_MASK) != 0)) {
+            // Shortcut to BookmarkManager Window
             GerenciadorMarcadores.setVisible();
-        else
+            evt.consume();
+        } else 
             GerenciadorMarcadores.get().keyPressed(evt);
 
     }


### PR DESCRIPTION
I noticed that copying the content of a cell using CTRL+C is not working (at least in my environment).
The whole line of the table is copied, which is the default behavior of JTable's.
It seems the default implementation runs after the customized one, overwriting clipboard content.
I believe this is a regression caused by #710.

As a solution, I added explicit calls to evt.consume() in the table key listener, whenever a key is actually processed by the application.
It solved the issue described here (selected cell content is now copied), and it is a good practice in general.