### PR TITLE
#954 fix: clean attachment extension in Email viewers

### DIFF
--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
@@ -326,49 +326,7 @@ public class Util {
     }
 
     public static String getValidFilename(String filename) {
-        filename = filename.trim();
-
-        String invalidChars = "\\/:;*?\"<>|"; //$NON-NLS-1$
-        char[] chars = filename.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            if ((invalidChars.indexOf(chars[i]) >= 0) || (chars[i] < '\u0020')) {
-                filename = filename.replace(chars[i] + "", ""); //$NON-NLS-1$ //$NON-NLS-2$
-            }
-        }
-
-        String[] invalidNames = { "CON", "PRN", "AUX", "NUL", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-                "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
-                "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
-
-        for (String name : invalidNames) {
-            if (filename.equalsIgnoreCase(name) || filename.toUpperCase().startsWith(name + ".")) { //$NON-NLS-1$
-                filename = "1" + filename; //$NON-NLS-1$
-            }
-        }
-
-        // Limite máximo do Joliet
-        int MAX_LENGTH = 64;
-
-        if (filename.length() > MAX_LENGTH) {
-            int extIndex = filename.lastIndexOf('.');
-            if (extIndex == -1) {
-                filename = filename.substring(0, MAX_LENGTH);
-            } else {
-                String ext = filename.substring(extIndex);
-                int MAX_EXT_LEN = 20;
-                if (ext.length() > MAX_EXT_LEN) {
-                    ext = filename.substring(extIndex, extIndex + MAX_EXT_LEN);
-                }
-                filename = filename.substring(0, MAX_LENGTH - ext.length()) + ext;
-            }
-        }
-
-        char c;
-        while (filename.length() > 0 && ((c = filename.charAt(filename.length() - 1)) == ' ' || c == '.')) {
-            filename = filename.substring(0, filename.length() - 1);
-        }
-
-        return filename;
+        return IOUtil.getValidFilename(filename);
     }
 
     public static void changeEncoding(File file) throws IOException {

--- a/iped-utils/src/main/java/dpf/sp/gpinf/indexer/util/IOUtil.java
+++ b/iped-utils/src/main/java/dpf/sp/gpinf/indexer/util/IOUtil.java
@@ -102,6 +102,52 @@ public class IOUtil {
             return false;
     }
 
+    public static String getValidFilename(String filename) {
+        filename = filename.trim();
+
+        String invalidChars = "\\/:;*?\"<>|"; //$NON-NLS-1$
+        char[] chars = filename.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            if ((invalidChars.indexOf(chars[i]) >= 0) || (chars[i] < '\u0020')) {
+                filename = filename.replace(chars[i] + "", ""); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+        }
+
+        String[] invalidNames = { "CON", "PRN", "AUX", "NUL", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+                "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
+                "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
+
+        for (String name : invalidNames) {
+            if (filename.equalsIgnoreCase(name) || filename.toUpperCase().startsWith(name + ".")) { //$NON-NLS-1$
+                filename = "1" + filename; //$NON-NLS-1$
+            }
+        }
+
+        // Limite máximo do Joliet
+        int MAX_LENGTH = 64;
+
+        if (filename.length() > MAX_LENGTH) {
+            int extIndex = filename.lastIndexOf('.');
+            if (extIndex == -1) {
+                filename = filename.substring(0, MAX_LENGTH);
+            } else {
+                String ext = filename.substring(extIndex);
+                int MAX_EXT_LEN = 20;
+                if (ext.length() > MAX_EXT_LEN) {
+                    ext = filename.substring(extIndex, extIndex + MAX_EXT_LEN);
+                }
+                filename = filename.substring(0, MAX_LENGTH - ext.length()) + ext;
+            }
+        }
+
+        char c;
+        while (filename.length() > 0 && ((c = filename.charAt(filename.length() - 1)) == ' ' || c == '.')) {
+            filename = filename.substring(0, filename.length() - 1);
+        }
+
+        return filename;
+    }
+
     public static final boolean isDiskFull(IOException e) {
         if (e == null)
             return false;

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
@@ -333,6 +333,7 @@ public class EmailViewer extends HtmlViewer {
             String fileExt = ""; //$NON-NLS-1$
             if (attachName != null && attachName.lastIndexOf(".") > -1) { //$NON-NLS-1$
                 fileExt = attachName.substring(attachName.lastIndexOf(".")); //$NON-NLS-1$
+                fileExt = IOUtil.getValidFilename(fileExt);
             }
 
             attach = File.createTempFile("attach", fileExt); //$NON-NLS-1$

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
@@ -373,9 +373,10 @@ public class MsgViewer extends HtmlViewer {
                 ByteChunk byteChunk = att.getAttachData();
                 if (byteChunk != null) {
                     String fileExt = "";
-                    if (attachName != null && attachName.lastIndexOf(".") > -1)
+                    if (attachName != null && attachName.lastIndexOf(".") > -1) {
                         fileExt = attachName.substring(attachName.lastIndexOf("."));
-
+                        fileExt = IOUtil.getValidFilename(fileExt);
+                    }
                     File file = File.createTempFile("attach", fileExt);
                     FileUtils.writeByteArrayToFile(file, byteChunk.getValue());
                     file.deleteOnExit();


### PR DESCRIPTION
Closes #954: filter out invalid NTFS chars from attachment extension in EML/MSGViewers before extracting attachments to temp folder.