### PR TITLE
#362 better check empty queues and idle workers

### DIFF
--- a/iped-api/src/main/java/iped3/ICaseData.java
+++ b/iped-api/src/main/java/iped3/ICaseData.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
-import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * (INTERFACE DO IPED) Classe que define todos os dados do caso.
@@ -85,13 +84,6 @@ public interface ICaseData extends Serializable {
      * @return retorna o volume de dados descobertos até o momento
      */
     long getDiscoveredVolume();
-
-    /**
-     * Obtém fila de arquivos de evidência do caso.
-     *
-     * @return fila de arquivos.
-     */
-    LinkedBlockingDeque<IItem> getItemQueue();
 
     /**
      * Obtém o objeto raiz da árvore de arquivos do caso.

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Worker.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Worker.java
@@ -237,13 +237,12 @@ public class Worker extends Thread {
                             this.wait();
                         }
                     } else {
-                        LOGGER.debug(this.getName() + " Queue size = " + caseData.getItemQueue().size()
-                                + " itemsInThisWorker = " + itensBeingProcessed + " itemsInAllWorkers = "
-                                + manager.numItensBeingProcessed());
-
                         caseData.getItemQueue().addLast(queueEnd);
                         long timeSinceLastItemProcessed = System.currentTimeMillis() - lastItemProcessingTime;
                         if (itensBeingProcessed > 0 && timeSinceLastItemProcessed >= MIN_WAIT_TIME_TO_SEND_QUEUE_END) {
+                            LOGGER.debug(this.getName() + " Queue size = " + caseData.getItemQueue().size()
+                                    + " itemsInThisWorker = " + itensBeingProcessed + " itemsInAllWorkers = "
+                                    + manager.numItensBeingProcessed());
                             process(queueEnd);
                         } else {
                             // no items accumulated in this worker, wait some time to increase

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Worker.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/Worker.java
@@ -32,7 +32,7 @@ import dpf.sp.gpinf.indexer.localization.Messages;
 import dpf.sp.gpinf.indexer.process.task.AbstractTask;
 import dpf.sp.gpinf.indexer.process.task.TaskInstaller;
 import dpf.sp.gpinf.indexer.util.IPEDException;
-import iped3.ICaseData;
+import gpinf.dev.data.CaseData;
 import iped3.IItem;
 
 /**
@@ -52,7 +52,7 @@ public class Worker extends Thread {
 
     private static String workerNamePrefix = "Worker-"; //$NON-NLS-1$
 
-    private static final int MIN_WAIT_TIME_TO_SEND_QUEUE_END = 3000;
+    private static final int MIN_WAIT_TIME_TO_SEND_QUEUE_END = 1000;
     private static volatile long lastItemProcessingTime = 0;
 
     public IndexWriter writer;
@@ -60,8 +60,8 @@ public class Worker extends Thread {
 
     public volatile AbstractTask runningTask;
     public List<AbstractTask> tasks = new ArrayList<AbstractTask>();
-    public AbstractTask firstTask;
-    public volatile int itensBeingProcessed = 0;
+    private AbstractTask firstTask;
+    private int itemsBeingProcessed = 0;
 
     public enum STATE {
         RUNNING, PAUSING, PAUSED
@@ -72,12 +72,14 @@ public class Worker extends Thread {
     public Manager manager;
     public Statistics stats;
     public File output;
-    public ICaseData caseData;
+    public CaseData caseData;
     public volatile Exception exception;
     public volatile IItem evidence;
     public final int id;
 
-    public Worker(int k, ICaseData caseData, IndexWriter writer, File output, Manager manager) throws Exception {
+    private boolean waiting = false;
+
+    public Worker(int k, CaseData caseData, IndexWriter writer, File output, Manager manager) throws Exception {
         super(new ThreadGroup(workerNamePrefix + k), workerNamePrefix + k); // $NON-NLS-1$
         id = k;
         this.caseData = caseData;
@@ -124,13 +126,17 @@ public class Worker extends Thread {
     }
 
     public void finish() throws Exception {
-        this.interrupt();
         synchronized (this) {
+            this.interrupt();
             this.wait();
         }
         if (exception != null) {
             throw exception;
         }
+    }
+
+    public synchronized boolean isWaiting() {
+        return this.waiting;
     }
 
     public void processNextQueue() {
@@ -146,22 +152,18 @@ public class Worker extends Thread {
      * @param evidence
      *            Item a ser processado
      */
-    public void process(IItem evidence) {
+    private void process(IItem evidence) {
 
         IItem prevEvidence = this.evidence;
         if (!evidence.isQueueEnd()) {
             this.evidence = evidence;
+            this.itemsBeingProcessed++;
         }
 
         try {
 
             LOGGER.debug("{} Processing {} ({} bytes)", getName(), evidence.getPath(), evidence.getLength()); //$NON-NLS-1$
 
-            // Loop principal que executa cada tarefa de processamento
-            /*
-             * for(AbstractTask task : tasks) if(!evidence.isToIgnore()){
-             * processTask(evidence, task); }
-             */
             firstTask.processAndSendToNextTask(evidence);
 
         } catch (Throwable t) {
@@ -176,6 +178,10 @@ public class Worker extends Thread {
                 }
             }
 
+        }
+
+        if (!evidence.isQueueEnd()) {
+            this.itemsBeingProcessed--;
         }
 
         this.evidence = prevEvidence;
@@ -200,13 +206,22 @@ public class Worker extends Thread {
         caseData.incDiscoveredEvidences(1);
         // Se a fila está pequena, enfileira
         if (time == ProcessTime.LATER
-                || (time == ProcessTime.AUTO && caseData.getItemQueue().size() < 10 * manager.getWorkers().length)) {
+                || (time == ProcessTime.AUTO && caseData.getCurrentQueueSize() < 10 * manager.getWorkers().length)) {
             caseData.addItemFirstNonBlocking(evidence);
         } // caso contrário processa o item no worker atual
         else {
+            if (!evidence.isQueueEnd()) {
+                caseData.incItemsBeingProcessed();
+            }
             long t = System.nanoTime() / 1000;
+
             process(evidence);
+
             runningTask.addSubitemProcessingTime(System.nanoTime() / 1000 - t);
+
+            if (!evidence.isQueueEnd()) {
+                caseData.decItemsBeingProcessed();
+            }
         }
 
     }
@@ -220,34 +235,58 @@ public class Worker extends Thread {
 
             try {
                 evidence = null;
-                evidence = caseData.getItemQueue().takeFirst();
+                boolean sleep = false;
+                while (evidence == null) {
+                    if (sleep) {
+                        // this should be very rare
+                        sleep = false;
+                        Thread.sleep(100);
+                    }
+                    synchronized (caseData) {
+                        evidence = caseData.pollFirstFromCurrentQueue();
+                        if (evidence == null) {
+                            sleep = true;
+                            continue;
+                        }
+                        if (!evidence.isQueueEnd()) {
+                            caseData.incItemsBeingProcessed();
+                        }
+                    }
+                }
+
 
                 if (!evidence.isQueueEnd()) {
                     lastItemProcessingTime = System.currentTimeMillis();
+
                     process(evidence);
+                    
+                    if (!evidence.isQueueEnd()) {
+                        caseData.decItemsBeingProcessed();
+                    }
 
                 } else {
                     IItem queueEnd = evidence;
-                    if (manager.numItensBeingProcessed() == 0 && caseData.getItemQueue().size() == 0) {
-                        caseData.getItemQueue().addLast(queueEnd);
-                        process(queueEnd);
+                    if (caseData.isNoItemInQueueOrBeingProcessed()) {
+                        caseData.addLastToCurrentQueue(queueEnd);
                         evidence = null;
+
+                        LOGGER.debug(this.getName() + " going to wait queue change.");
                         synchronized(this) {
-                            LOGGER.debug(this.getName() + " going to wait notify!");
-                            this.wait();
+                            try {
+                                waiting = true;
+                                this.wait();
+                            } finally {
+                                waiting = false;
+                            }
                         }
                     } else {
-                        caseData.getItemQueue().addLast(queueEnd);
+                        caseData.addLastToCurrentQueue(queueEnd);
                         long timeSinceLastItemProcessed = System.currentTimeMillis() - lastItemProcessingTime;
-                        if (itensBeingProcessed > 0 && timeSinceLastItemProcessed >= MIN_WAIT_TIME_TO_SEND_QUEUE_END) {
-                            LOGGER.debug(this.getName() + " Queue size = " + caseData.getItemQueue().size()
-                                    + " itemsInThisWorker = " + itensBeingProcessed + " itemsInAllWorkers = "
-                                    + manager.numItensBeingProcessed());
+                        if (itemsBeingProcessed > 0 && timeSinceLastItemProcessed >= MIN_WAIT_TIME_TO_SEND_QUEUE_END) {
+                            LOGGER.debug(this.getName() + " Queue size = " + caseData.getCurrentQueueSize()
+                                    + " itemsInThisWorker = " + itemsBeingProcessed + " itemsInAllWorkers = "
+                                    + caseData.getItemsBeingProcessed());
                             process(queueEnd);
-                        } else {
-                            // no items accumulated in this worker, wait some time to increase
-                            // the chance of other worker taking the queue-end
-                            // Thread.sleep(1000);
                         }
                     }
                 }

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/AbstractTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/AbstractTask.java
@@ -15,7 +15,7 @@ import dpf.sp.gpinf.indexer.process.MimeTypesProcessingOrder;
 import dpf.sp.gpinf.indexer.process.Statistics;
 import dpf.sp.gpinf.indexer.process.Worker;
 import dpf.sp.gpinf.indexer.process.Worker.STATE;
-import iped3.ICaseData;
+import gpinf.dev.data.CaseData;
 import iped3.IItem;
 import macee.core.Configurable;
 
@@ -56,7 +56,7 @@ public abstract class AbstractTask {
      * Representa o caso atual. As diferentes instâncias das tarefas podem armazenar
      * objetos compartilhados no mapa objectMap do caso.
      */
-    protected ICaseData caseData;
+    protected CaseData caseData;
 
     /**
      * Próxima tarefa que será executada no pipeline.
@@ -170,10 +170,6 @@ public abstract class AbstractTask {
             Thread.sleep(1000);
         }
 
-        if (this == worker.firstTask && !evidence.isQueueEnd()) {
-            worker.itensBeingProcessed++;
-        }
-
         AbstractTask prevTask = worker.runningTask;
         IItem prevEvidence = worker.evidence;
         worker.runningTask = this;
@@ -209,9 +205,6 @@ public abstract class AbstractTask {
                 stats.addVolume(len);
             }
         }
-        
-        if (nextTask == null && !evidence.isQueueEnd())
-            worker.itensBeingProcessed--;
     }
 
     /**
@@ -231,9 +224,6 @@ public abstract class AbstractTask {
                 evidence.dispose();
                 SkipCommitedTask.checkAgainLaterProcessedParents(evidence);
                 caseData.addItemToQueue(evidence, priority);
-                if (!evidence.isQueueEnd()) {
-                    worker.itensBeingProcessed--;
-                }
             }
         }
     }

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/PythonTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/PythonTask.java
@@ -16,7 +16,7 @@ import dpf.sp.gpinf.indexer.config.LocalConfig;
 import dpf.sp.gpinf.indexer.search.IPEDSearcher;
 import dpf.sp.gpinf.indexer.search.IPEDSource;
 import dpf.sp.gpinf.indexer.util.ImageUtil;
-import iped3.ICaseData;
+import gpinf.dev.data.CaseData;
 import iped3.IItem;
 import jep.Jep;
 import jep.JepException;
@@ -46,7 +46,7 @@ public class PythonTask extends AbstractTask {
         this.scriptFile = scriptFile;
     }
 
-    public void setCaseData(ICaseData caseData) {
+    public void setCaseData(CaseData caseData) {
         super.caseData = caseData;
     }
 


### PR DESCRIPTION
This closes #362 fixing some race conditions:
- when checking if processing queue is empty AND if there is no item being processed by workers;
- when checking if workers are idle to change processing queue;

A monitor lock was used and the old LinkedBlockingDeque for queues was replaced by a simple LinkedList.