### PR TITLE
Improved decoding of string tags in e-Mule MET files #811

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/gpinf/emule/KnownMetParser.java
@@ -256,11 +256,75 @@ public class KnownMetParser {
         return sb.toString();
     }
 
-    private static final String toStr(byte[] b, int offset, int length) {
-        if (offset + length >= b.length)
+    public static final String toStr(byte[] b, int offset, int length) {
+        if (offset + length > b.length)
             return null;
-        if (toByte(b, offset) == 0xEF && toByte(b, offset + 1) == 0xBB && toByte(b, offset + 2) == 0xBF)
-            return new String(b, offset + 3, length - 3, Charset.forName("UTF-8")); //$NON-NLS-1$
-        return new String(b, offset, length, Charset.forName("ISO8859_1")); //$NON-NLS-1$
+        if (toByte(b, offset) == 0xEF && toByte(b, offset + 1) == 0xBB && toByte(b, offset + 2) == 0xBF) {
+            Charset utf8 = Charset.forName("UTF-8");
+            StringBuilder sb = new StringBuilder();
+            int last = offset + 3;
+            for (int i = offset + 3; i < offset + length; i++) {
+                int a0 = toByte(b, i);
+                if (a0 == 0xcc && toByte(b, i + 1) == 0x81 && i > offset + 3) {
+                    char a = (char) toByte(b, i - 1);
+                    char v = 0;
+                    if (a == 'a')
+                        v = 'á';
+                    else if (a == 'e')
+                        v = 'é';
+                    else if (a == 'i')
+                        v = 'í';
+                    else if (a == 'o')
+                        v = 'ó';
+                    else if (a == 'u')
+                        v = 'ú';
+                    else if (a == 'c')
+                        v = 'ç';
+                    else if (a == 'A')
+                        v = 'Á';
+                    else if (a == 'E')
+                        v = 'É';
+                    else if (a == 'I')
+                        v = 'Í';
+                    else if (a == 'O')
+                        v = 'Ó';
+                    else if (a == 'U')
+                        v = 'Ú';
+                    else if (a == 'C')
+                        v = 'Ç';
+                    if (v != 0) {
+                        sb.append(new String(b, last, i - last - 1, utf8));
+                        sb.append(v);
+                        i++;
+                        last = i + 1;
+                    }
+                } else if (a0 == 0xC3) {
+                    int ignore = 1;
+                    for (int j = i + 1; j < offset + length; j++) {
+                        int a2 = toByte(b, j + 1);
+                        if (a2 == 0xC2) {
+                            ignore++;
+                            continue;
+                        }
+                        int a1 = toByte(b, j);
+                        if (a1 == 0x82 || a1 == 0x83 || a1 == 0xC2 || a1 == 0xC3 || a1 == 0xC6 || a1 == 0x92
+                                || a1 == 0x3F) {
+                            ignore++;
+                            continue;
+                        }
+                        if (ignore >= 3) {
+                            sb.append(new String(b, last, i - last, utf8));
+                            sb.append(new String(new byte[] { (byte) a0, (byte) a1 }, utf8));
+                            i = j;
+                            last = i + 1;
+                        }
+                        break;
+                    }
+                }
+            }
+            sb.append(new String(b, last, offset + length - last, utf8));
+            return sb.toString();
+        }
+        return new String(b, offset, length, Charset.forName("ISO8859_1"));
     }
 }


### PR DESCRIPTION
As pointed out in #811, since the parser for known.met files was implemented, file names of some entries are not decoded properly, when they contain accents (and sometimes others special characters).

Usually strings that contain non-ascii characters are encoded using UTF-8.
For some reason, part of the strings had same extra/strange bytes, which does not match any standard charset.
Interestingly, I found cases inside the same known.met file in which the same words are encoded in different ways, in distinct entries.

I could not find a general solution, but found a few "problematic patterns", inspecting the binary content of many known.met and *.part.met files.
The code now handle these "patterns", improving the decoded file names for most of the cases.

I ran a few tests with other tools that decode/view these files, and they also have trouble to decode most of these strings.