### PR TITLE
#827 java11 upgrade

### DIFF
--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -72,9 +72,9 @@
                                 <artifactItem>
                                     <groupId>java</groupId>
                                     <artifactId>jre</artifactId>
-                                    <version>1.8.0_152</version>
+                                    <version>11.0.13</version>
                                     <type>zip</type>
-                                    <overWrite>true</overWrite>
+                                    <overWrite>false</overWrite>
                                     <outputDirectory>${release.dir}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
@@ -66,7 +66,7 @@ import iped3.util.BasicProps;
 public class Util {
 
     public static final Integer MIN_JAVA_VER = 8;
-    public static final Integer MAX_JAVA_VER = 8;
+    public static final Integer MAX_JAVA_VER = 11;
 
     // These java versions have a WebView bug that crashes the JVM: JDK-8196011
     private static final String[] buggedVersions = { "1.8.0_161", "1.8.0_162", "1.8.0_171" };

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -166,6 +166,11 @@
             <version>${java.dbx.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>github.sepinf</groupId>
+            <artifactId>png-reader</artifactId>
+            <version>jdk11+28-p1</version>
+        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
Upgrade embedded JRE to Liberica 11.0.13 x64 Full (includes JavaFX). Closes #827.