### PR TITLE
#895 fix

### DIFF
--- a/iped-app/resources/localization/iped-utils-messages.properties
+++ b/iped-app/resources/localization/iped-utils-messages.properties
@@ -1,3 +1,4 @@
 IOUtil.ConfirmOpening=Are you sure to open or run
+IOUtil.ConfirmOpening.Unknown=unknown
 SelectImage.ImageNotFound=Evidence Not Found: 
 SelectImage.NewImgPath=Select new path for 

--- a/iped-app/resources/localization/iped-utils-messages_de_DE.properties
+++ b/iped-app/resources/localization/iped-utils-messages_de_DE.properties
@@ -1,3 +1,4 @@
 IOUtil.ConfirmOpening=Bist du dir sicher zum Öffnen oder Ausführen von
+IOUtil.ConfirmOpening.Unknown=unknown
 SelectImage.ImageNotFound=Beweismittel nicht gefunden: 
 SelectImage.NewImgPath=Wähle neuen Pfad für 

--- a/iped-app/resources/localization/iped-utils-messages_pt_BR.properties
+++ b/iped-app/resources/localization/iped-utils-messages_pt_BR.properties
@@ -1,3 +1,4 @@
 IOUtil.ConfirmOpening=Você tem certeza em abrir ou executar
+IOUtil.ConfirmOpening.Unknown=desconhecido
 SelectImage.ImageNotFound=Arquivo de evidência não encontrado: 
 SelectImage.NewImgPath=Selecione o novo caminho para 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
@@ -46,7 +46,10 @@ public class SetTypeTask extends AbstractTask {
 
     private String getExtBySig(IItem evidence) throws TikaException, IOException {
 
-        String origExt = "." + evidence.getExt(); //$NON-NLS-1$
+        String origExt = evidence.getExt();
+        if (!origExt.isEmpty()) {
+            origExt = "." + origExt;
+        }
         MediaType mediaType = evidence.getMediaType();
         String ext = Util.getTrueExtension(origExt, mediaType);
         return ext;

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
@@ -71,7 +71,7 @@ public class SetTypeTask extends AbstractTask {
             }
         }
 
-        if (ext.isEmpty() || ext.equals(".txt")) { //$NON-NLS-1$
+        if (!ext1.isEmpty() && (ext.isEmpty() || ext.equals(".txt"))) { //$NON-NLS-1$
             ext = ext1;
         }
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SetTypeTask.java
@@ -1,13 +1,14 @@
 package dpf.sp.gpinf.indexer.process.task;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.tika.config.TikaConfig;
+import org.apache.tika.exception.TikaException;
 import org.apache.tika.mime.MediaType;
-import org.apache.tika.mime.MimeTypeException;
 
 import dpf.sp.gpinf.indexer.config.ConfigurationManager;
+import dpf.sp.gpinf.indexer.parsers.util.Util;
 import gpinf.dev.filetypes.GenericFileType;
 import iped3.IItem;
 import iped3.util.ExtraProperties;
@@ -21,8 +22,6 @@ import macee.core.Configurable;
 public class SetTypeTask extends AbstractTask {
 
     public static final String EXT_MISMATCH = "extMismatch"; //$NON-NLS-1$
-
-    private TikaConfig tikaConfig;
 
     @Override
     public void process(IItem evidence) throws Exception {
@@ -45,37 +44,12 @@ public class SetTypeTask extends AbstractTask {
 
     }
 
-    public String getExtBySig(IItem evidence) {
+    private String getExtBySig(IItem evidence) throws TikaException, IOException {
 
-        String ext = ""; //$NON-NLS-1$
-        String ext1 = "." + evidence.getExt(); //$NON-NLS-1$
+        String origExt = "." + evidence.getExt(); //$NON-NLS-1$
         MediaType mediaType = evidence.getMediaType();
-        if (!mediaType.equals(MediaType.OCTET_STREAM)) {
-            try {
-                do {
-                    boolean first = true;
-                    for (String ext2 : tikaConfig.getMimeRepository().forName(mediaType.toString()).getExtensions()) {
-                        if (first) {
-                            ext = ext2;
-                            first = false;
-                        }
-                        if (ext2.equals(ext1)) {
-                            ext = ext1;
-                            break;
-                        }
-                    }
-
-                } while (ext.isEmpty() && !MediaType.OCTET_STREAM
-                        .equals((mediaType = tikaConfig.getMediaTypeRegistry().getSupertype(mediaType))));
-            } catch (MimeTypeException e) {
-            }
-        }
-
-        if (!ext1.isEmpty() && (ext.isEmpty() || ext.equals(".txt"))) { //$NON-NLS-1$
-            ext = ext1;
-        }
-
-        return ext.toLowerCase();
+        String ext = Util.getTrueExtension(origExt, mediaType);
+        return ext;
 
     }
 
@@ -86,7 +60,6 @@ public class SetTypeTask extends AbstractTask {
 
     @Override
     public void init(ConfigurationManager configurationManager) throws Exception {
-        tikaConfig = TikaConfig.getDefaultConfig();
     }
 
     @Override

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/Util.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/Util.java
@@ -1,5 +1,6 @@
 package dpf.sp.gpinf.indexer.parsers.util;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -12,9 +13,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.tika.Tika;
+import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.AutoDetectReader;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.TextContentHandler;
 import org.apache.tika.sax.ToTextContentHandler;
@@ -24,6 +30,7 @@ import org.xml.sax.SAXException;
 import dpf.sp.gpinf.indexer.parsers.IndexerDefaultParser;
 import dpf.sp.gpinf.indexer.parsers.RawStringParser;
 import dpf.sp.gpinf.indexer.util.IOUtil;
+import iped3.IItem;
 import iped3.io.IItemBase;
 import iped3.search.IItemSearcher;
 
@@ -35,6 +42,7 @@ public class Util {
     public static final String KNOWN_CONTENT_ENCODING = "KNOWN-CONTENT-ENCODING"; //$NON-NLS-1$
 
     private static IndexerDefaultParser autoParser;
+    private static TikaConfig tikaConfig;
 
     private static IndexerDefaultParser getAutoParser() {
         if (autoParser == null) {
@@ -345,6 +353,53 @@ public class Util {
             return getParentPath(path.substring(0, path.length() - 1));
         else
             return path.substring(0, i);
+    }
+
+    public static String getTrueExtension(File file) {
+        String trueExt = "";
+        String origExt = "";
+        try {
+            int idx = file.getName().lastIndexOf('.');
+            if (idx != -1) {
+                origExt = file.getName().substring(idx);
+            }
+            Metadata meta = new Metadata();
+            MediaType mediaType = MediaType.OCTET_STREAM;
+            try (TikaInputStream in = TikaInputStream.get(file.toPath(), meta)) {
+                if (tikaConfig == null) {
+                    tikaConfig = new TikaConfig();
+                }
+                mediaType = tikaConfig.getDetector().detect(in, meta);
+            }
+            if (!mediaType.equals(MediaType.OCTET_STREAM)) {
+                do {
+                    boolean first = true;
+                    for (String ext : tikaConfig.getMimeRepository().forName(mediaType.toString()).getExtensions()) {
+                        if (first) {
+                            trueExt = ext;
+                            first = false;
+                        }
+                        if (ext.equals(origExt)) {
+                            trueExt = origExt;
+                            break;
+                        }
+                    }
+
+                } while (trueExt.isEmpty() && !MediaType.OCTET_STREAM
+                        .equals((mediaType = tikaConfig.getMediaTypeRegistry().getSupertype(mediaType))));
+            }
+
+            if (trueExt.isEmpty() || trueExt.equals(".txt")) { //$NON-NLS-1$
+                trueExt = origExt;
+            }
+            if (trueExt.startsWith(".")) {
+                trueExt = trueExt.substring(1);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return trueExt.toLowerCase();
     }
 
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/Util.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/Util.java
@@ -389,7 +389,7 @@ public class Util {
                         .equals((mediaType = tikaConfig.getMediaTypeRegistry().getSupertype(mediaType))));
             }
 
-            if (trueExt.isEmpty() || trueExt.equals(".txt")) { //$NON-NLS-1$
+            if (!origExt.isEmpty() && (trueExt.isEmpty() || trueExt.equals(".txt"))) { //$NON-NLS-1$
                 trueExt = origExt;
             }
             if (trueExt.startsWith(".")) {

--- a/iped-utils/src/main/java/dpf/sp/gpinf/indexer/util/IOUtil.java
+++ b/iped-utils/src/main/java/dpf/sp/gpinf/indexer/util/IOUtil.java
@@ -70,11 +70,11 @@ public class IOUtil {
         externalOpenConfig = config;
     }
 
-    public static boolean isToOpenExternally(String fileName, String fileExt) {
+    public static boolean isToOpenExternally(String fileName, String trueExt) {
         return IOUtil.externalOpenConfig == ExternalOpenEnum.ALWAYS
-                || (IOUtil.externalOpenConfig == ExternalOpenEnum.ASK_ALWAYS && IOUtil.confirmOpenDialog(fileName))
+                || (IOUtil.externalOpenConfig == ExternalOpenEnum.ASK_ALWAYS && IOUtil.confirmOpenDialog(fileName, trueExt))
                 || (IOUtil.externalOpenConfig == ExternalOpenEnum.ASK_IF_EXE
-                        && (!IOUtil.isDangerousExtension(fileExt) || IOUtil.confirmOpenDialog(fileName)));
+                        && (!IOUtil.isDangerousExtension(trueExt) || IOUtil.confirmOpenDialog(fileName, trueExt)));
     }
 
     public static final boolean isDangerousExtension(String ext) {
@@ -90,9 +90,11 @@ public class IOUtil {
         }
     }
 
-    public static final boolean confirmOpenDialog(String fileName) {
+    public static final boolean confirmOpenDialog(String fileName, String trueExt) {
+        String fileType = !trueExt.isEmpty() ? "(." + trueExt + ")"
+                : "(" + Messages.getString("IOUtil.ConfirmOpening.Unknown") + ")";
         int option = JOptionPane.showConfirmDialog(null,
-                Messages.getString("IOUtil.ConfirmOpening") + " \"" + fileName + "\" ?", "",
+                Messages.getString("IOUtil.ConfirmOpening") + " \"" + fileName + "\" " + fileType + " ?", "",
                 JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
         if (option == JOptionPane.YES_OPTION)
             return true;

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dpf.sp.gpinf.indexer.parsers.RFC822Parser;
+import dpf.sp.gpinf.indexer.parsers.util.Util;
 import dpf.sp.gpinf.indexer.ui.fileViewer.Messages;
 import dpf.sp.gpinf.indexer.util.FileContentSource;
 import dpf.sp.gpinf.indexer.util.IOUtil;
@@ -135,7 +136,7 @@ public class EmailViewer extends HtmlViewer {
 
         public void open(int attNum) {
             AttachInfo info = mch.attachments.values().toArray(new AttachInfo[0])[attNum];
-            if (IOUtil.isToOpenExternally(info.name, IOUtil.getExtension(info.tmpFile))) {
+            if (IOUtil.isToOpenExternally(info.name, Util.getTrueExtension(info.tmpFile))) {
                 this.openFile(info.tmpFile);
             }
         }

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dpf.sp.gpinf.indexer.parsers.util.ToXMLContentHandler;
+import dpf.sp.gpinf.indexer.parsers.util.Util;
 import dpf.sp.gpinf.indexer.ui.fileViewer.Messages;
 import dpf.sp.gpinf.indexer.util.FileContentSource;
 import dpf.sp.gpinf.indexer.util.IOUtil;
@@ -592,7 +593,7 @@ public class MsgViewer extends HtmlViewer {
             Pair<File, String> pair = attachs.get(attNum);
             File file = pair.getLeft();
             String attachName = pair.getRight();
-            if (IOUtil.isToOpenExternally(attachName, IOUtil.getExtension(file))) {
+            if (IOUtil.isToOpenExternally(attachName, Util.getTrueExtension(file))) {
                 this.openFile(file);
             }
         }


### PR DESCRIPTION
Closes #895. Summary:
- A random filename is always used in HtmlViewer, regardless of the datasource type;
- HtmlViewer now asks before opening files > 10MB and checks/displays their detected extension to user;
- Eml/Msg viewers now check and display to user the detected attachment extension in file open dialog;