### PR TITLE
Support for embedded and splitted E01/DD/VMDK images

### DIFF
--- a/iped-api/src/main/java/iped3/util/MediaTypes.java
+++ b/iped-api/src/main/java/iped3/util/MediaTypes.java
@@ -21,8 +21,8 @@ public class MediaTypes {
     public static final MediaType JBIG2 = MediaType.image("x-jbig2");
     public static final MediaType OUTLOOK_MSG = MediaType.application("vnd.ms-outlook");
     public static final MediaType RAW_IMAGE = MediaType.application("x-raw-image"); //$NON-NLS-1$
+    public static final MediaType EWF_IMAGE = MediaType.application("x-ewf-image"); //$NON-NLS-1$
     public static final MediaType E01_IMAGE = MediaType.application("x-e01-image"); //$NON-NLS-1$
-    public static final MediaType E01_FIRST_IMAGE = MediaType.application("x-e01-first-image"); //$NON-NLS-1$
     public static final MediaType ISO_IMAGE = MediaType.application("x-iso9660-image"); //$NON-NLS-1$
     public static final MediaType VMDK = MediaType.application("x-vmdk"); //$NON-NLS-1$
     public static final MediaType VMDK_DATA = MediaType.application("x-vmdk-data"); //$NON-NLS-1$

--- a/iped-api/src/main/java/iped3/util/MediaTypes.java
+++ b/iped-api/src/main/java/iped3/util/MediaTypes.java
@@ -25,6 +25,8 @@ public class MediaTypes {
     public static final MediaType E01_FIRST_IMAGE = MediaType.application("x-e01-first-image"); //$NON-NLS-1$
     public static final MediaType ISO_IMAGE = MediaType.application("x-iso9660-image"); //$NON-NLS-1$
     public static final MediaType VMDK = MediaType.application("x-vmdk"); //$NON-NLS-1$
+    public static final MediaType VMDK_DATA = MediaType.application("x-vmdk-data"); //$NON-NLS-1$
+    public static final MediaType VMDK_DESCRIPTOR = MediaType.application("x-vmdk-descriptor"); //$NON-NLS-1$
     public static final MediaType VHD = MediaType.application("x-vhd"); //$NON-NLS-1$
     public static final MediaType VHDX = MediaType.application("x-vhdx"); //$NON-NLS-1$
     public static final MediaType VDI = MediaType.application("x-vdi"); //$NON-NLS-1$

--- a/iped-api/src/main/java/iped3/util/MediaTypes.java
+++ b/iped-api/src/main/java/iped3/util/MediaTypes.java
@@ -22,6 +22,7 @@ public class MediaTypes {
     public static final MediaType OUTLOOK_MSG = MediaType.application("vnd.ms-outlook");
     public static final MediaType RAW_IMAGE = MediaType.application("x-raw-image"); //$NON-NLS-1$
     public static final MediaType E01_IMAGE = MediaType.application("x-e01-image"); //$NON-NLS-1$
+    public static final MediaType E01_FIRST_IMAGE = MediaType.application("x-e01-first-image"); //$NON-NLS-1$
     public static final MediaType ISO_IMAGE = MediaType.application("x-iso9660-image"); //$NON-NLS-1$
     public static final MediaType VMDK = MediaType.application("x-vmdk"); //$NON-NLS-1$
     public static final MediaType VHD = MediaType.application("x-vhd"); //$NON-NLS-1$

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -6,7 +6,7 @@
 	<typesToProcess>application/x-vdi; application/x-vhdx</typesToProcess>
 	<typesToProcess>application/x-thumbs; application/x-thumbcache</typesToProcess>
 -->
-    <typesToNotProcess>application/x-raw-image; application/x-e01-image; application/x-vmdk; application/x-vmdk-data; application/x-vhd</typesToNotProcess>
+    <typesToNotProcess>application/x-raw-image; application/x-ewf-image; application/x-vmdk; application/x-vmdk-data; application/x-vhd</typesToNotProcess>
     <typesToNotProcess>application/x-tika-msoffice; video; text/html; application/pdf; image; application/x-iso9660-image; application/x-udf-image;</typesToNotProcess>
     <typesToNotProcess>application/vnd.ms-outlook-pst; application/outlook-dbx; application/mbox; application/x-incredimail;</typesToNotProcess>
     <typesToNotProcess>message/rfc822; message/x-emlx; application/vnd.ms-outlook; message/outlook-pst</typesToNotProcess>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -6,7 +6,7 @@
 	<typesToProcess>application/x-vdi; application/x-vhdx</typesToProcess>
 	<typesToProcess>application/x-thumbs; application/x-thumbcache</typesToProcess>
 -->
-    <typesToNotProcess>application/x-raw-image; application/x-e01-image; application/x-vmdk; application/x-vhd</typesToNotProcess>
+    <typesToNotProcess>application/x-raw-image; application/x-e01-image; application/x-vmdk; application/x-vmdk-data; application/x-vhd</typesToNotProcess>
     <typesToNotProcess>application/x-tika-msoffice; video; text/html; application/pdf; image; application/x-iso9660-image; application/x-udf-image;</typesToNotProcess>
     <typesToNotProcess>application/vnd.ms-outlook-pst; application/outlook-dbx; application/mbox; application/x-incredimail;</typesToNotProcess>
     <typesToNotProcess>message/rfc822; message/x-emlx; application/vnd.ms-outlook; message/outlook-pst</typesToNotProcess>

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -623,7 +623,7 @@
         </magic>
     </mime-type>
   	
-    <mime-type type="application/x-e01-image">
+    <mime-type type="application/x-ewf-image">
         <_comment>E01 disk images</_comment>
         <magic priority="50">
             <match value="0x5646090D0AFF00" type="string" offset="1"/>
@@ -631,8 +631,8 @@
         <sub-class-of type="application/x-disk-image"/>
     </mime-type>
     
-    <mime-type type="application/x-e01-first-image">
-        <sub-class-of type="application/x-e01-image"/>
+    <mime-type type="application/x-e01-image">
+        <sub-class-of type="application/x-ewf-image"/>
         <glob pattern="*.e01"/>
     </mime-type>
         

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -638,6 +638,7 @@
         
     <mime-type type="application/x-raw-image">
         <_comment>RAW disk images</_comment>
+        <_comment>This priority must be equal to x-vmdk</_comment>
         <magic priority="30">
             <match value="0x55AA" type="string" offset="510">
                 <match value="0x0000" type="string" offset="444"/>
@@ -646,6 +647,24 @@
         </magic>
         <sub-class-of type="application/x-disk-image"/>
         <glob pattern="*.dd"/>
+    </mime-type>
+    
+    <mime-type type="application/x-vmdk">
+        <_comment>This priority must be equal to x-raw-image</_comment>
+        <magic priority="30">
+            <match value="0x55AA" type="string" offset="510">
+                <match value="0x0000" type="string" offset="444"/>
+                <match value="0x5A5A" type="string" offset="444"/>
+            </match>
+        </magic>
+        <glob pattern="*.vmdk"/>
+    </mime-type>
+    
+    <mime-type type="application/x-vmdk-descriptor">
+        <magic priority="50">
+            <match value="# Disk DescriptorFile" type="string" offset="0"/>
+        </magic>
+        <sub-class-of type="text/plain"/>
     </mime-type>
     
     <mime-type type="application/x-wim-image">

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -629,6 +629,10 @@
             <match value="0x5646090D0AFF00" type="string" offset="1"/>
         </magic>
         <sub-class-of type="application/x-disk-image"/>
+    </mime-type>
+    
+    <mime-type type="application/x-e01-first-image">
+        <sub-class-of type="application/x-e01-image"/>
         <glob pattern="*.e01"/>
     </mime-type>
         

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -647,6 +647,8 @@
         </magic>
         <sub-class-of type="application/x-disk-image"/>
         <glob pattern="*.dd"/>
+        <glob pattern="*.000"/>
+        <glob pattern="*.001"/>
     </mime-type>
     
     <mime-type type="application/x-vmdk">

--- a/iped-app/resources/config/conf/scripts/RefineCategoryTask.js
+++ b/iped-app/resources/config/conf/scripts/RefineCategoryTask.js
@@ -24,6 +24,10 @@ function process(e){
 	var categorias = e.getCategories();
 	var length = e.getLength();
 	var ext = e.getExt().toLowerCase();
+	
+	if(/.*(-delta|-flat|-(f|s)[0-9]{3})\.vmdk/i.test(e.getName())){
+	    e.setMediaTypeStr("application/x-vmdk-data");
+	}
 
 	if(e.getExt().toLowerCase().equals("mts")){
 		e.setMediaTypeStr("video/mp2t");

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
@@ -135,6 +135,7 @@ public class SleuthkitReader extends DataSourceReader {
     private boolean fastmode = false;
     private boolean embeddedDisk = false;
     private int itemCount = 0;
+    private volatile boolean decodingError = false;
 
     // Referência estática para a JVM não finalizar o objeto que será usado
     // futuramente
@@ -155,6 +156,10 @@ public class SleuthkitReader extends DataSourceReader {
 
     public int getItemCount() {
         return itemCount;
+    }
+
+    public boolean hasDecodingError() {
+        return this.decodingError;
     }
 
     public boolean isSupported(File file) {
@@ -546,6 +551,7 @@ public class SleuthkitReader extends DataSourceReader {
             if (exit != 0) {
                 LOGGER.error("Sleuthkit LoadDb returned an error {}. Possibly" //$NON-NLS-1$
                         + " many items were not added to the case!", exit); //$NON-NLS-1$
+                decodingError = true;
             }
 
         } catch (InterruptedException ie) {
@@ -1119,6 +1125,7 @@ public class SleuthkitReader extends DataSourceReader {
                             if (line.toLowerCase().contains("error") //$NON-NLS-1$
                                     && !line.toLowerCase().contains("microsoft reserved partition")) { //$NON-NLS-1$
                                 LOGGER.error("Sleuthkit error processing {}: {}", image, line.trim()); //$NON-NLS-1$
+                                decodingError = true;
                             } else {
                                 LOGGER.info("Sleuthkit: " + line.trim()); //$NON-NLS-1$
                             }

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
@@ -860,7 +860,8 @@ public class SleuthkitReader extends DataSourceReader {
         if (listOnly || fastmode || embeddedDisk) {
             itemCount++;
             caseData.incDiscoveredEvidences(1);
-            caseData.incDiscoveredVolume(evidence.getLength());
+            if (!embeddedDisk)
+                caseData.incDiscoveredVolume(evidence.getLength());
             if (listOnly)
                 return null;
         }

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
@@ -20,6 +20,7 @@ import dpf.sp.gpinf.indexer.parsers.KnownMetParser;
 import dpf.sp.gpinf.indexer.parsers.PartMetParser;
 import dpf.sp.gpinf.indexer.parsers.jdbc.SQLite3Parser;
 import dpf.sp.gpinf.indexer.parsers.ufed.UFEDChatParser;
+import iped3.util.MediaTypes;
 
 /**
  * Classe de definição de prioridade de processamento de itens com base no
@@ -67,6 +68,10 @@ public class MimeTypesProcessingOrder {
         mediaTypes.put(WhatsAppParser.CHAT_STORAGE, 2);
 
         mediaTypes.put(UFEDChatParser.UFED_CHAT_MIME, 1);
+        
+        // support for embedded splited image formats
+        mediaTypes.put(MediaTypes.E01_FIRST_IMAGE, 1);
+        mediaTypes.put(MediaTypes.RAW_IMAGE, 1);
 
         // avoid NPE when the parser gets the item from parseContext when external
         // parsing is on

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
@@ -70,7 +70,7 @@ public class MimeTypesProcessingOrder {
         mediaTypes.put(UFEDChatParser.UFED_CHAT_MIME, 1);
         
         // support for embedded splited image formats
-        mediaTypes.put(MediaTypes.E01_FIRST_IMAGE, 1);
+        mediaTypes.put(MediaTypes.E01_IMAGE, 1);
         mediaTypes.put(MediaTypes.RAW_IMAGE, 1);
         mediaTypes.put(MediaTypes.VMDK_DESCRIPTOR, 1);
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/MimeTypesProcessingOrder.java
@@ -72,6 +72,7 @@ public class MimeTypesProcessingOrder {
         // support for embedded splited image formats
         mediaTypes.put(MediaTypes.E01_FIRST_IMAGE, 1);
         mediaTypes.put(MediaTypes.RAW_IMAGE, 1);
+        mediaTypes.put(MediaTypes.VMDK_DESCRIPTOR, 1);
 
         // avoid NPE when the parser gets the item from parseContext when external
         // parsing is on

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
@@ -31,6 +31,8 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
 
     private static Logger logger = LoggerFactory.getLogger(EmbeddedDiskProcessTask.class);
 
+    private static final int MIN_DD_SIZE = 1024;
+
     private static final String ENABLE_PARAM = "processEmbeddedDisks";
 
     private static final String outputFolder = "embeddedDisks";
@@ -85,6 +87,10 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
 
         if (isFirstImagePart(item)) {
             if (MediaTypes.RAW_IMAGE.equals(item.getMediaType())) {
+                // skip some false positives like $MBR files
+                if (item.getLength() < MIN_DD_SIZE) {
+                    return;
+                }
                 // look up for DD parts
                 ItemSearcher searcher = (ItemSearcher) caseData.getCaseObject(IItemSearcher.class.getName());
                 int dotIdx = item.getName().lastIndexOf(".");

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
@@ -40,8 +40,8 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
     private static final String outputFolder = "embeddedDisks";
 
     private static Set<MediaType> supportedMimes = MediaType.set(MediaTypes.VMDK, MediaTypes.VMDK_DATA,
-            MediaTypes.VMDK_DESCRIPTOR, MediaTypes.VHD, MediaTypes.RAW_IMAGE, MediaTypes.E01_IMAGE,
-            MediaTypes.E01_FIRST_IMAGE);
+            MediaTypes.VMDK_DESCRIPTOR, MediaTypes.VHD, MediaTypes.RAW_IMAGE, MediaTypes.EWF_IMAGE,
+            MediaTypes.E01_IMAGE);
 
     private static Set<File> exportedDisks = Collections.synchronizedSet(new HashSet<>());
 
@@ -77,7 +77,7 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
     }
 
     private static boolean isFirstOrUniqueImagePart(IItem item) {
-        return MediaTypes.E01_FIRST_IMAGE.equals(item.getMediaType())
+        return MediaTypes.E01_IMAGE.equals(item.getMediaType())
                 || MediaTypes.RAW_IMAGE.equals(item.getMediaType())
                 || MediaTypes.VMDK_DESCRIPTOR.equals(item.getMediaType());
     }
@@ -110,7 +110,7 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
                 }
             }
 
-        } else if (MediaTypes.E01_IMAGE.equals(item.getMediaType())
+        } else if (MediaTypes.EWF_IMAGE.equals(item.getMediaType())
                 || MediaTypes.VMDK_DATA.equals(item.getMediaType())) {
             // export e01/vmdk parts to process them later
             exportItem(item);

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/EmbeddedDiskProcessTask.java
@@ -18,7 +18,9 @@ import org.slf4j.LoggerFactory;
 import dpf.sp.gpinf.indexer.config.ConfigurationManager;
 import dpf.sp.gpinf.indexer.config.EnableTaskProperty;
 import dpf.sp.gpinf.indexer.datasource.SleuthkitReader;
+import dpf.sp.gpinf.indexer.parsers.IndexerDefaultParser;
 import dpf.sp.gpinf.indexer.process.ItemSearcher;
+import dpf.sp.gpinf.indexer.util.TextCache;
 import gpinf.dev.data.Item;
 import iped3.IItem;
 import iped3.io.IItemBase;
@@ -123,6 +125,11 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
                 item.setHasChildren(true);
                 item.setExtraAttribute(ParsingTask.HAS_SUBITEM, Boolean.TRUE.toString());
                 item.setExtraAttribute(ParsingTask.NUM_SUBITEMS, numSubitems);
+            }
+            if (reader.hasDecodingError()) {
+                item.getMetadata().set(IndexerDefaultParser.PARSER_EXCEPTION, Boolean.TRUE.toString());
+            } else {
+                ((Item) item).setParsedTextCache(new TextCache());
             }
         }
 

--- a/iped-engine/src/main/java/gpinf/dev/data/Item.java
+++ b/iped-engine/src/main/java/gpinf/dev/data/Item.java
@@ -1162,15 +1162,23 @@ public class Item implements ISleuthKitItem {
      */
     @Deprecated
     public void setParsedTextCache(String parsedText) {
-        this.textCache = new TextCache();
+        TextCache textCache = new TextCache();
         try {
-            this.textCache.write(parsedText);
+            textCache.write(parsedText);
         } catch (IOException e) {
             e.printStackTrace();
         }
+        this.setParsedTextCache(textCache);
     }
 
     public void setParsedTextCache(TextCache textCache) {
+        if (this.textCache != null) {
+            try {
+                this.textCache.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
         this.textCache = textCache;
     }
 


### PR DESCRIPTION
Closes #102: add support for splitted E01/DD/VMDK images sending them to second processing queue.

EXX/VMDK segments are exported while processing the first queue and processed later together with first image segment. DD segments are exported later when processing second queue because they have no signature, being detected when first DD segment is processed, using its name and parent folder.