### PR TITLE
Handle HEIC/HEIF sequences as videos #854

### DIFF
--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -78,18 +78,32 @@
     	<magic priority="60">
       		<match value="ftypheic" type="string" offset="4"/>
       		<match value="ftypheix" type="string" offset="4"/>
+    	</magic>
+    	<sub-class-of type="application/octet-stream"/>
+    	<glob pattern="*.heic"/>
+  	</mime-type>
+  	
+	<mime-type type="image/heic-sequence">
+    	<magic priority="60">
       		<match value="ftyphevc" type="string" offset="4"/>
       		<match value="ftyphevx" type="string" offset="4"/>
     	</magic>
-    	<glob pattern="*.heic"/>
+    	<sub-class-of type="application/octet-stream"/>
   	</mime-type>
   	
   	<mime-type type="image/heif">
     	<magic priority="60">
       		<match value="ftypmif1" type="string" offset="4"/>
+    	</magic>
+    	<sub-class-of type="application/octet-stream"/>
+    	<glob pattern="*.heif"/>
+  	</mime-type>
+
+  	<mime-type type="image/heif-sequence">
+    	<magic priority="60">
       		<match value="ftypmsf1" type="string" offset="4"/>
     	</magic>
-    	<glob pattern="*.heif"/>
+    	<sub-class-of type="application/octet-stream"/>
   	</mime-type>
 
 	<mime-type type="application/x-dbf">

--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -192,7 +192,9 @@
         
         <parser class="dpf.sp.gpinf.indexer.parsers.MultipleParser">
             <mime>image/heic</mime>
+            <mime>image/heif</mime>
             <mime>image/heic-sequence</mime>
+            <mime>image/heif-sequence</mime>
             <params>
                 <param name="parserName" type="string">HeicParser</param>
                 <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.image.HeifParser</param>

--- a/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
+++ b/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
@@ -196,7 +196,9 @@
         
         <parser class="dpf.sp.gpinf.indexer.parsers.MultipleParser">
             <mime>image/heic</mime>
+            <mime>image/heif</mime>
             <mime>image/heic-sequence</mime>
+            <mime>image/heif-sequence</mime>
             <params>
                 <param name="parserName" type="string">HeicParser</param>
                 <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.image.HeifParser</param>

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
@@ -98,8 +98,9 @@ public class GalleryModel extends AbstractTableModel {
         return ImageThumbTask.isImageType(MediaType.parse(mediaType));
     }
 
-    private boolean isAnimationImage(Document doc) {
-        return doc.get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
+    private boolean isAnimationImage(Document doc, String mediaType) {
+        return VideoThumbTask.isImageSequence(mediaType) || 
+                doc.get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
     }
 
     private boolean isSupportedVideo(String mediaType) {
@@ -181,7 +182,7 @@ public class GalleryModel extends AbstractTableModel {
                     }
 
                     BytesRef bytesRef = doc.getBinaryValue(IndexItem.THUMB);
-                    if (bytesRef != null && ((!isSupportedVideo(mediaType) && !isAnimationImage(doc)) || App.get().useVideoThumbsInGallery)) {
+                    if (bytesRef != null && ((!isSupportedVideo(mediaType) && !isAnimationImage(doc, mediaType)) || App.get().useVideoThumbsInGallery)) {
                         byte[] thumb = bytesRef.bytes;
                         if (thumb.length > 0) {
                             image = ImageIO.read(new ByteArrayInputStream(thumb));
@@ -192,7 +193,7 @@ public class GalleryModel extends AbstractTableModel {
 
                     String hash = doc.get(IndexItem.HASH);
                     if (image == null && hash != null && !hash.isEmpty()) {
-                        image = getViewImage(docId, hash, isSupportedVideo(mediaType) || isAnimationImage(doc));
+                        image = getViewImage(docId, hash, isSupportedVideo(mediaType) || isAnimationImage(doc, mediaType));
                         int resizeTolerance = 4;
                         if (image != null) {
                             if (image.getWidth() < thumbSize - resizeTolerance
@@ -305,7 +306,7 @@ public class GalleryModel extends AbstractTableModel {
                 try {
                     Document doc = App.get().appCase.getSearcher().doc(docId);
                     String mediaType = doc.get(IndexItem.CONTENTTYPE);
-                    if (isSupportedVideo(mediaType) || isAnimationImage(doc)) {
+                    if (isSupportedVideo(mediaType) || isAnimationImage(doc, mediaType)) {
                         it.remove();
                     }
                 } catch (Exception e) {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/DIETask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/DIETask.java
@@ -325,7 +325,8 @@ public class DIETask extends AbstractTask {
      */
 
     private static boolean isAnimationImage(IItem item) {
-        return item.getMetadata().get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
+        return VideoThumbTask.isImageSequence(item.getMediaType().toString()) ||
+                item.getMetadata().get(VideoThumbTask.ANIMATION_FRAMES_PROP) != null;
     }
 
     /**

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -367,24 +367,30 @@ public class VideoThumbTask extends ThumbTask {
                 mainTmpFile = new File(mainOutFile.getParentFile(), evidence.getHash() + tempSuffix);
                 mainConfig.setOutFile(mainTmpFile);
 
-                //Set the number of frames for animated images
+                //Check if it is an animated images
                 int numFrames = 0;
-                String strFrames = evidence.getMetadata().get(ANIMATION_FRAMES_PROP);
-                if (strFrames != null) 
-                    numFrames = Integer.parseInt(strFrames);
+                boolean isAnimated = isImageSequence(evidence.getMediaType().toString());
+                if (!isAnimated) {
+                    String strFrames = evidence.getMetadata().get(ANIMATION_FRAMES_PROP);
+                    if (strFrames != null) {
+                        numFrames = Integer.parseInt(strFrames);
+                        if (numFrames > 0)
+                            isAnimated = true;
+                    }
+                }
 
                 long t = System.currentTimeMillis();
                 r = videoThumbsMaker.createThumbs(evidence.getTempFile(), tmpFolder, configs, numFrames);
                 t = System.currentTimeMillis() - t;
-                if (r != null && numFrames > 0) {
+                if (r != null && isAnimated) {
                     //Clear video duration for animated images
                     r.setVideoDuration(-1);
                 }
                 if (r.isSuccess() && (mainOutFile.exists() || mainTmpFile.renameTo(mainOutFile))) {
-                    (numFrames > 0 ? totalAnimatedImagesProcessed : totalVideosProcessed).incrementAndGet();
+                    (isAnimated ? totalAnimatedImagesProcessed : totalVideosProcessed).incrementAndGet();
                 } else {
                     r.setSuccess(false);
-                    (numFrames > 0 ? totalAnimatedImagesFailed : totalVideosFailed).incrementAndGet();
+                    (isAnimated ? totalAnimatedImagesFailed : totalVideosFailed).incrementAndGet();
                     if (r.isTimeout()) {
                         stats.incTimeouts();
                         evidence.setExtraAttribute(ImageThumbTask.THUMB_TIMEOUT, "true"); //$NON-NLS-1$
@@ -392,7 +398,7 @@ public class VideoThumbTask extends ThumbTask {
                                 + evidence.getLength() + " bytes)"); //$NON-NLS-1$
                     }
                 }
-                (numFrames > 0 ? totalAnimatedImagesTime : totalVideosTime).addAndGet(t);
+                (isAnimated ? totalAnimatedImagesTime : totalVideosTime).addAndGet(t);
             }
         } catch (Exception e) {
             logger.warn(evidence.toString(), e);
@@ -500,6 +506,14 @@ public class VideoThumbTask extends ThumbTask {
     public static boolean isVideoType(MediaType mediaType) {
         return MetadataUtil.isVideoType(mediaType);
     }
+    
+
+    /**
+     * Check if the evidence's mediaType is an image sequence.
+     */
+    public static boolean isImageSequence(String mediaType) {
+        return mediaType.equals("image/heic-sequence") || mediaType.equals("image/heif-sequence");
+    }
 
     /** 
      * Checks if the evidence is an animated image, and update
@@ -508,8 +522,11 @@ public class VideoThumbTask extends ThumbTask {
     private static boolean checkAnimatedImage(IItem evidence) {
         int numImages = -1;
         String mediaType = evidence.getMediaType().toString();
-        
-        if (mediaType.equals("image/gif")) {
+
+        if (isImageSequence(mediaType)) {
+            return true;
+
+        } else if (mediaType.equals("image/gif")) {
             ImageReader reader = null;
             try (BufferedInputStream is = evidence.getBufferedStream(); ImageInputStream iis = ImageIO.createImageInputStream(is)) {
                 reader = ImageIO.getImageReaders(iis).next();

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -367,7 +367,7 @@ public class VideoThumbTask extends ThumbTask {
                 mainTmpFile = new File(mainOutFile.getParentFile(), evidence.getHash() + tempSuffix);
                 mainConfig.setOutFile(mainTmpFile);
 
-                //Check if it is an animated images
+                //Check if it is an animated image
                 int numFrames = 0;
                 boolean isAnimated = isImageSequence(evidence.getMediaType().toString());
                 if (!isAnimated) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OCRParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OCRParser.java
@@ -194,6 +194,9 @@ public class OCRParser extends AbstractParser {
         types.add(MediaType.image("aces")); //$NON-NLS-1$
         types.add(MediaType.image("emf")); //$NON-NLS-1$
         types.add(MediaType.image("heic")); //$NON-NLS-1$
+        types.add(MediaType.image("heif")); //$NON-NLS-1$
+        types.add(MediaType.image("heic-sequence")); //$NON-NLS-1$
+        types.add(MediaType.image("heif-sequence")); //$NON-NLS-1$
         types.add(MediaType.image("svg+xml")); //$NON-NLS-1$
         types.add(MediaType.image("vnd.adobe.photoshop")); //$NON-NLS-1$
         types.add(MediaType.image("vnd.wap.wbmp")); //$NON-NLS-1$


### PR DESCRIPTION
Applies the same solution used for Animated GIFs and APNGs, for HEIF/HEIC sequences (#854).

By the way, the test images that I have here were not being rendered by ImageMagick 6.
Perhaps it will work after upgrading to 7 (#855).
However, after this change, these images will be send to ImageMagick for OCR only (not for thumbnail creation or visualization).