### PR TITLE
#1067: Embed python+jep

### DIFF
--- a/iped-api/src/main/java/iped3/configuration/IConfigurationDirectory.java
+++ b/iped-api/src/main/java/iped3/configuration/IConfigurationDirectory.java
@@ -11,6 +11,8 @@ public interface IConfigurationDirectory {
 
     public static final String IPED_ROOT = "iped.root";
 
+    public static final String IPED_APP_ROOT = "iped.app.root";
+
     public List<Path> getResourceLookupFolders();
 
     public List<Path> lookUpResource(Predicate<Path> predicate) throws IOException;

--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -90,8 +90,8 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.python</groupId>
-                                    <artifactId>python-jep</artifactId>
-                                    <version>3.9.12-4.0.3</version>
+                                    <artifactId>python-jep-dlib</artifactId>
+                                    <version>3.9.12-4.0.3-19.23.1</version>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${release.dir}</outputDirectory>

--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -81,6 +81,25 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-python</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.python</groupId>
+                                    <artifactId>python-jep</artifactId>
+                                    <version>3.9.12-4.0.3</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${release.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-esedbexport</id>
                         <phase>package</phase>
                         <goals>

--- a/iped-app/resources/config/conf/scripts/FaceRecognitionProcess.py
+++ b/iped-app/resources/config/conf/scripts/FaceRecognitionProcess.py
@@ -4,6 +4,7 @@
 
 import face_recognition as fr
 import PIL
+from PIL import Image
 import numpy as np
 import sys
 import traceback
@@ -90,7 +91,7 @@ def main():
                         new_size = (int(size[0] * scale), max_size)
                         
                     img0 = img
-                    img = img.resize(new_size, resample=PIL.Image.BILINEAR)
+                    img = img.resize(new_size, resample=Image.Resampling.BILINEAR)
                     upsample = 0
             
         except Exception:

--- a/iped-app/resources/config/conf/scripts/FaceRecognitionTask.py
+++ b/iped-app/resources/config/conf/scripts/FaceRecognitionTask.py
@@ -9,9 +9,7 @@
 import os
 import time
 import subprocess
-import numpy as np
 import threading, queue
-import FaceRecognitionProcess as fp
 import traceback
 import platform
 
@@ -31,10 +29,10 @@ maxProcesses = None
 numCreatedProcs = 0
 numCreatedProcsLock = threading.Lock()
 
+from java.lang import System
+ipedRoot = System.getProperty('iped.root')
+
 bin = 'python'
-terminate = fp.terminate
-imgError = fp.imgError
-ping = fp.ping
 
 detection_model = 'hog'
 max_size = 1024
@@ -67,8 +65,7 @@ def createExternalProcess():
     proc = None
     for i in range(3):
         if proc is None or proc.poll() is not None:
-            from java.lang import System
-            proc = subprocess.Popen([bin, os.path.join(System.getProperty('iped.root'), 'conf', 'scripts', processScript), str(max_size), detection_model, str(up_sampling)], 
+            proc = subprocess.Popen([bin, os.path.join(ipedRoot, 'conf', 'scripts', processScript), str(max_size), detection_model, str(up_sampling)], 
                                     stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         
         if pingExternalProcess(proc):
@@ -111,6 +108,12 @@ class FaceRecognitionTask:
         if not self.enabled:
             return
         
+        global fp, terminate, imgError, ping
+        import FaceRecognitionProcess as fp
+        terminate = fp.terminate
+        imgError = fp.imgError
+        ping = fp.ping
+        
         # check if was called from gui the first time
         global maxProcesses, firstInstance
         # load configuration properties
@@ -118,11 +121,12 @@ class FaceRecognitionTask:
         numProcs = extraProps.getProperty(numFaceRecognitionProcessesProp)
         if firstInstance and numProcs is not None:
             maxProcesses = int(numProcs)
-            # hides the terminal on windows gui
-            if platform.system().lower() == 'windows':
-                global bin
-                bin = 'pythonw'
         firstInstance = False
+        
+        # configure embedded python path on windows
+        if platform.system().lower() == 'windows':
+            global bin
+            bin = os.path.join(ipedRoot, 'python', 'pythonw')
         
         numProcs = extraProps.getProperty(numFaceRecognitionProcessesProp)
         if maxProcesses is None and numProcs is not None:
@@ -269,6 +273,7 @@ class FaceRecognitionTask:
                 for j in range(128):
                     line = proc.stdout.readline()
                     list.append(float(line))
+                import numpy as np
                 np_array = np.array(list)
                 face_encodings.append(np_array)
             

--- a/iped-app/resources/config/conf/scripts/FaceRecognitionTask.py
+++ b/iped-app/resources/config/conf/scripts/FaceRecognitionTask.py
@@ -114,6 +114,9 @@ class FaceRecognitionTask:
         imgError = fp.imgError
         ping = fp.ping
         
+        global np
+        import numpy as np
+        
         # check if was called from gui the first time
         global maxProcesses, firstInstance
         # load configuration properties
@@ -273,7 +276,6 @@ class FaceRecognitionTask:
                 for j in range(128):
                     line = proc.stdout.readline()
                     list.append(float(line))
-                import numpy as np
                 np_array = np.array(list)
                 face_encodings.append(np_array)
             

--- a/iped-app/resources/config/conf/scripts/NSFWNudityDetectTask.py
+++ b/iped-app/resources/config/conf/scripts/NSFWNudityDetectTask.py
@@ -14,8 +14,6 @@ batchSize = 50
 maxThreads = None
 
 import traceback
-from PIL import Image as PilImage
-import numpy as np
 import io
 import time
 import sys
@@ -36,6 +34,8 @@ def loadModel():
         file = System.getProperty('iped.root') + '/models/nsfw-keras-1.0.0.h5'
         from keras.models import load_model
         model = load_model(file)
+        global np
+        import numpy as np
         x = np.zeros((1, 224, 224, 3))
         #compile predict function to be used by multiple threads
         model.predict(x)
@@ -77,6 +77,7 @@ def convertJavaByteArray(byteArray):
 def loadRawImage(input):
     global loadImgTime 
     t = time.time()
+    from PIL import Image as PilImage
     img = PilImage.open(io.BytesIO(input))
     img = img.convert('RGB')
     img = img.resize(targetSize, PilImage.NEAREST)

--- a/iped-app/resources/config/conf/scripts/NSFWNudityDetectTask.py
+++ b/iped-app/resources/config/conf/scripts/NSFWNudityDetectTask.py
@@ -34,8 +34,6 @@ def loadModel():
         file = System.getProperty('iped.root') + '/models/nsfw-keras-1.0.0.h5'
         from keras.models import load_model
         model = load_model(file)
-        global np
-        import numpy as np
         x = np.zeros((1, 224, 224, 3))
         #compile predict function to be used by multiple threads
         model.predict(x)
@@ -77,7 +75,6 @@ def convertJavaByteArray(byteArray):
 def loadRawImage(input):
     global loadImgTime 
     t = time.time()
-    from PIL import Image as PilImage
     img = PilImage.open(io.BytesIO(input))
     img = img.convert('RGB')
     img = img.resize(targetSize, PilImage.NEAREST)
@@ -106,10 +103,13 @@ class NSFWNudityDetectTask:
     def init(self, configuration):
         global enabled
         enabled = configuration.getEnableTaskProperty(enableProp)
-        if enabled:
-            loadModel()
+        if not enabled:
+            return
+        global PilImage, np
+        from PIL import Image as PilImage
+        import numpy as np
+        loadModel()
         createSemaphore()
-        return
     
     def finish(self):
         num_finishes = caseData.getCaseObject('num_finishes')

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/Main.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/Main.java
@@ -57,7 +57,7 @@ public class Main {
     File keywords;
     List<File> dataSource;
     File output;
-
+    boolean isReportingFromCaseDir = false;
     File logFile;
     LogConfiguration logConfiguration;
 
@@ -133,6 +133,7 @@ public class Main {
             rootPath = new File(url.toURI()).getParent();
             // test for report generation from case folder
             if (rootPath.endsWith("iped" + File.separator + "lib")) { //$NON-NLS-1$ //$NON-NLS-2$
+                isReportingFromCaseDir = true;
                 rootPath = new File(url.toURI()).getParentFile().getParent();
             }
         }
@@ -254,6 +255,12 @@ public class Main {
             Configuration.getInstance().loadConfigurables(iped.configPath);
 
             if (!fromCustomLoader) {
+
+                if (iped.isReportingFromCaseDir) {
+                    Configuration.getInstance().loadIpedRoot();
+                } else {
+                    Configuration.getInstance().saveIpedRoot(iped.rootPath);
+                }
 
                 // blocks internet access from viewers
                 Policy.setPolicy(new DefaultPolicy());

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/AppMain.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/AppMain.java
@@ -180,6 +180,8 @@ public class AppMain {
 
             if (!finalLoader && processingManager == null) {
 
+                Configuration.getInstance().loadIpedRoot();
+
                 // blocks internet access from viewers
                 Policy.setPolicy(new DefaultPolicy());
                 System.setSecurityManager(new SecurityManager());

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
@@ -29,6 +29,7 @@ import javax.swing.JProgressBar;
 import javax.swing.RowSorter;
 import javax.swing.RowSorter.SortKey;
 import javax.swing.SortOrder;
+import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileFilter;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -122,13 +123,17 @@ public class SimilarFacesFilterActions {
                     e1.printStackTrace();
                 }
 
-                WaitDialog wait = new WaitDialog(app, Messages.getString("FaceSimilarity.LoadingFace"));
+                final WaitDialog wait = new WaitDialog(app, Messages.getString("FaceSimilarity.LoadingFace"));
 
                 FaceFeatureExtractor callable = new FaceFeatureExtractor(app.similarFacesRefItem,
                         app.appCase.getModuleDir()) {
                     @Override
                     protected void onFinish() {
-                        wait.setVisible(false);
+                        SwingUtilities.invokeLater(new Runnable() {
+                            public void run() {
+                                wait.setVisible(false);
+                            }
+                        });
                     }
                 };
                 Future<byte[]> future = executor.submit(callable);

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
@@ -231,9 +231,9 @@ public class SimilarFacesFilterActions {
         public byte[] call() throws Exception {
 
             try {
-                if (task == null) {
+                if (FaceFeatureExtractor.task == null) {
                     File script = new File(moduleDir, SCRIPT_PATH);
-                    task = new PythonTask(script);
+                    PythonTask task = new PythonTask(script);
                     task.setCaseData(new CaseData(0));
                     AbstractTaskPropertiesConfig taskConfig = (AbstractTaskPropertiesConfig) ConfigurationManager.get()
                             .getTaskConfigurable(CONF_FILE);
@@ -242,12 +242,14 @@ public class SimilarFacesFilterActions {
                     if (taskConfig != null) {
                         taskConfig.getConfiguration().setProperty(NUM_PROCESSES, "1");
                     }
+                    task.setThrowExceptionInsteadOfLogging(true);
                     task.init(ConfigurationManager.get());
                     Runtime.getRuntime().addShutdownHook(new Thread() {
                         public void run() {
                             dispose();
                         }
                     });
+                    FaceFeatureExtractor.task = task;
                 }
 
                 // populate info used by task
@@ -255,7 +257,7 @@ public class SimilarFacesFilterActions {
                 item.setExtraAttribute(ImageThumbTask.HAS_THUMB, true);
                 item.setHash(DigestUtils.md5Hex(Files.readAllBytes(item.getTempFile().toPath())));
 
-                task.process(item);
+                FaceFeatureExtractor.task.process(item);
                 // TODO enable when queue end is handled
                 // Item queueEnd = new Item();
                 // queueEnd.setQueueEnd(true);

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/SimilarFacesFilterActions.java
@@ -237,7 +237,11 @@ public class SimilarFacesFilterActions {
                     task.setCaseData(new CaseData(0));
                     AbstractTaskPropertiesConfig taskConfig = (AbstractTaskPropertiesConfig) ConfigurationManager.get()
                             .getTaskConfigurable(CONF_FILE);
-                    taskConfig.getConfiguration().setProperty(NUM_PROCESSES, "1");
+
+                    // if jep is not found, no config is returned for python tasks
+                    if (taskConfig != null) {
+                        taskConfig.getConfiguration().setProperty(NUM_PROCESSES, "1");
+                    }
                     task.init(ConfigurationManager.get());
                     Runtime.getRuntime().addShutdownHook(new Thread() {
                         public void run() {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/Configuration.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/Configuration.java
@@ -20,6 +20,8 @@ package dpf.sp.gpinf.indexer.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -45,6 +47,8 @@ public class Configuration {
     public static final String CONF_DIR = "conf"; //$NON-NLS-1$
     public static final String PROFILES_DIR = "profiles"; //$NON-NLS-1$
     public static final String CASE_PROFILE_DIR = "profile"; //$NON-NLS-1$
+
+    private static final File ipedRoot = new File(System.getProperty("user.home"), ".iped/ipedRoot.txt");
 
     private static Configuration singleton;
     private static AtomicBoolean loaded = new AtomicBoolean();
@@ -99,13 +103,26 @@ public class Configuration {
 
         configureLogger(configPath);
 
-        System.setProperty(IConfigurationDirectory.IPED_ROOT, appRoot);
+        System.setProperty(IConfigurationDirectory.IPED_APP_ROOT, appRoot);
         System.setProperty(IConfigurationDirectory.IPED_CONF_PATH, configPath);
 
         properties.load(new File(appRoot, LOCAL_CONFIG));
         File mainConfig = new File(configPath, CONFIG_FILE);
         if (mainConfig.exists()) {
             properties.load(mainConfig);
+        }
+    }
+
+    public void saveIpedRoot(String path) throws IOException {
+        System.setProperty(IConfigurationDirectory.IPED_ROOT, path);
+        Files.write(ipedRoot.toPath(), path.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public void loadIpedRoot() throws IOException {
+        if (ipedRoot.exists()) {
+            byte[] bytes = Files.readAllBytes(ipedRoot.toPath());
+            String path = new String(bytes, StandardCharsets.UTF_8);
+            System.setProperty(IConfigurationDirectory.IPED_ROOT, path);
         }
     }
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/Configuration.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/Configuration.java
@@ -115,6 +115,7 @@ public class Configuration {
 
     public void saveIpedRoot(String path) throws IOException {
         System.setProperty(IConfigurationDirectory.IPED_ROOT, path);
+        ipedRoot.getParentFile().mkdirs();
         Files.write(ipedRoot.toPath(), path.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/PluginConfig.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/PluginConfig.java
@@ -45,7 +45,7 @@ public class PluginConfig extends AbstractPropertiesConfigurable {
     }
 
     public File getPluginFolder() {
-        String appRoot = System.getProperty(IConfigurationDirectory.IPED_ROOT);
+        String appRoot = System.getProperty(IConfigurationDirectory.IPED_APP_ROOT);
         try {
             return new File(appRoot, relativePluginFolder).getCanonicalFile();
         } catch (IOException e) {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/PythonTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/PythonTask.java
@@ -25,6 +25,7 @@ import jep.NDArray;
 
 public class PythonTask extends AbstractTask {
 
+    private static final String JEP_NOT_FOUND = PythonParser.JEP_NOT_FOUND;
     private static final String DISABLED = PythonParser.DISABLED;
     private static final String SEE_MANUAL = PythonParser.SEE_MANUAL;
 
@@ -41,9 +42,14 @@ public class PythonTask extends AbstractTask {
     private boolean isEnabled = true;
     private boolean scriptLoaded = false;
     private boolean sendToNextTaskExists = true;
+    private boolean throwExceptionInsteadOfLogging = false;
 
     public PythonTask(File scriptFile) {
         this.scriptFile = scriptFile;
+    }
+
+    public void setThrowExceptionInsteadOfLogging(boolean value) {
+        this.throwExceptionInsteadOfLogging = value;
     }
 
     public void setCaseData(CaseData caseData) {
@@ -209,12 +215,18 @@ public class PythonTask extends AbstractTask {
             Jep jep = PythonParser.getJep();
             if (jep == null) {
                 isEnabled = false;
+                if (throwExceptionInsteadOfLogging) {
+                    throw new Exception(JEP_NOT_FOUND + SEE_MANUAL);
+                }
             } else {
                 loadScript(jep, true);
             }
         } catch (JepException e) {
+            String msg = e.getMessage() + ". " + scriptFile.getName() + DISABLED + SEE_MANUAL;
+            if (throwExceptionInsteadOfLogging) {
+                throw new Exception(msg);
+            }
             if (jepExceptionPerScript.get(scriptFile) == null) {
-                String msg = e.getMessage() + ". " + scriptFile.getName() + DISABLED + SEE_MANUAL;
                 LOGGER.error(msg);
                 e.printStackTrace();
                 jepExceptionPerScript.put(scriptFile, e);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
@@ -24,10 +24,13 @@ import org.xml.sax.SAXException;
 
 import dpf.sp.gpinf.indexer.parsers.IndexerDefaultParser;
 import dpf.sp.gpinf.indexer.parsers.util.Messages;
+import iped3.configuration.IConfigurationDirectory;
 import jep.JEPClassFinder;
 import jep.Jep;
 import jep.JepConfig;
 import jep.JepException;
+import jep.MainInterpreter;
+import jep.PyConfig;
 import jep.SharedInterpreter;
 
 public class PythonParser extends AbstractParser {
@@ -62,6 +65,13 @@ public class PythonParser extends AbstractParser {
             config.redirectStdErr(System.err);
             config.redirectStdout(System.out);
             SharedInterpreter.setConfig(config);
+
+            if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+                PyConfig pyConfig = new PyConfig();
+                pyConfig.setPythonHome(System.getProperty(IConfigurationDirectory.IPED_ROOT) + "/python");
+                MainInterpreter.setInitParams(pyConfig);
+            }
+
         } catch (JepException e1) {
             throw new RuntimeException(e1);
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
@@ -167,11 +167,14 @@ public class PythonParser extends AbstractParser {
         try {
             jep = new SharedInterpreter();
 
-        } catch (UnsatisfiedLinkError e) {
+        } catch (Throwable e) {
             if (!jepNotFoundPrinted.getAndSet(true)) {
                 String msg = JEP_NOT_FOUND + SEE_MANUAL;
                 LOGGER.error(msg);
                 e.printStackTrace();
+            }
+            if (!(e instanceof UnsatisfiedLinkError) && !(e.getCause() instanceof UnsatisfiedLinkError)) {
+                throw e;
             }
             return null;
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
@@ -67,9 +67,12 @@ public class PythonParser extends AbstractParser {
             SharedInterpreter.setConfig(config);
 
             if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-                PyConfig pyConfig = new PyConfig();
-                pyConfig.setPythonHome(System.getProperty(IConfigurationDirectory.IPED_ROOT) + "/python");
-                MainInterpreter.setInitParams(pyConfig);
+                String ipedRoot = System.getProperty(IConfigurationDirectory.IPED_ROOT);
+                if (ipedRoot != null && new File(ipedRoot).exists()) {
+                    PyConfig pyConfig = new PyConfig();
+                    pyConfig.setPythonHome(ipedRoot + "/python");
+                    MainInterpreter.setInitParams(pyConfig);
+                }
             }
 
         } catch (JepException e1) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/python/PythonParser.java
@@ -171,15 +171,16 @@ public class PythonParser extends AbstractParser {
             jep = new SharedInterpreter();
 
         } catch (Throwable e) {
-            if (!jepNotFoundPrinted.getAndSet(true)) {
-                String msg = JEP_NOT_FOUND + SEE_MANUAL;
-                LOGGER.error(msg);
-                e.printStackTrace();
-            }
-            if (!(e instanceof UnsatisfiedLinkError) && !(e.getCause() instanceof UnsatisfiedLinkError)) {
+            if (e instanceof UnsatisfiedLinkError || e.getCause() instanceof UnsatisfiedLinkError) {
+                if (!jepNotFoundPrinted.getAndSet(true)) {
+                    String msg = JEP_NOT_FOUND + SEE_MANUAL;
+                    LOGGER.error(msg);
+                    e.printStackTrace();
+                }
+                return null;
+            } else {
                 throw e;
             }
-            return null;
         }
 
         // setGlobalVar(jep, "logger", LOGGER); //$NON-NLS-1$


### PR DESCRIPTION
When ready, this will close #1067: embed python+jep

A portable python-3.9.12 plus JEP-4.0.3 (and its dependencies) already compiled for Windows will be included, increasing IPED uncompressed size in about ~20MB. I compiled JEP against numpy-1.22.3, but later removed numpy because it uses ~60MB space. Installing numpy later is enough to make dependent modules to work fine, but maybe the same numpy version will be needed, I'll put a warning in the wiki.

I hope this will make running (c)python modules easier on Windows, since JEP won't need to be compiled anymore.