### PR TITLE
closes #1035: decode base64 strings, new metadata to flag base64 byte[]

### DIFF
--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/UfedXmlReader.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
@@ -19,6 +20,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -735,6 +737,21 @@ public class UfedXmlReader extends DataSourceReader {
                                 throw new SAXException(e);
                             }
                         else if (item != null && !value.isEmpty()) {
+                            if ("Base64String".equalsIgnoreCase(currentNode.atts.get("format"))) {
+                                String decoded = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+                                boolean isString = true;
+                                for (char c : decoded.toCharArray()) {
+                                    if (!(Character.isLetter(c) || c == 0x0A || c == 0x0D || c == 0x09 || c == 0x0B
+                                            || (c >= 0x20 && c <= 0x7E) || (c >= 0xA0 && c <= 0xFF))) {
+                                        isString = false;
+                                    }
+                                }
+                                if (isString) {
+                                    value = decoded;
+                                } else {
+                                    item.getMetadata().add(meta + ":format", "base64");
+                                }
+                            }
                             item.getMetadata().add(meta, value);
                             if (inChat && ignoreSupportedChats && parentNameAttr.equals("Source")
                                     && supportedApps.contains(value)) {


### PR DESCRIPTION
Closes #1035.

Sometimes base64 values are binary byte[], not printable strings, so I added check for some printable character ranges. If some decoded char is outside the allowed range, the value is kept base64 encoded and an _originalMetaKey_:format = base64 metadata is added to the item.

Let me know if we should add more allowed char ranges to the validation check.