### PR TITLE
#908 custom security policy

### DIFF
--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/IndexFiles.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/IndexFiles.java
@@ -21,6 +21,7 @@ package dpf.sp.gpinf.indexer;
 import java.io.File;
 import java.io.PrintStream;
 import java.net.URL;
+import java.security.Policy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -40,6 +41,7 @@ import dpf.sp.gpinf.indexer.process.ProgressConsole;
 import dpf.sp.gpinf.indexer.process.ProgressFrame;
 import dpf.sp.gpinf.indexer.ui.UiScale;
 import dpf.sp.gpinf.indexer.util.CustomLoader;
+import dpf.sp.gpinf.indexer.util.DefaultPolicy;
 import dpf.sp.gpinf.indexer.util.IPEDException;
 import dpf.sp.gpinf.indexer.util.LibreOfficeFinder;
 import dpf.sp.gpinf.indexer.util.UNOLibFinder;
@@ -255,6 +257,11 @@ public class IndexFiles {
             Configuration.getInstance().loadConfigurables(iped.configPath);
 
             if (!fromCustomLoader) {
+
+                // blocks internet access from viewers
+                Policy.setPolicy(new DefaultPolicy());
+                System.setSecurityManager(new SecurityManager());
+
                 List<File> jars = new ArrayList<File>();
                 PluginConfig pluginConfig = ConfigurationManager.get().findObject(PluginConfig.class);
                 jars.addAll(Arrays.asList(pluginConfig.getPluginJars()));

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/AppMain.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/AppMain.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.Policy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,7 @@ import dpf.sp.gpinf.indexer.config.PluginConfig;
 import dpf.sp.gpinf.indexer.process.Manager;
 import dpf.sp.gpinf.indexer.ui.UiScale;
 import dpf.sp.gpinf.indexer.util.CustomLoader;
+import dpf.sp.gpinf.indexer.util.DefaultPolicy;
 import dpf.sp.gpinf.indexer.util.IOUtil;
 import dpf.sp.gpinf.indexer.util.LibreOfficeFinder;
 import dpf.sp.gpinf.indexer.util.UNOLibFinder;
@@ -177,6 +179,11 @@ public class AppMain {
             Configuration.getInstance().loadConfigurables(libDir.getParentFile().getAbsolutePath());
 
             if (!finalLoader && processingManager == null) {
+
+                // blocks internet access from viewers
+                Policy.setPolicy(new DefaultPolicy());
+                System.setSecurityManager(new SecurityManager());
+
                 List<File> jars = new ArrayList<File>();
                 PluginConfig pluginConfig = ConfigurationManager.get().findObject(PluginConfig.class);
                 jars.addAll(Arrays.asList(pluginConfig.getPluginJars()));

--- a/iped-engine/src/main/java/br/gov/pf/labld/graph/GraphFileWriter.java
+++ b/iped-engine/src/main/java/br/gov/pf/labld/graph/GraphFileWriter.java
@@ -309,7 +309,7 @@ public class GraphFileWriter implements Closeable, Flushable {
     }
 
     public void compressGeneratedCSVFiles() throws IOException {
-        Arrays.asList(root.listFiles()).parallelStream().forEach(f -> {
+        Arrays.asList(root.listFiles()).stream().forEach(f -> {
             File gzip = new File(f.getAbsolutePath() + ".gzip");
             try (GZIPOutputStream gzos = new GZIPOutputStream(
                     Files.newOutputStream(gzip.toPath(), StandardOpenOption.CREATE))) {
@@ -322,7 +322,7 @@ public class GraphFileWriter implements Closeable, Flushable {
     }
 
     public void uncompressPreviousCSVFiles() {
-        Arrays.asList(root.listFiles()).parallelStream().forEach(f -> {
+        Arrays.asList(root.listFiles()).stream().forEach(f -> {
             int idx = f.getAbsolutePath().lastIndexOf(".gzip");
             if (idx != -1) {
                 File csv = new File(f.getAbsolutePath().substring(0, idx));
@@ -340,7 +340,7 @@ public class GraphFileWriter implements Closeable, Flushable {
     public static void prepareMultiCaseCSVs(File output, List<File> csvParents) throws IOException {
         AtomicInteger subDir = new AtomicInteger(-1);
         Set<String> ids = Collections.synchronizedSet(new HashSet<>());
-        csvParents.parallelStream().forEach(parent -> {
+        csvParents.stream().forEach(parent -> {
             int num = subDir.incrementAndGet();
             try {
                 File[] subFiles = parent.listFiles();

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/MinIOTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/MinIOTask.java
@@ -21,7 +21,6 @@ import dpf.sp.gpinf.indexer.CmdLineArgs;
 import dpf.sp.gpinf.indexer.config.ConfigurationManager;
 import dpf.sp.gpinf.indexer.config.MinIOConfig;
 import dpf.sp.gpinf.indexer.util.SeekableInputStreamFactory;
-import dpf.sp.gpinf.network.util.ProxySever;
 import gpinf.dev.data.Item;
 import io.minio.BucketExistsArgs;
 import io.minio.ErrorCode;
@@ -219,9 +218,6 @@ public class MinIOTask extends AbstractTask {
         if (hash == null || hash.isEmpty() || item.getLength() == null || item.getLength() <= 0)
             return;
 
-        // disable blocking proxy possibly enabled by HtmlViewer
-        ProxySever.get().disable();
-
         try (SeekableInputStream is = item.getStream()) {
             String fullPath = insertItem(hash, new BufferedInputStream(is), is.size(), item.getMediaType().toString(), false);
             if (fullPath != null) {
@@ -319,8 +315,6 @@ public class MinIOTask extends AbstractTask {
             this.minioClient = minioClient;
             this.bucket = bucket;
             this.id = id;
-            // disable blocking proxy possibly enabled by HtmlViewer
-            ProxySever.get().disable();
         }
 
         @Override

--- a/iped-geo/src/main/java/dpf/mt/gpinf/mapas/googlemaps/MapaCanvasWebkit.java
+++ b/iped-geo/src/main/java/dpf/mt/gpinf/mapas/googlemaps/MapaCanvasWebkit.java
@@ -1,8 +1,6 @@
 package dpf.mt.gpinf.mapas.googlemaps;
 
 import java.awt.Component;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
@@ -14,7 +12,6 @@ import dpf.mt.gpinf.mapas.AbstractMapaCanvas;
 import dpf.mt.gpinf.mapas.impl.JMapOptionsPane;
 import dpf.mt.gpinf.mapas.webkit.JSInterfaceFunctions;
 import dpf.sp.gpinf.indexer.util.UiUtil;
-import dpf.sp.gpinf.network.util.ProxySever;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -28,7 +25,7 @@ import javafx.scene.web.WebEvent;
 import javafx.scene.web.WebView;
 import netscape.javascript.JSObject;
 
-public class MapaCanvasWebkit extends AbstractMapaCanvas implements MouseMotionListener {
+public class MapaCanvasWebkit extends AbstractMapaCanvas {
 
     WebView browser;
     WebEngine webEngine = null;
@@ -40,7 +37,6 @@ public class MapaCanvasWebkit extends AbstractMapaCanvas implements MouseMotionL
     @SuppressWarnings("restriction")
     public MapaCanvasWebkit() {
         this.jfxPanel = new JFXPanel();
-        this.jfxPanel.addMouseMotionListener(this);
 
         Platform.runLater(new Runnable() {
             public void run() {
@@ -108,7 +104,6 @@ public class MapaCanvasWebkit extends AbstractMapaCanvas implements MouseMotionL
 
         Platform.runLater(new Runnable() {
             public void run() {
-                ProxySever.get().disable();
                 webEngine.loadContent(html);
                 jfxPanel.invalidate();
             }
@@ -216,16 +211,6 @@ public class MapaCanvasWebkit extends AbstractMapaCanvas implements MouseMotionL
                 }
             }
         });
-    }
-
-    @Override
-    public void mouseDragged(MouseEvent e) {
-        ProxySever.get().disable();
-    }
-
-    @Override
-    public void mouseMoved(MouseEvent e) {
-        ProxySever.get().disable();
     }
 
 }

--- a/iped-geo/src/main/java/dpf/mt/gpinf/mapas/openstreet/MapaCanvasOpenStreet.java
+++ b/iped-geo/src/main/java/dpf/mt/gpinf/mapas/openstreet/MapaCanvasOpenStreet.java
@@ -1,8 +1,6 @@
 package dpf.mt.gpinf.mapas.openstreet;
 
 import java.awt.Component;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionListener;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
@@ -11,7 +9,6 @@ import org.apache.commons.io.IOUtils;
 
 import dpf.mt.gpinf.mapas.AbstractMapaCanvas;
 import dpf.sp.gpinf.indexer.util.UiUtil;
-import dpf.sp.gpinf.network.util.ProxySever;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -25,7 +22,7 @@ import javafx.scene.web.WebEvent;
 import javafx.scene.web.WebView;
 import netscape.javascript.JSObject;
 
-public class MapaCanvasOpenStreet extends AbstractMapaCanvas implements MouseMotionListener {
+public class MapaCanvasOpenStreet extends AbstractMapaCanvas {
 
     WebView browser;
     WebEngine webEngine = null;
@@ -39,7 +36,6 @@ public class MapaCanvasOpenStreet extends AbstractMapaCanvas implements MouseMot
 
     public MapaCanvasOpenStreet() {
         this.jfxPanel = new JFXPanel();
-        this.jfxPanel.addMouseMotionListener(this);
 
         Platform.runLater(new Runnable() {
             public void run() {
@@ -121,7 +117,6 @@ public class MapaCanvasOpenStreet extends AbstractMapaCanvas implements MouseMot
 
         Platform.runLater(new Runnable() {
             public void run() {
-                ProxySever.get().disable();
                 webEngine.loadContent(html);
                 jfxPanel.invalidate();
             }
@@ -255,16 +250,6 @@ public class MapaCanvasOpenStreet extends AbstractMapaCanvas implements MouseMot
                 }
             }
         });
-    }
-
-    @Override
-    public void mouseDragged(MouseEvent e) {
-        ProxySever.get().disable();
-    }
-
-    @Override
-    public void mouseMoved(MouseEvent e) {
-        ProxySever.get().disable();
     }
 
 }

--- a/iped-geo/src/main/java/dpf/mt/gpinf/mapas/webkit/AbstractWebkitMapaCanvas.java
+++ b/iped-geo/src/main/java/dpf/mt/gpinf/mapas/webkit/AbstractWebkitMapaCanvas.java
@@ -1,7 +1,7 @@
 package dpf.mt.gpinf.mapas.webkit;
 
 import dpf.mt.gpinf.mapas.AbstractMapaCanvas;
-import dpf.sp.gpinf.network.util.ProxySever;
+
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -64,7 +64,6 @@ public abstract class AbstractWebkitMapaCanvas extends AbstractMapaCanvas {
 
         Platform.runLater(new Runnable() {
             public void run() {
-                ProxySever.get().disable();
                 webEngine.loadContent(html);
                 jfxPanel.invalidate();
             }

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlLinkViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlLinkViewer.java
@@ -58,7 +58,6 @@ public class HtmlLinkViewer extends HtmlViewer implements SelectionListener {
         this.attachSearcher = attachSearcher;
         this.fileHandler = new AttachmentHandler();
         this.enableJavascript = true;
-        this.enableProxy = false;
 
         Platform.runLater(new Runnable() {
             @Override

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlViewer.java
@@ -21,7 +21,6 @@ import dpf.sp.gpinf.indexer.parsers.util.Util;
 import dpf.sp.gpinf.indexer.ui.fileViewer.Messages;
 import dpf.sp.gpinf.indexer.util.UiUtil;
 import dpf.sp.gpinf.indexer.util.IOUtil;
-import dpf.sp.gpinf.network.util.ProxySever;
 import iped3.io.IStreamSource;
 import iped3.IItem;
 import javafx.application.Platform;
@@ -56,7 +55,6 @@ public class HtmlViewer extends Viewer {
     WebView htmlViewer;
     WebEngine webEngine;
     boolean enableJavascript = false;
-    boolean enableProxy = true;
     FileHandler fileHandler = new FileHandler();
 
     protected volatile File tmpFile;
@@ -136,9 +134,6 @@ public class HtmlViewer extends Viewer {
 
                         if (tmpFile.length() <= getMaxHtmlSize()) {
                             webEngine.setJavaScriptEnabled(enableJavascript);
-                            if (enableProxy) {
-                                ProxySever.get().enable();
-                            }
                             webEngine.setUserStyleSheetLocation(UiUtil.getUIHtmlStyle());
                             webEngine.load(tmpFile.toURI().toURL().toString());
 

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/util/DefaultPolicy.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/util/DefaultPolicy.java
@@ -1,0 +1,42 @@
+package dpf.sp.gpinf.indexer.util;
+
+import java.net.SocketPermission;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLPermission;
+import java.security.Permission;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+
+import dpf.sp.gpinf.indexer.ui.fileViewer.frames.HtmlViewer;
+
+/**
+ * Custom application policy to block Internet access from html and other
+ * viewers.
+ * 
+ * @author Nassif
+ *
+ */
+public class DefaultPolicy extends Policy {
+
+    @Override
+    public boolean implies(ProtectionDomain domain, Permission perm) {
+
+        if (!(perm instanceof SocketPermission || perm instanceof URLPermission)) {
+            return true;
+        }
+
+        try {
+            URI from = domain.getCodeSource().getLocation().toURI();
+            URI viewer = HtmlViewer.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            if (from.equals(viewer)) {
+                return false;
+            }
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
Closes #908: now a custom policy is used to block Internet access from viewers while allowing access from other modules, like the map tab. This black list policy eventually could be changed to a module white list policy in the future.