### PR TITLE
fix #852 upgrade to imagemagick-7.1.0-q8-x64 to fix animated webp thumbs

### DIFF
--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -262,7 +262,7 @@
                                 <artifactItem>
                                     <groupId>org.imagemagick</groupId>
                                     <artifactId>imagemagick-zip</artifactId>
-                                    <version>7.0.8-14.1</version>
+                                    <version>7.1.0-q8-x64</version>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${tools.dir}</outputDirectory>


### PR DESCRIPTION
Fix #852. Merging should be done just after running some regression tests for other image file formats.