### PR TITLE
Set ufed:msgChildIds to be an Integer (#848)

### DIFF
--- a/iped-app/resources/config/conf/metadataTypes.txt
+++ b/iped-app/resources/config/conf/metadataTypes.txt
@@ -4121,6 +4121,7 @@ twitter:image:src = java.lang.String
 twitter:title = java.lang.String
 ufed:extractionId = java.lang.Integer
 ufed:labels = java.lang.String
+ufed:msgChildIds = java.lang.Integer
 ufed:RepeatInterval = java.lang.Integer
 ufed:SMSC = java.lang.String
 ufed:VisitCount = java.lang.Integer


### PR DESCRIPTION
In the cases we have here, just setting **ufed:msgChildIds** to be an **Integer** in **metadataTypes.txt** solved the issue described in #848, but I am not sure if this is the best (or correct) way of handling this. 