### PR TITLE
#1029 upgrade to Tika 2

### DIFF
--- a/iped-api/src/main/java/iped3/util/ExtraProperties.java
+++ b/iped-api/src/main/java/iped3/util/ExtraProperties.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.Property;
+import org.apache.tika.metadata.TikaCoreProperties;
 
 /**
  * Metadados extras produzidos pelos parsers do pacote.
@@ -16,7 +17,7 @@ public class ExtraProperties {
 
     public static final String GLOBAL_ID = "globalId"; //$NON-NLS-1$
 
-    public static final String TIKA_PARSER_USED = "X-Parsed-By"; //$NON-NLS-1$
+    public static final String TIKA_PARSER_USED = TikaCoreProperties.TIKA_PARSED_BY.getName();
 
     public static final String DATASOURCE_READER = "X-Reader"; //$NON-NLS-1$
 

--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -63,7 +63,7 @@
         <!--<parser class="org.apache.tika.parser.image.HeifParser"></parser>-->
         <parser class="org.apache.tika.parser.iptc.IptcAnpaParser"></parser>
         <parser class="org.apache.tika.parser.iwork.IWorkPackageParser"></parser>
-        <!--<parser class="org.apache.tika.parser.jpeg.JpegParser"></parser>-->
+        <!--<parser class="org.apache.tika.parser.image.JpegParser"></parser>-->
         <!--We have our own impls
         <parser class="org.apache.tika.parser.mail.RFC822Parser"></parser>
         <parser class="org.apache.tika.parser.mbox.MboxParser"></parser>
@@ -167,7 +167,7 @@
             <mime>image/jpeg</mime>
             <params>
                 <param name="parserName" type="string">JPEGParser</param>
-                <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.jpeg.JpegParser</param>
+                <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.image.JpegParser</param>
             </params>
         </parser>
         

--- a/iped-app/resources/config/conf/parsers/PythonParserJabber.py
+++ b/iped-app/resources/config/conf/parsers/PythonParserJabber.py
@@ -8,7 +8,7 @@ For more info about general parser api, see https://github.com/sepinf-inc/IPED/w
 from org.apache.tika.sax import XHTMLContentHandler
 from org.apache.tika.io import TikaInputStream
 from org.apache.tika.io import TemporaryResources
-from org.apache.tika.metadata import Metadata, Message
+from org.apache.tika.metadata import Metadata, Message, TikaCoreProperties
 from org.apache.tika.exception import TikaException
 from org.apache.tika.extractor import EmbeddedDocumentExtractor
 from org.apache.tika.sax import EmbeddedContentHandler
@@ -115,7 +115,7 @@ class PythonParserJabber:
             extractor = context.get(EmbeddedDocumentExtractor)
             tis = TikaInputStream.get(stream, tmpResources)
             tmpFilePath = tis.getFile().getAbsolutePath()
-            origFileName = metadata.get(Metadata.RESOURCE_NAME_KEY)
+            origFileName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY)
             
             # extract text from html chat to be indexed, searched for regexes and so on...
             HtmlParser().parse(tis, EmbeddedContentHandler(xhtml), metadata, context)
@@ -233,7 +233,7 @@ class PythonParserJabber:
                 '''
                 meta = Metadata()
                 meta.set(BasicProps.LENGTH, "")
-                meta.set(Metadata.RESOURCE_NAME_KEY, msg_name_prefix + str(msg_num))
+                meta.set(TikaCoreProperties.RESOURCE_NAME_KEY, msg_name_prefix + str(msg_num))
                 meta.set(Message.MESSAGE_FROM, iped_sender)
                 meta.set(Message.MESSAGE_TO, iped_receiver)
                 meta.set(ExtraProperties.MESSAGE_DATE,iped_date)

--- a/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
+++ b/iped-app/resources/config/profiles/triage/conf/ParserConfig.xml
@@ -63,7 +63,7 @@
         <parser class="org.apache.tika.parser.image.HeifParser"></parser>
         <parser class="org.apache.tika.parser.iptc.IptcAnpaParser"></parser-->
         <parser class="org.apache.tika.parser.iwork.IWorkPackageParser"></parser>
-        <!--parser class="org.apache.tika.parser.jpeg.JpegParser"></parser-->
+        <!--parser class="org.apache.tika.parser.image.JpegParser"></parser-->
         <!--We have our own impls
         <parser class="org.apache.tika.parser.mail.RFC822Parser"></parser>
         <parser class="org.apache.tika.parser.mbox.MboxParser"></parser>
@@ -171,7 +171,7 @@
             <mime>image/jpeg</mime>
             <params>
                 <param name="parserName" type="string">JPEGParser</param>
-                <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.jpeg.JpegParser</param>
+                <param name="parsers" type="string">dpf.sp.gpinf.indexer.parsers.OCRParser;org.apache.tika.parser.image.JpegParser</param>
             </params>
         </parser>
         

--- a/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
+++ b/iped-app/src/main/java/dpf/sp/gpinf/indexer/desktop/GalleryModel.java
@@ -36,9 +36,9 @@ import javax.swing.ImageIcon;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.util.BytesRef;
-import org.apache.tika.io.CloseShieldInputStream;
 import org.apache.tika.mime.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/iped-engine/pom.xml
+++ b/iped-engine/pom.xml
@@ -204,11 +204,6 @@
   			<version>3.0.4</version>
 		</dependency>
         <dependency>
-	    	<groupId>com.optimaize.languagedetector</groupId>
-    		<artifactId>language-detector</artifactId>
-    		<version>0.6</version>
-		</dependency>
-        <dependency>
    			<groupId>com.zaxxer</groupId>
    			<artifactId>SparseBitSet</artifactId>
    			<version>1.1</version>
@@ -272,6 +267,15 @@
             <!-- check https://github.com/sepinf-inc/IPED/issues/1068 when upgrading this -->
             <version>1.21</version>
         </dependency>
-    </dependencies>
-    
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-langdetect-optimaize</artifactId>
+            <version>${tika.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parser-nlp-module</artifactId>
+            <version>${tika.version}</version>
+         </dependency>
+     </dependencies>
 </project>

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/datasource/SleuthkitReader.java
@@ -1199,7 +1199,7 @@ public class SleuthkitReader extends DataSourceReader {
                     e.printStackTrace();
 
                 } finally {
-                    IOUtils.closeQuietly(stream);
+                    IOUtil.closeQuietly(stream);
                     String msg = out.toString().trim();
                     for (String line : msg.split("\n")) { //$NON-NLS-1$
                         if (!line.trim().isEmpty()) {

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/IndexItem.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/IndexItem.java
@@ -154,7 +154,7 @@ public class IndexItem extends BasicProps {
 
         ignoredMetadata.add(Metadata.CONTENT_TYPE);
         ignoredMetadata.add(Metadata.CONTENT_LENGTH);
-        ignoredMetadata.add(Metadata.RESOURCE_NAME_KEY);
+        ignoredMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY);
         ignoredMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE);
         ignoredMetadata.add(IndexerDefaultParser.INDEXER_TIMEOUT);
         ignoredMetadata.add(TikaCoreProperties.CONTENT_TYPE_HINT.getName());

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/ParsingTask.java
@@ -257,7 +257,7 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
         Long len = evidence.getLength();
         if (len != null)
             metadata.set(Metadata.CONTENT_LENGTH, len.toString());
-        metadata.set(Metadata.RESOURCE_NAME_KEY, evidence.getName());
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, evidence.getName());
         if (evidence.getMediaType() != null) {
             metadata.set(Metadata.CONTENT_TYPE, evidence.getMediaType().toString());
             metadata.set(IndexerDefaultParser.INDEXER_CONTENT_TYPE, evidence.getMediaType().toString());

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SignatureTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/SignatureTask.java
@@ -10,6 +10,7 @@ import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.Detector;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.mime.MimeTypesFactory;
 import org.slf4j.Logger;
@@ -49,7 +50,7 @@ public class SignatureTask extends AbstractTask {
         MediaType type = evidence.getMediaType();
         if (type == null) {
             Metadata metadata = new Metadata();
-            metadata.set(Metadata.RESOURCE_NAME_KEY, evidence.getName());
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, evidence.getName());
             try {
                 if (processFileSignatures) {
                     TikaInputStream tis = null;
@@ -91,7 +92,7 @@ public class SignatureTask extends AbstractTask {
                         String suffix = HFS_ATTR_SUFFIX[i++];
                         if (evidence.getName().endsWith(suffix)) {
                             String name = evidence.getName().substring(0, evidence.getName().lastIndexOf(suffix));
-                            metadata.set(Metadata.RESOURCE_NAME_KEY, name);
+                            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
                             type = detector.detect(null, metadata).getBaseType();
                         }
                     }

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/util/Util.java
@@ -52,10 +52,10 @@ import org.apache.poi.poifs.filesystem.DirectoryEntry;
 import org.apache.poi.poifs.filesystem.DocumentEntry;
 import org.apache.poi.poifs.filesystem.DocumentInputStream;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.tika.detect.microsoft.POIFSContainerDetector;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
-import org.apache.tika.parser.microsoft.POIFSContainerDetector;
 
 import com.sun.jna.Native;
 

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -33,46 +33,47 @@
     		<artifactId>jaxb-api</artifactId>
     		<version>2.1</version>
 		</dependency>
-        <dependency>
+		<dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
+            <artifactId>tika-parsers-standard-package</artifactId>
             <version>${tika.version}</version>
-            <type>jar</type>
             <exclusions>
         		<exclusion>
           			<groupId>com.pff</groupId>
     				<artifactId>java-libpst</artifactId>
         		</exclusion>
-        		<exclusion>
-  					<groupId>org.opengis</groupId>
-				  	<artifactId>geoapi</artifactId>
-        		</exclusion>
-        		<exclusion>
-          			<groupId>edu.ucar</groupId>
-          			<artifactId>*</artifactId>
-        		</exclusion>
-        		<exclusion>
-          			<groupId>org.apache.opennlp</groupId>
-          			<artifactId>*</artifactId>
-        		</exclusion>
-        		<exclusion>
-					<groupId>org.apache.sis.core</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.sis.storage</groupId>
-					<artifactId>sis-netcdf</artifactId>
-				</exclusion>
-        		<exclusion>
-          			<groupId>com.google.guava</groupId>
-          			<artifactId>guava</artifactId>
-        		</exclusion>
-        		<exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-      		</exclusions> 
+        	</exclusions>
         </dependency>
+		<dependency>
+  		    <groupId>org.apache.tika</groupId>
+		    <artifactId>tika-parser-sqlite3-module</artifactId>
+		    <version>${tika.version}</version>
+		</dependency>
+		<dependency>
+  		    <groupId>net.java.dev.jna</groupId>
+		    <artifactId>jna</artifactId>
+		    <version>5.7.0</version>
+		</dependency>
+		<dependency>
+  		    <groupId>com.fasterxml.jackson.core</groupId>
+		    <artifactId>jackson-core</artifactId>
+		    <version>2.13.2</version>
+		</dependency>
+		<dependency>
+  		    <groupId>com.fasterxml.jackson.core</groupId>
+		    <artifactId>jackson-databind</artifactId>
+		    <version>2.13.2.2</version>
+		</dependency>
+		<dependency>
+		    <groupId>com.googlecode.json-simple</groupId>
+		    <artifactId>json-simple</artifactId>
+		    <version>1.1.1</version>
+		</dependency>
+		<dependency>
+		    <groupId>com.github.openjson</groupId>
+		    <artifactId>openjson</artifactId>
+		    <version>1.0.12</version>
+		</dependency>
         <dependency>
             <groupId>org.tallison</groupId>
             <artifactId>isoparser</artifactId>

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/ChromeSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/ChromeSqliteParser.java
@@ -110,7 +110,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler downloadsHandler = new ToXMLContentHandler(tmpDownloadsFile, "UTF-8"); //$NON-NLS-1$
                     Metadata downloadsMetadata = new Metadata();
                     downloadsMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, CHROME_DOWNLOADS.toString());
-                    downloadsMetadata.add(Metadata.RESOURCE_NAME_KEY, "Chrome Downloads"); //$NON-NLS-1$
+                    downloadsMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Chrome Downloads"); //$NON-NLS-1$
                     downloadsMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(0));
                     downloadsMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     downloadsMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -133,7 +133,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataDownload = new Metadata();
 
                     metadataDownload.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, CHROME_DOWNLOADS_REG.toString());
-                    metadataDownload.add(Metadata.RESOURCE_NAME_KEY, "Chrome Download Entry " + i); //$NON-NLS-1$
+                    metadataDownload.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Chrome Download Entry " + i); //$NON-NLS-1$
                     metadataDownload.add(ExtraProperties.URL, d.getUrlFromDownload());
                     metadataDownload.add(ExtraProperties.LOCAL_PATH, d.getDownloadedLocalPath());
                     metadataDownload.set(TikaCoreProperties.CREATED, d.getDownloadedDate());
@@ -154,7 +154,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler historyHandler = new ToXMLContentHandler(tmpHistoryFile, "UTF-8"); //$NON-NLS-1$
                     Metadata historyMetadata = new Metadata();
                     historyMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, CHROME_HISTORY.toString());
-                    historyMetadata.add(Metadata.RESOURCE_NAME_KEY, "Chrome History"); //$NON-NLS-1$
+                    historyMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Chrome History"); //$NON-NLS-1$
                     historyMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(1));
                     historyMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     historyMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -177,7 +177,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataHistory = new Metadata();
 
                     metadataHistory.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, CHROME_HISTORY_REG.toString());
-                    metadataHistory.add(Metadata.RESOURCE_NAME_KEY, "Chrome History Entry " + i); //$NON-NLS-1$
+                    metadataHistory.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Chrome History Entry " + i); //$NON-NLS-1$
                     metadataHistory.add(TikaCoreProperties.TITLE, h.getTitle());
                     metadataHistory.set(ExtraProperties.ACCESSED, h.getVisitDate());
                     metadataHistory.set(ExtraProperties.VISIT_DATE, h.getVisitDate());
@@ -194,7 +194,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler searchesHandler = new ToXMLContentHandler(tmpSearchesFile, "UTF-8"); //$NON-NLS-1$
                     Metadata searchesMetadata = new Metadata();
                     searchesMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, CHROME_SEARCHES.toString());
-                    searchesMetadata.add(Metadata.RESOURCE_NAME_KEY, "Chrome Searches"); //$NON-NLS-1$
+                    searchesMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Chrome Searches"); //$NON-NLS-1$
                     searchesMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(0));
                     searchesMetadata.set(BasicProps.HASCHILD, "false"); //$NON-NLS-1$
                     searchesMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/EdgeWebCacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/EdgeWebCacheParser.java
@@ -156,7 +156,7 @@ public class EdgeWebCacheParser extends AbstractParser {
                         ToXMLContentHandler historyHandler = new ToXMLContentHandler(tmpHistoryFile, "UTF-8"); //$NON-NLS-1$
                         Metadata historyMetadata = new Metadata();
                         historyMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, EDGE_HISTORY.toString());
-                        historyMetadata.add(Metadata.RESOURCE_NAME_KEY, "Edge History " + ec.getTableName()); // $NON-NLS-1$
+                        historyMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Edge History " + ec.getTableName()); // $NON-NLS-1$
                         historyMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(virtualId));
                         historyMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                         historyMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -177,7 +177,7 @@ public class EdgeWebCacheParser extends AbstractParser {
                         Metadata metadataHistory = new Metadata();
 
                         metadataHistory.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, EDGE_HISTORY_REG.toString());
-                        metadataHistory.add(Metadata.RESOURCE_NAME_KEY, "Edge History Entry " + i); //$NON-NLS-1$
+                        metadataHistory.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Edge History Entry " + i); //$NON-NLS-1$
                         metadataHistory.set(TikaCoreProperties.CREATED, ev.getCreationDate());
                         metadataHistory.set(TikaCoreProperties.MODIFIED, ev.getModifiedDate());
                         metadataHistory.set(ExtraProperties.ACCESSED, ev.getAccessedDate());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/FirefoxSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/FirefoxSqliteParser.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
-import org.apache.tika.io.IOExceptionWithCause;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -38,8 +37,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.openjson.JSONObject;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 
 import dpf.sp.gpinf.indexer.parsers.IndexerDefaultParser;
 import dpf.sp.gpinf.indexer.parsers.jdbc.SQLite3Parser;
@@ -113,7 +110,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler bookmarksHandler = new ToXMLContentHandler(tmpBookmarksFile, "UTF-8"); //$NON-NLS-1$
                     Metadata bookmarksMetadata = new Metadata();
                     bookmarksMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_BOOKMARKS.toString());
-                    bookmarksMetadata.add(Metadata.RESOURCE_NAME_KEY, "Firefox Bookmarks"); //$NON-NLS-1$
+                    bookmarksMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox Bookmarks"); //$NON-NLS-1$
                     bookmarksMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(0));
                     bookmarksMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     bookmarksMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -135,7 +132,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataBookmark = new Metadata();
 
                     metadataBookmark.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_BOOKMARKS_REG.toString());
-                    metadataBookmark.add(Metadata.RESOURCE_NAME_KEY, "Firefox Bookmark Entry " + i); //$NON-NLS-1$
+                    metadataBookmark.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox Bookmark Entry " + i); //$NON-NLS-1$
                     metadataBookmark.add(TikaCoreProperties.TITLE, b.getTitle());
                     metadataBookmark.set(TikaCoreProperties.CREATED, b.getDateAdded());
                     metadataBookmark.set(TikaCoreProperties.MODIFIED, b.getLastModified());
@@ -153,7 +150,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler historyHandler = new ToXMLContentHandler(tmpHistoryFile, "UTF-8"); //$NON-NLS-1$
                     Metadata historyMetadata = new Metadata();
                     historyMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_HISTORY.toString());
-                    historyMetadata.add(Metadata.RESOURCE_NAME_KEY, "Firefox History"); //$NON-NLS-1$
+                    historyMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox History"); //$NON-NLS-1$
                     historyMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(1));
                     historyMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     historyMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -175,7 +172,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataHistory = new Metadata();
 
                     metadataHistory.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_HISTORY_REG.toString());
-                    metadataHistory.add(Metadata.RESOURCE_NAME_KEY, "Firefox History Entry " + i); //$NON-NLS-1$
+                    metadataHistory.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox History Entry " + i); //$NON-NLS-1$
                     metadataHistory.add(TikaCoreProperties.TITLE, h.getTitle());
                     metadataHistory.set(ExtraProperties.ACCESSED, h.getVisitDate());
                     metadataHistory.set(ExtraProperties.VISIT_DATE, h.getVisitDate());
@@ -193,7 +190,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler downloadsHandler = new ToXMLContentHandler(tmpDownloadFile, "UTF-8"); //$NON-NLS-1$
                     Metadata downloadsMetadata = new Metadata();
                     downloadsMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_DOWNLOADS.toString());
-                    downloadsMetadata.add(Metadata.RESOURCE_NAME_KEY, "Firefox Downloads"); //$NON-NLS-1$
+                    downloadsMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox Downloads"); //$NON-NLS-1$
                     downloadsMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(2));
                     downloadsMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     downloadsMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -215,7 +212,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataDownload = new Metadata();
 
                     metadataDownload.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, MOZ_DOWNLOADS_REG.toString());
-                    metadataDownload.add(Metadata.RESOURCE_NAME_KEY, "Firefox Download Entry " + i); //$NON-NLS-1$
+                    metadataDownload.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Firefox Download Entry " + i); //$NON-NLS-1$
                     metadataDownload.add(ExtraProperties.URL, d.getUrlFromDownload());
                     metadataDownload.add(ExtraProperties.LOCAL_PATH, d.getDownloadedLocalPath());
                     metadataDownload.set(TikaCoreProperties.CREATED, d.getDownloadedDate());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/SafariPlistParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/SafariPlistParser.java
@@ -109,7 +109,7 @@ public class SafariPlistParser extends AbstractParser {
                         ToXMLContentHandler historyHandler = new ToXMLContentHandler(tmpHistoryFile, "UTF-8"); //$NON-NLS-1$
                         Metadata historyMetadata = new Metadata();
                         historyMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_HISTORY.toString());
-                        historyMetadata.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist History"); //$NON-NLS-1$
+                        historyMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist History"); //$NON-NLS-1$
                         historyMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(0));
                         historyMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                         historyMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -132,7 +132,7 @@ public class SafariPlistParser extends AbstractParser {
                         Metadata metadataHistory = new Metadata();
 
                         metadataHistory.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_HISTORY_REG.toString());
-                        metadataHistory.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist History Entry " + i); //$NON-NLS-1$
+                        metadataHistory.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist History Entry " + i); //$NON-NLS-1$
                         metadataHistory.add(TikaCoreProperties.TITLE, v.getTitle());
                         metadataHistory.set(ExtraProperties.ACCESSED, v.getLastVisitDate());
                         metadataHistory.set(ExtraProperties.VISIT_DATE, v.getLastVisitDate());
@@ -155,7 +155,7 @@ public class SafariPlistParser extends AbstractParser {
                         ToXMLContentHandler downloadHandler = new ToXMLContentHandler(tmpDownloadFile, "UTF-8"); //$NON-NLS-1$
                         Metadata downloadMetadata = new Metadata();
                         downloadMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_DOWNLOADS.toString());
-                        downloadMetadata.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist Downloads"); //$NON-NLS-1$
+                        downloadMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist Downloads"); //$NON-NLS-1$
                         downloadMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(1));
                         downloadMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                         downloadMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -179,7 +179,7 @@ public class SafariPlistParser extends AbstractParser {
 
                         metadataDownload.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE,
                                 SAFARI_DOWNLOADS_REG.toString());
-                        metadataDownload.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist Download Entry " + i); //$NON-NLS-1$
+                        metadataDownload.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist Download Entry " + i); //$NON-NLS-1$
                         metadataDownload.add(ExtraProperties.URL, d.getUrlFromDownload());
                         metadataDownload.add(ExtraProperties.LOCAL_PATH, d.getDownloadedLocalPath());
                         if (d.getDownloadedDate() != null)
@@ -207,7 +207,7 @@ public class SafariPlistParser extends AbstractParser {
                         ToXMLContentHandler bookmarkHandler = new ToXMLContentHandler(tmpBookmarkFile, "UTF-8"); //$NON-NLS-1$
                         Metadata bookmarkMetadata = new Metadata();
                         bookmarkMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_DOWNLOADS.toString());
-                        bookmarkMetadata.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist Bookmarks"); //$NON-NLS-1$
+                        bookmarkMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist Bookmarks"); //$NON-NLS-1$
                         bookmarkMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(2));
                         bookmarkMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                         bookmarkMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -231,7 +231,7 @@ public class SafariPlistParser extends AbstractParser {
 
                         metadataBookmark.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE,
                                 SAFARI_DOWNLOADS_REG.toString());
-                        metadataBookmark.add(Metadata.RESOURCE_NAME_KEY, "Safari Plist Bookmark Entry " + i); //$NON-NLS-1$
+                        metadataBookmark.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari Plist Bookmark Entry " + i); //$NON-NLS-1$
                         metadataBookmark.add(TikaCoreProperties.TITLE, b.getTitle());
                         metadataBookmark.add(ExtraProperties.URL, b.getUrl());
                         metadataBookmark.add(ExtraProperties.PARENT_VIRTUAL_ID, String.valueOf(2));

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/SafariSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/browsers/parsers/SafariSqliteParser.java
@@ -93,7 +93,7 @@ public class SafariSqliteParser extends AbstractSqliteBrowserParser {
                     ToXMLContentHandler historyHandler = new ToXMLContentHandler(tmpHistoryFile, "UTF-8"); //$NON-NLS-1$
                     Metadata historyMetadata = new Metadata();
                     historyMetadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_HISTORY.toString());
-                    historyMetadata.add(Metadata.RESOURCE_NAME_KEY, "Safari History"); //$NON-NLS-1$
+                    historyMetadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari History"); //$NON-NLS-1$
                     historyMetadata.add(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(1));
                     historyMetadata.set(BasicProps.HASCHILD, "true"); //$NON-NLS-1$
                     historyMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
@@ -116,7 +116,7 @@ public class SafariSqliteParser extends AbstractSqliteBrowserParser {
                     Metadata metadataHistory = new Metadata();
 
                     metadataHistory.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, SAFARI_HISTORY_REG.toString());
-                    metadataHistory.add(Metadata.RESOURCE_NAME_KEY, "Safari History Entry " + i); //$NON-NLS-1$
+                    metadataHistory.add(TikaCoreProperties.RESOURCE_NAME_KEY, "Safari History Entry " + i); //$NON-NLS-1$
                     metadataHistory.add(TikaCoreProperties.TITLE, h.getTitle());
                     metadataHistory.set(ExtraProperties.ACCESSED, h.getVisitDate());
                     metadataHistory.set(ExtraProperties.VISIT_DATE, h.getVisitDate());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/gdrive/parsers/GDriveCloudGraphParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/gdrive/parsers/GDriveCloudGraphParser.java
@@ -139,7 +139,7 @@ public class GDriveCloudGraphParser extends SQLite3DBParser {
         Metadata metadataCloudGraphItem = new Metadata();
 
         metadataCloudGraphItem.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, GDRIVE_CLOUD_GRAPH_REG.toString());
-        metadataCloudGraphItem.add(Metadata.RESOURCE_NAME_KEY, "GDrive CloudGraph Entry " + i);
+        metadataCloudGraphItem.add(TikaCoreProperties.RESOURCE_NAME_KEY, "GDrive CloudGraph Entry " + i);
         metadataCloudGraphItem.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 
         // These properties need to get a "Date" type as parameters, so it can correctly

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/gdrive/parsers/GDriveSnapshotParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/gdrive/parsers/GDriveSnapshotParser.java
@@ -128,7 +128,7 @@ public class GDriveSnapshotParser extends SQLite3DBParser {
         Metadata metadataSnapshotItem = new Metadata();
 
         metadataSnapshotItem.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, GDRIVE_SNAPSHOT_REG.toString());
-        metadataSnapshotItem.add(Metadata.RESOURCE_NAME_KEY, "GDrive Snapshot Entry " + i);
+        metadataSnapshotItem.add(TikaCoreProperties.RESOURCE_NAME_KEY, "GDrive Snapshot Entry " + i);
         metadataSnapshotItem.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 
         // These properties need to get a "Date" type as parameters, so it can correctly

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/winx/parsers/WinXTimelineParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/inc/sepinf/winx/parsers/WinXTimelineParser.java
@@ -158,7 +158,7 @@ public class WinXTimelineParser extends SQLite3DBParser {
         Metadata metadataTimelineItem = new Metadata();
 
         metadataTimelineItem.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, WIN10_TIMELINE_REG.toString());
-        metadataTimelineItem.add(Metadata.RESOURCE_NAME_KEY, "WinXTimeline Entry " + i);
+        metadataTimelineItem.add(TikaCoreProperties.RESOURCE_NAME_KEY, "WinXTimeline Entry " + i);
         metadataTimelineItem.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 
         // These properties need to get a "Date" type as parameters, so it can correctly

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/bittorrent/BitTorrentResumeDatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/bittorrent/BitTorrentResumeDatParser.java
@@ -11,7 +11,7 @@ import java.util.TimeZone;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -58,7 +58,7 @@ public class BitTorrentResumeDatParser extends AbstractParser {
         df.setTimeZone(TimeZone.getTimeZone("GMT+0")); //$NON-NLS-1$
 
         metadata.set(HttpHeaders.CONTENT_TYPE, RESUME_DAT_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         BencodedDict dict = new BencodedDict(stream, df);
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaLibraryDatParser.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -61,7 +61,7 @@ public class ShareazaLibraryDatParser extends AbstractParser {
             throws IOException, SAXException, TikaException {
 
         metadata.set(HttpHeaders.CONTENT_TYPE, LIBRARY_DAT_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         MFCParser parser = new MFCParser(stream);
         Library library = new Library();

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaSearchesDatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/shareazaparser/ShareazaSearchesDatParser.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -56,7 +56,7 @@ public class ShareazaSearchesDatParser extends AbstractParser {
             throws IOException, SAXException, TikaException {
 
         metadata.set(HttpHeaders.CONTENT_TYPE, SEARCH_DAT_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         MFCParser parser = new MFCParser(stream);
         Searches searches = new Searches();

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mt/gpinf/registry/RegistryParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mt/gpinf/registry/RegistryParser.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -45,7 +45,7 @@ public class RegistryParser extends AbstractParser {
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
             throws IOException, SAXException, TikaException {
         /* filtra os itens a serem parseados */
-        String nome = metadata.get(TikaMetadataKeys.RESOURCE_NAME_KEY).toUpperCase();
+        String nome = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY).toUpperCase();
         try {
             if (defaultRegistryKeyParser == null) {
                 defaultRegistryKeyParser = RegistryKeyParserManager.getRegistryKeyParserManager()

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/pi/gpinf/firefox/parsers/FirefoxSavedSessionParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/pi/gpinf/firefox/parsers/FirefoxSavedSessionParser.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.io.ByteArrayOutputStream;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -286,7 +287,8 @@ public class FirefoxSavedSessionParser extends AbstractParser {
 
     private TikaException getTikaException(Metadata metadata, Exception cause) {
         TikaException e = new TikaException(
-                "Possible false positive LZ4 Mozilla Firefox file: " + metadata.get(Metadata.RESOURCE_NAME_KEY));
+                "Possible false positive LZ4 Mozilla Firefox file: "
+                        + metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
         if (cause != null) {
             e.initCause(cause);
         }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/AresParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/AresParser.java
@@ -33,7 +33,7 @@ import java.util.TimeZone;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -85,7 +85,7 @@ public class AresParser extends AbstractParser {
         df.setTimeZone(TimeZone.getTimeZone("GMT+0")); //$NON-NLS-1$
 
         metadata.set(HttpHeaders.CONTENT_TYPE, ARES_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         List<AresEntry> l = gpinf.ares.AresParser.parseToList(stream);
         if (l == null)

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/EDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/EDBParser.java
@@ -23,6 +23,7 @@ import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -117,7 +118,7 @@ public class EDBParser extends AbstractParser {
                 for (File table : tables) {
 
                     Metadata tableMetadata = new Metadata();
-                    tableMetadata.set(Metadata.RESOURCE_NAME_KEY, TABLE_PREFIX + "-" + table.getName()); //$NON-NLS-1$
+                    tableMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, TABLE_PREFIX + "-" + table.getName()); //$NON-NLS-1$
                     tableMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 
                     if (metadata.get(Metadata.CONTENT_TYPE).endsWith("x-webcache")) //$NON-NLS-1$
@@ -194,7 +195,7 @@ public class EDBParser extends AbstractParser {
                         writer.write(SimpleHTMLEncoder.htmlEncode(name));
 
                         Metadata meta = new Metadata();
-                        meta.set(Metadata.RESOURCE_NAME_KEY, name);
+                        meta.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
                         try (InputStream is = new ByteArrayInputStream(Hex.decodeHex(value.toCharArray()))) {
                             extractor.parseEmbedded(is, handler, meta, true);
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/IncrediMailParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/IncrediMailParser.java
@@ -76,7 +76,7 @@ public class IncrediMailParser extends AbstractParser {
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
 
-        String name = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        String name = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         String charsetName = "windows-1252"; //$NON-NLS-1$
         InputStreamReader isr = new InputStreamReader(stream, charsetName);

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/IndexerDefaultParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/IndexerDefaultParser.java
@@ -32,7 +32,7 @@ import org.apache.tika.fork.ForkParser2;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.CompositeParser;
 import org.apache.tika.parser.EmptyParser;
@@ -333,7 +333,7 @@ public class IndexerDefaultParser extends CompositeParser {
                 String[] names = metadata.names();
                 Arrays.sort(names);
                 for (String name : names) {
-                    if (name != null && !name.equals(TikaMetadataKeys.RESOURCE_NAME_KEY)
+                    if (name != null && !name.equals(TikaCoreProperties.RESOURCE_NAME_KEY)
                             && !name.equals("PLTE PLTEEntry") && !name.equals("Chroma Palette PaletteEntry") //$NON-NLS-1$ //$NON-NLS-2$
                             && !name.equals(Metadata.CONTENT_TYPE)) {
                         String text = name + ": "; //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/KnownMetParser.java
@@ -36,7 +36,7 @@ import java.util.TimeZone;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -98,7 +98,7 @@ public class KnownMetParser extends AbstractParser {
         df.setTimeZone(TimeZone.getTimeZone("GMT+0")); //$NON-NLS-1$
 
         metadata.set(HttpHeaders.CONTENT_TYPE, EMULE_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         List<KnownMetEntry> l = gpinf.emule.KnownMetParser.parseToList(stream);
         if (l == null)

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LNKShortcutParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LNKShortcutParser.java
@@ -30,7 +30,7 @@ import java.util.TimeZone;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -76,7 +76,7 @@ public class LNKShortcutParser extends AbstractParser {
         df.setTimeZone(TimeZone.getTimeZone("GMT+0")); //$NON-NLS-1$
 
         metadata.set(HttpHeaders.CONTENT_TYPE, LNK_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/LibpffPSTParser.java
@@ -31,7 +31,7 @@ import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
-import org.apache.tika.parser.rtf.RTFParser;
+import org.apache.tika.parser.microsoft.rtf.RTFParser;
 import org.apache.tika.sax.BodyContentHandler;
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.slf4j.Logger;
@@ -138,7 +138,7 @@ public class LibpffPSTParser extends AbstractParser {
         this.handler = handler;
         extractor = context.get(EmbeddedDocumentExtractor.class, new ParsingEmbeddedDocumentExtractor(context));
 
-        String fileName = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        String fileName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         ItemInfo itemInfo = context.get(ItemInfo.class);
         if (itemInfo != null)
             fileName = itemInfo.getPath();
@@ -585,7 +585,7 @@ public class LibpffPSTParser extends AbstractParser {
             Metadata metadata = new Metadata();
             metadata.set(ExtraProperties.ITEM_VIRTUAL_ID, String.valueOf(++virtualId));
             metadata.set(ExtraProperties.PARENT_VIRTUAL_ID, String.valueOf(parent));
-            metadata.set(Metadata.RESOURCE_NAME_KEY, name);
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
             metadata.set(ExtraProperties.MESSAGE_IS_ATTACHMENT, Boolean.TRUE.toString());
             if (deleted)
                 metadata.set(ExtraProperties.DELETED, "true"); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSAccessParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MSAccessParser.java
@@ -33,15 +33,15 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -97,7 +97,7 @@ public class MSAccessParser extends AbstractParser {
             database = builder.open();
 
             metadata.set(HttpHeaders.CONTENT_TYPE, ACCESS_MIME_TYPE);
-            metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+            metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
             for (Property prop : database.getSummaryProperties())
                 metadata.set(prop.getName(), prop.getValue().toString());
 
@@ -166,7 +166,7 @@ public class MSAccessParser extends AbstractParser {
                                         blobStream = oleBlob.getBinaryStream();
 
                                     if (content instanceof OleBlob.PackageContent) {
-                                        metadata.set(Metadata.RESOURCE_NAME_KEY,
+                                        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY,
                                                 ((PackageContent) content).getPrettyName());
                                     }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MboxParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MboxParser.java
@@ -82,7 +82,7 @@ public class MboxParser extends AbstractParser {
         String charsetName = "windows-1252"; //$NON-NLS-1$
         InputStreamReader isr = new InputStreamReader(stream, charsetName);
         BufferedReader reader = new BufferedReader(isr, 100000);
-        String name = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        String name = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         String line;
         int count = 0;

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MultipleParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/MultipleParser.java
@@ -10,12 +10,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.config.Field;
 import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -150,7 +151,7 @@ public class MultipleParser extends AbstractParser {
 
     private Metadata getNewMetadata(Metadata metadata) {
         Metadata newMetadata = new Metadata();
-        newMetadata.set(Metadata.RESOURCE_NAME_KEY, metadata.get(Metadata.RESOURCE_NAME_KEY));
+        newMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
         newMetadata.set(Metadata.CONTENT_LENGTH, metadata.get(Metadata.CONTENT_LENGTH));
         newMetadata.set(Metadata.CONTENT_TYPE, metadata.get(Metadata.CONTENT_TYPE));
         newMetadata.set(IndexerDefaultParser.INDEXER_CONTENT_TYPE,

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OCRParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OCRParser.java
@@ -48,8 +48,8 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/OutlookPSTParser.java
@@ -52,7 +52,7 @@ import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
-import org.apache.tika.parser.rtf.RTFParser;
+import org.apache.tika.parser.microsoft.rtf.RTFParser;
 import org.apache.tika.sax.BodyContentHandler;
 import org.apache.tika.sax.XHTMLContentHandler;
 import org.slf4j.Logger;
@@ -136,7 +136,7 @@ public class OutlookPSTParser extends AbstractParser {
         this.context = context;
         extractor = context.get(EmbeddedDocumentExtractor.class, new ParsingEmbeddedDocumentExtractor(context));
 
-        String fileName = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        String fileName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         ItemInfo itemInfo = context.get(ItemInfo.class);
         if (itemInfo != null)
             fileName = itemInfo.getPath();
@@ -671,7 +671,7 @@ public class OutlookPSTParser extends AbstractParser {
                         filename = attach.getFilename();
 
                     Metadata metadata = new Metadata();
-                    metadata.set(Metadata.RESOURCE_NAME_KEY, filename);
+                    metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, filename);
                     metadata.set(TikaCoreProperties.CREATED, attach.getCreationTime());
                     // metadata.set(TikaCoreProperties.MODIFIED,
                     // attach.getLastModificationTime());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PDFOCRTextParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PDFOCRTextParser.java
@@ -36,8 +36,11 @@ import org.apache.tika.config.Field;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.DublinCore;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.Office;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.pdf.PDFParser;
@@ -190,13 +193,13 @@ public class PDFOCRTextParser extends PDFParser {
             }
 
             if (numPages == 0)
-                if (metadata.get(Metadata.RESOURCE_NAME_KEY).startsWith("Carved")) //$NON-NLS-1$
+                if (metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY).startsWith("Carved")) //$NON-NLS-1$
                     throw new TikaException("PDF document contains zero pages"); //$NON-NLS-1$
                 else
                     numPages = 1;
 
             int charCount = countHandler.getCharCount();
-            metadata.set(Metadata.CHARACTER_COUNT, charCount);
+            metadata.set(Office.CHARACTER_COUNT, charCount);
 
             if (ocrParser.isEnabled() && !processEmbeddedImages && charCount / numPages <= maxCharsToOcr) {
                 tis = TikaInputStream.get(file);
@@ -276,28 +279,28 @@ public class PDFOCRTextParser extends PDFParser {
                 PInfo info = iceDoc.getInfo();
                 String value = info.getSubject();
                 if (value != null)
-                    metadata.add(Metadata.SUBJECT, value);
+                    metadata.add(TikaCoreProperties.SUBJECT, value);
                 value = info.getTitle();
                 if (value != null)
-                    metadata.add(Metadata.TITLE, value);
+                    metadata.add(TikaCoreProperties.TITLE, value);
                 value = info.getAuthor();
                 if (value != null)
-                    metadata.add(Metadata.AUTHOR, value);
+                    metadata.add(TikaCoreProperties.CREATOR, value);
                 value = info.getCreator();
                 if (value != null)
-                    metadata.add(Metadata.CREATOR, value);
+                    metadata.add(TikaCoreProperties.CREATOR, value);
                 value = info.getProducer();
                 if (value != null)
-                    metadata.add(Metadata.APPLICATION_NAME, value);
+                    metadata.add(TikaCoreProperties.CREATOR_TOOL, value);
                 value = info.getKeywords();
                 if (value != null)
-                    metadata.add(Metadata.KEYWORDS, value);
+                    metadata.add(Office.KEYWORDS, value);
                 PDate date = info.getCreationDate();
                 if (date != null)
-                    metadata.add(Metadata.CREATION_DATE, date.toString());
+                    metadata.add(TikaCoreProperties.CREATED, date.toString());
                 date = info.getModDate();
                 if (date != null)
-                    metadata.add(Metadata.MODIFIED, date.toString());
+                    metadata.add(TikaCoreProperties.MODIFIED, date.toString());
 
             } catch (Exception e) {
                 e.printStackTrace();

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PackageParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PackageParser.java
@@ -52,11 +52,11 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipExtraField;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.tika.exception.EncryptedDocumentException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
-import org.apache.tika.io.CloseShieldInputStream;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -184,7 +184,7 @@ public class PackageParser extends AbstractParser {
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
 
-        String nameKey = metadata.get(Metadata.RESOURCE_NAME_KEY);
+        String nameKey = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         boolean isCarved = nameKey != null ? nameKey.startsWith("Carved") : false; //$NON-NLS-1$
         BooleanWrapper encrypted = new BooleanWrapper();
         HashSet<String> parentMap = new HashSet<>();
@@ -370,7 +370,7 @@ public class PackageParser extends AbstractParser {
     private void createParent(String name, String parent, EmbeddedDocumentExtractor extractor,
             XHTMLContentHandler xhtml) throws SAXException, IOException {
         Metadata entrydata = new Metadata();
-        entrydata.set(Metadata.RESOURCE_NAME_KEY, name);
+        entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
         entrydata.set(ExtraProperties.EMBEDDED_FOLDER, "true"); //$NON-NLS-1$
         entrydata.set(ExtraProperties.ITEM_VIRTUAL_ID, name);
         entrydata.set(ExtraProperties.PARENT_VIRTUAL_ID, parent);
@@ -391,8 +391,8 @@ public class PackageParser extends AbstractParser {
             entrydata.set(Metadata.CONTENT_LENGTH, Long.toString(entry.getSize()));
         }
         if (name != null && name.length() > 0) {
-            entrydata.set(Metadata.RESOURCE_NAME_KEY, name);
-            entrydata.set(Metadata.EMBEDDED_RELATIONSHIP_ID, name);
+            entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+            entrydata.set(TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID, name);
             entrydata.set(ExtraProperties.ITEM_VIRTUAL_ID, name); // $NON-NLS-1$
         }
         if (entry instanceof ZipArchiveEntry) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/PartMetParser.java
@@ -16,7 +16,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -60,7 +60,7 @@ public class PartMetParser extends AbstractParser {
         df.setTimeZone(TimeZone.getTimeZone("GMT+0"));
 
         metadata.set(HttpHeaders.CONTENT_TYPE, EMULE_PART_MET_MIME_TYPE);
-        metadata.remove(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        metadata.remove(TikaCoreProperties.RESOURCE_NAME_KEY);
 
         // PART.MET files are very small, so 1 MB should be more than enough.
         byte[] bytes = new byte[1 << 20];

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RARParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RARParser.java
@@ -45,6 +45,7 @@ import com.github.junrar.exception.RarException;
 import com.github.junrar.rarfile.FileHeader;
 
 import dpf.sp.gpinf.indexer.parsers.util.Util;
+import dpf.sp.gpinf.indexer.util.EmptyInputStream;
 import iped3.util.ExtraProperties;
 
 /**
@@ -137,12 +138,17 @@ public class RARParser extends AbstractParser {
             EmbeddedDocumentExtractor extractor) throws RarException, IOException, SAXException {
         InputStream subFile = null;
         try {
-            subFile = rar.getInputStream(header);
+            if (header.getFullUnpackSize() > 0) {
+                subFile = rar.getInputStream(header);
+            } else {
+                subFile = new EmptyInputStream();
+            }
+
             Metadata entrydata = new Metadata();
             if (header.isDirectory())
                 entrydata.set(ExtraProperties.EMBEDDED_FOLDER, "true"); //$NON-NLS-1$
             
-            entrydata.set(Metadata.RESOURCE_NAME_KEY, header.getFileNameString().replace("\\", "/")); //$NON-NLS-1$ //$NON-NLS-2$
+            entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, header.getFileNameString().replace("\\", "/")); //$NON-NLS-1$ //$NON-NLS-2$
             entrydata.set(TikaCoreProperties.CREATED, header.getCTime());
             entrydata.set(TikaCoreProperties.MODIFIED, header.getMTime());
             entrydata.set(ExtraProperties.ACCESSED, header.getATime());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RFC822Parser.java
@@ -50,12 +50,11 @@ import org.apache.poi.util.ReplacingInputStream;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
-import org.apache.tika.io.TaggedInputStream;
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.HttpHeaders;
 import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
-import org.apache.tika.metadata.TikaMetadataKeys;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -118,12 +117,12 @@ public class RFC822Parser extends AbstractParser {
             stream = new ReplacingInputStream(new ReplacingInputStream(stream, "\r\n", "\n"), "\r", "\n");
         }
 
-        TaggedInputStream tagged = TaggedInputStream.get(stream);
+        TikaInputStream tstream = TikaInputStream.get(stream);
         try {
-            parser.parse(tagged);
+            parser.parse(tstream);
 
         } catch (IOException e) {
-            tagged.throwIfCauseOf(e);
+            tstream.throwIfCauseOf(e);
             throw new TikaException("Failed to parse an email message", e); //$NON-NLS-1$
 
         } catch (MimeException e) {
@@ -207,7 +206,7 @@ public class RFC822Parser extends AbstractParser {
                 if (attachName == null) {
                     attachName = Messages.getString("RFC822Parser.UnNamed"); //$NON-NLS-1$
                 }
-                submd.set(TikaMetadataKeys.RESOURCE_NAME_KEY, attachName);
+                submd.set(TikaCoreProperties.RESOURCE_NAME_KEY, attachName);
             }
 
             try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RegistryParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/RegistryParser.java
@@ -18,6 +18,7 @@ import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -113,7 +114,7 @@ public class RegistryParser extends AbstractParser {
         try {
             TikaInputStream tis = TikaInputStream.get(stream, tmp);
 
-            String filename = metadata.get(Metadata.RESOURCE_NAME_KEY);
+            String filename = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
             File tempFile = null;
             String[] finalCmd = null;
             for (String regName : regNames)
@@ -158,7 +159,7 @@ public class RegistryParser extends AbstractParser {
                 }
 
                 Metadata reportMetadata = new Metadata();
-                reportMetadata.set(Metadata.RESOURCE_NAME_KEY, filename + "-Report"); //$NON-NLS-1$
+                reportMetadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, filename + "-Report"); //$NON-NLS-1$
                 reportMetadata.set(IndexerDefaultParser.INDEXER_CONTENT_TYPE, "application/x-windows-registry-report"); //$NON-NLS-1$
                 reportMetadata.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/SevenZipParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/SevenZipParser.java
@@ -279,7 +279,7 @@ public class SevenZipParser extends AbstractParser {
             try {
                 final Metadata entrydata = new Metadata();
                 subitemPath = item.getPath().replace("\\", "/"); //$NON-NLS-1$ //$NON-NLS-2$
-                entrydata.set(Metadata.RESOURCE_NAME_KEY, subitemPath);
+                entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, subitemPath);
                 entrydata.set(ExtraProperties.ITEM_VIRTUAL_ID, item.getPath());
                 entrydata.set(ExtraProperties.PARENT_VIRTUAL_ID, Util.getParentPath(item.getPath()));
                 entrydata.set(TikaCoreProperties.CREATED, item.getCreationTime());

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/external/ExternalParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/external/ExternalParser.java
@@ -36,12 +36,13 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.IOUtils;
-import org.apache.tika.io.NullOutputStream;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
@@ -328,13 +329,14 @@ public class ExternalParser extends AbstractParser {
                     extractMetadata(is, metadata);
                 } else {
                     File tmpFile = inputToStdIn ? null : stream.getFile();
-                    extractOutput(is, xhtml, metadata.get(Metadata.RESOURCE_NAME_KEY), tmpFile);
+                    extractOutput(is, xhtml, metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), tmpFile);
                 }
             }
 
         } catch (InterruptedException e) {
-            LOGGER.warn(parserName + " interrupted while processing " + metadata.get(Metadata.RESOURCE_NAME_KEY) + " ("
-                    + metadata.get(Metadata.CONTENT_LENGTH) + " bytes)");
+            LOGGER.warn(
+                    parserName + " interrupted while processing " + metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY)
+                            + " (" + metadata.get(Metadata.CONTENT_LENGTH) + " bytes)");
 
             if (process != null)
                 process.destroyForcibly();

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/AbstractDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/AbstractDBParser.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
-import org.apache.tika.io.IOExceptionWithCause;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.metadata.Database;
 import org.apache.tika.metadata.Metadata;
@@ -216,7 +215,7 @@ abstract class AbstractDBParser extends AbstractParser {
         try {
             connection = DriverManager.getConnection(connectionString);
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         return connection;
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/JDBCTableReader.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/JDBCTableReader.java
@@ -38,12 +38,10 @@ import org.apache.tika.detect.Detector;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.io.FilenameUtils;
-import org.apache.tika.io.IOExceptionWithCause;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Database;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.mime.MimeTypes;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.XHTMLContentHandler;
@@ -53,6 +51,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
+
+import dpf.sp.gpinf.indexer.util.IOUtil;
 
 /**
  * General base class to iterate through rows of a JDBC table
@@ -94,7 +94,7 @@ class JDBCTableReader {
                 return false;
             }
         } catch (SQLException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         try {
             ResultSetMetaData meta = results.getMetaData();
@@ -171,7 +171,7 @@ class JDBCTableReader {
                     headers.add(meta.getColumnName(i));
                 }
             } catch (SQLException e) {
-                throw new IOExceptionWithCause(e);
+                throw new IOException(e);
             }
         return headers;
     }
@@ -202,7 +202,7 @@ class JDBCTableReader {
         m.set(Metadata.CONTENT_LENGTH, Integer.toString(readSize));
         // just in case something screwy is going on with the column name
         String name = FilenameUtils.normalize(FilenameUtils.getName(columnName + "_" + rowNum + ".txt")); //$NON-NLS-1$ //$NON-NLS-2$
-        m.set(TikaMetadataKeys.RESOURCE_NAME_KEY, name);
+        m.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
         // is there a more efficient way to go from a Reader to an InputStream?
         String s = clob.getSubString(0, readSize);
         // EmbeddedDocumentExtractor ex =
@@ -245,7 +245,7 @@ class JDBCTableReader {
                 if (is.getLength() > MIN_SIZE) {
                     if (context.get(Parser.class) != null || !(ex instanceof ParsingEmbeddedDocumentExtractor)) {
                         String name = tableName + "_" + columnName + "_" + rowNum + ".data"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                        m.set(TikaMetadataKeys.RESOURCE_NAME_KEY, name);
+                        m.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
                         ex.parseEmbedded(is, handler, m, false);
                     }
                     return "[BLOB]";
@@ -264,7 +264,7 @@ class JDBCTableReader {
                         // swallow
                     }
                 }
-                IOUtils.closeQuietly(is);
+                IOUtil.closeQuietly(is);
             }
         return null;
     }
@@ -301,7 +301,7 @@ class JDBCTableReader {
 
         } catch (SQLException e) {
             results = null;
-            // throw new IOExceptionWithCause(e);
+            // throw new IOException(e);
         }
         rows = 0;
         return results;

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/SQLite3DBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/jdbc/SQLite3DBParser.java
@@ -29,7 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.tika.io.IOExceptionWithCause;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -71,7 +70,7 @@ public class SQLite3DBParser extends AbstractDBParser {
         try {
             Class.forName(getJDBCClassName());
         } catch (ClassNotFoundException e) {
-            throw new IOExceptionWithCause(e);
+            throw new IOException(e);
         }
         TemporaryResources tmp = new TemporaryResources();
         try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/sp/gpinf/indexer/parsers/util/MetadataUtil.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import org.apache.tika.metadata.IPTC;
 import org.apache.tika.metadata.Message;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.Office;
 import org.apache.tika.metadata.Property;
 import org.apache.tika.metadata.TIFF;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -163,7 +164,7 @@ public class MetadataUtil {
     
     private static Set<String> getIgnorePreviewMetas() {
         ignorePreviewMetas = new HashSet<>();
-        ignorePreviewMetas.add(Metadata.RESOURCE_NAME_KEY);
+        ignorePreviewMetas.add(TikaCoreProperties.RESOURCE_NAME_KEY);
         ignorePreviewMetas.add(Metadata.CONTENT_LENGTH);
         ignorePreviewMetas.add(Metadata.CONTENT_TYPE);
         ignorePreviewMetas.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE);
@@ -176,9 +177,9 @@ public class MetadataUtil {
         Set<String> generalKeys = new HashSet<String>();
 
         generalKeys.add(Metadata.CONTENT_TYPE);
-        generalKeys.add(Metadata.RESOURCE_NAME_KEY);
+        generalKeys.add(TikaCoreProperties.RESOURCE_NAME_KEY);
         generalKeys.add(Metadata.CONTENT_LENGTH);
-        generalKeys.add(Metadata.EMBEDDED_RELATIONSHIP_ID);
+        generalKeys.add(TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID);
         generalKeys.add(TikaCoreProperties.ORIGINAL_RESOURCE_NAME.getName());
         generalKeys.add(TikaCoreProperties.TIKA_META_EXCEPTION_WARNING.getName());
         generalKeys.add(TikaCoreProperties.TIKA_META_EXCEPTION_EMBEDDED_STREAM.getName());
@@ -234,7 +235,6 @@ public class MetadataUtil {
         props.add(TikaCoreProperties.CREATED);
         props.add(TikaCoreProperties.MODIFIED);
         props.add(TikaCoreProperties.COMMENTS);
-        props.add(TikaCoreProperties.KEYWORDS);
         props.add(TikaCoreProperties.FORMAT);
         props.add(TikaCoreProperties.IDENTIFIER);
         props.add(TikaCoreProperties.CONTRIBUTOR);
@@ -249,10 +249,7 @@ public class MetadataUtil {
         props.add(TikaCoreProperties.TITLE);
         props.add(TikaCoreProperties.DESCRIPTION);
         props.add(TikaCoreProperties.PRINT_DATE);
-        props.add(TikaCoreProperties.TRANSITION_KEYWORDS_TO_DC_SUBJECT);
-        props.add(TikaCoreProperties.TRANSITION_SUBJECT_TO_DC_DESCRIPTION);
-        props.add(TikaCoreProperties.TRANSITION_SUBJECT_TO_DC_TITLE);
-        props.add(TikaCoreProperties.TRANSITION_SUBJECT_TO_OO_SUBJECT);
+        props.add(Office.KEYWORDS);
         props.add(IPTC.COPYRIGHT_OWNER_ID);
         props.add(IPTC.IMAGE_CREATOR_ID);
         props.add(IPTC.IMAGE_SUPPLIER_ID);
@@ -274,7 +271,7 @@ public class MetadataUtil {
         props.add(TikaCoreProperties.CREATED.getName());
         props.add(TikaCoreProperties.MODIFIED.getName());
         props.add(TikaCoreProperties.COMMENTS.getName());
-        props.add(TikaCoreProperties.KEYWORDS.getName());
+        props.add(Office.KEYWORDS.getName());
 
         // set by PDF and rarely set by OpenOffice/DcXML parsers today
         // props.add(TikaCoreProperties.FORMAT.getName());

--- a/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/EmbeddedDocumentParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/EmbeddedDocumentParser.java
@@ -8,7 +8,7 @@ import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +80,7 @@ public class EmbeddedDocumentParser implements EmbeddedDocumentExtractor, Serial
 
     public static NameTitle getNameTitle(Metadata metadata, int child) {
         boolean hasTitle = false;
-        String name = metadata.get(TikaMetadataKeys.RESOURCE_NAME_KEY);
+        String name = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
         if (name == null || name.isEmpty()) {
             name = metadata.get(ExtraProperties.MESSAGE_SUBJECT);
             if (name == null || name.isEmpty()) {
@@ -91,7 +91,7 @@ public class EmbeddedDocumentParser implements EmbeddedDocumentExtractor, Serial
             }
         }
         if (name == null || name.isEmpty()) {
-            name = metadata.get(TikaMetadataKeys.EMBEDDED_RELATIONSHIP_ID);
+            name = metadata.get(TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID);
         }
 
         if (name == null || name.isEmpty()) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/ExternalParsingParserFactory.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/ExternalParsingParserFactory.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.CompositeParser;

--- a/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/ForkClient2.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/fork/ForkClient2.java
@@ -40,9 +40,9 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
-import org.apache.tika.io.IOUtils;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.utils.ProcessUtils;

--- a/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/parser/mp4/ISO6709Extractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/org/apache/tika/parser/mp4/ISO6709Extractor.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tika.parser.mp4;
+
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.tika.metadata.Metadata;
+
+/**
+ * 
+ * Copied and pasted from Tika-1.28.2.
+ */
+class ISO6709Extractor implements Serializable {
+    // based on: https://en.wikipedia.org/wiki/ISO_6709
+    // strip lat long -- ignore crs for now
+    private static final Pattern ISO6709_PATTERN = Pattern
+            .compile("\\A([-+])(\\d{2,6})(\\.\\d+)?([-+])(\\d{3,7})(\\.\\d+)?");
+
+    // must be thread safe
+    public void extract(String s, Metadata m) {
+        if (s == null) {
+            return;
+        }
+        Matcher matcher = ISO6709_PATTERN.matcher(s);
+        if (matcher.find()) {
+            String lat = getLat(matcher.group(1), matcher.group(2), matcher.group(3));
+            String lng = getLng(matcher.group(4), matcher.group(5), matcher.group(6));
+            m.set(Metadata.LATITUDE, lat);
+            m.set(Metadata.LONGITUDE, lng);
+        } else {
+            // ignore problems for now?
+        }
+
+    }
+
+    private String getLng(String sign, String integer, String flot) {
+        String flotNormed = (flot == null) ? "" : flot;
+        if (integer.length() == 3) {
+            return sign + integer + flotNormed;
+        } else if (integer.length() == 5) {
+            return calcDecimalDegrees(sign, integer.substring(0, 3), integer.substring(3, 5) + flotNormed);
+        } else if (integer.length() == 7) {
+            return calcDecimalDegrees(sign, integer.substring(0, 3), integer.substring(3, 5),
+                    integer.substring(5, 7) + flotNormed);
+        } else {
+            // ignore problems for now?
+        }
+        return "";
+    }
+
+    private String getLat(String sign, String integer, String flot) {
+        String flotNormed = (flot == null) ? "" : flot;
+        if (integer.length() == 2) {
+            return sign + integer + flotNormed;
+        } else if (integer.length() == 4) {
+            return calcDecimalDegrees(sign, integer.substring(0, 2), integer.substring(2, 4) + flotNormed);
+        } else if (integer.length() == 6) {
+            return calcDecimalDegrees(sign, integer.substring(0, 2), integer.substring(2, 4),
+                    integer.substring(4, 6) + flotNormed);
+        } else {
+            // ignore problems for now?
+        }
+        return "";
+    }
+
+    private String calcDecimalDegrees(String sign, String degrees, String minutes) {
+        double d = Integer.parseInt(degrees);
+        d += (Double.parseDouble(minutes) / 60);
+        return sign + String.format(Locale.ROOT, "%.8f", d);
+    }
+
+    private String calcDecimalDegrees(String sign, String degrees, String minutes, String seconds) {
+        double d = Integer.parseInt(degrees);
+        d += (Double.parseDouble(minutes) / 60);
+        d += (Double.parseDouble(seconds) / 3600);
+        return sign + String.format(Locale.ROOT, "%.8f", d);
+    }
+}

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/mg/udi/gpinf/whatsappextractor/WhatsAppParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/mg/udi/gpinf/whatsappextractor/WhatsAppParserTest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class WhatsAppParserTest extends AbstractPkgTest {
         WhatsAppParser parser = new WhatsAppParser();
         Metadata metadata = new Metadata();
         metadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, "application/x-whatsapp-db");
-        metadata.add(Metadata.RESOURCE_NAME_KEY, "msgstore-d4");
+        metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "msgstore-d4");
         ContentHandler handler = new BodyContentHandler(1 << 20);
         parser.setExtractMessages(true);
         parser.setMergeBackups(false);
@@ -95,7 +96,7 @@ public class WhatsAppParserTest extends AbstractPkgTest {
         WhatsAppParser parser = new WhatsAppParser();
         Metadata metadata = new Metadata();
         metadata.add(IndexerDefaultParser.INDEXER_CONTENT_TYPE, "application/x-whatsapp-db");
-        metadata.add(Metadata.RESOURCE_NAME_KEY, "msgstore-d4");
+        metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, "msgstore-d4");
         parser.setExtractMessages(true);
         parser.setMergeBackups(true);
         parser.getSupportedTypes(whatsappContext);

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/mt/gpinf/registro/RegistryParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/mt/gpinf/registro/RegistryParserTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.ToTextContentHandler;
 import org.junit.Test;
@@ -33,7 +33,7 @@ public class RegistryParserTest extends TestCase {
 
         RegistryParser parser = new RegistryParser();
         Metadata metadata = new Metadata();
-        metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, "SECURITY");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "SECURITY");
         ContentHandler handler = new ToTextContentHandler();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("test-files/test_security").toURI());
@@ -58,7 +58,7 @@ public class RegistryParserTest extends TestCase {
 
         RegistryParser parser = new RegistryParser();
         Metadata metadata = new Metadata();
-        metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, "SAM");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "SAM");
         ContentHandler handler = new ToTextContentHandler();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("test-files/test_sam").toURI());
@@ -81,7 +81,7 @@ public class RegistryParserTest extends TestCase {
     public void testRegistroParserSYSTEM() throws IOException, SAXException, TikaException, URISyntaxException {
         RegistryParser parser = new RegistryParser();
         Metadata metadata = new Metadata();
-        metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, "SYSTEM");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "SYSTEM");
         ContentHandler handler = new ToTextContentHandler();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("test-files/test_system").toURI());
@@ -112,7 +112,7 @@ public class RegistryParserTest extends TestCase {
 
         RegistryParser parser = new RegistryParser();
         Metadata metadata = new Metadata();
-        metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, "SOFTWARE");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "SOFTWARE");
         ContentHandler handler = new ToTextContentHandler();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("test-files/test_software").toURI());
@@ -143,7 +143,7 @@ public class RegistryParserTest extends TestCase {
 
         RegistryParser parser = new RegistryParser();
         Metadata metadata = new Metadata();
-        metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, "NTUSER.DAT");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "NTUSER.DAT");
         ContentHandler handler = new ToTextContentHandler();
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("test-files/test_ntuser.dat").toURI());

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/AbstractPkgTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/AbstractPkgTest.java
@@ -91,8 +91,8 @@ public abstract class AbstractPkgTest extends TestCase {
 
             subitemCount++;
             String hdigest = new DigestUtils(MD5).digestAsHex(stream);
-            if (metadata.get(Metadata.RESOURCE_NAME_KEY) != null)
-                filenames.add(metadata.get(Metadata.RESOURCE_NAME_KEY));
+            if (metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY) != null)
+                filenames.add(metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
             if (metadata.get(TikaCoreProperties.MODIFIED) != null)
                 modifieddate.add(metadata.get(TikaCoreProperties.MODIFIED));
             itensmd5.add(hdigest.toUpperCase());
@@ -188,8 +188,8 @@ public abstract class AbstractPkgTest extends TestCase {
             // attachment
             if (metadata.get(ExtraProperties.MESSAGE_IS_ATTACHMENT) != null || false)
                 isattachment.add(metadata.get(ExtraProperties.MESSAGE_IS_ATTACHMENT));
-            if (metadata.get(Metadata.RESOURCE_NAME_KEY) != null)
-                attachmentname.add(metadata.get(Metadata.RESOURCE_NAME_KEY));
+            if (metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY) != null)
+                attachmentname.add(metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY));
             if ((metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT) != null))
                 numberofattachments.add(metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT));
             // contact

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/IndexerDefaultParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/IndexerDefaultParserTest.java
@@ -4,17 +4,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
 import org.junit.Test;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+
+import iped3.util.ExtraProperties;
 import junit.framework.TestCase;
 
 public class IndexerDefaultParserTest extends TestCase {
 
     // This class will test some files such as: Image, Video, Document, Text,
     // Package, PDF and an Unknown file type.
+
+    private static final String PARSED_BY = ExtraProperties.TIKA_PARSER_USED;
 
     private static InputStream getStream(String name) {
         return Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
@@ -54,7 +59,7 @@ public class IndexerDefaultParserTest extends TestCase {
             String mts = metadata.toString();
 
             assertTrue(hts.contains("Indexer-Content-Type: image/png"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.image.ImageParser"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.image.ImageParser"));
             assertTrue(hts.contains(
                     "image:IHDR: width=512, height=512, bitDepth=8, colorType=RGB, compressionMethod=deflate, filterMethod=adaptive"));
             assertTrue(hts.contains("image:tiff:BitsPerSample: 8 8 8"));
@@ -84,7 +89,7 @@ public class IndexerDefaultParserTest extends TestCase {
             String mts = metadata.toString();
 
             assertTrue(hts.contains("Indexer-Content-Type: video/x-flv"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.video.FLVParser"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.video.FLVParser"));
             assertTrue(hts.contains("video:audiocodecid: 2.0"));
             assertTrue(hts.contains("video:audiodatarate: 0.0"));
             assertTrue(hts.contains("video:audiosamplerate: 44100.0"));
@@ -132,28 +137,18 @@ public class IndexerDefaultParserTest extends TestCase {
 
             assertTrue(hts.contains(
                     "Indexer-Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.microsoft.ooxml.OOXMLParser"));
-            assertTrue(hts.contains("office:Application-Name: Microsoft Office Word"));
-            assertTrue(hts.contains("office:Application-Version: 12.0000"));
-            assertTrue(hts.contains("office:Character Count: 2724"));
-            assertTrue(hts.contains("office:Character-Count-With-Spaces: 3222"));
-            assertTrue(hts.contains("office:Line-Count: 22"));
-            assertTrue(hts.contains("office:Page-Count: 1"));
-            assertTrue(hts.contains("office:Paragraph-Count: 6"));
-            assertTrue(hts.contains("office:Revision-Number: 5"));
-            assertTrue(hts.contains("office:Template: Normal.dotm"));
-            assertTrue(hts.contains("office:Word-Count: 504"));
-            assertTrue(hts.contains("office:cp:revision: 5"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.microsoft.ooxml.OOXMLParser"));
             assertTrue(hts.contains("common:dc:creator: Guilherme Andreúce Sobreira Monteiro"));
             assertTrue(hts.contains("common:dcterms:created: 2021-04-08T17:03:00Z"));
             assertTrue(hts.contains("common:dcterms:modified: 2021-04-09T12:25:00Z"));
+            assertTrue(hts.contains("common:meta:last-author: Guilherme Andreúce Sobreira Monteiro"));
+            assertTrue(hts.contains("office:cp:revision: 5"));
             assertTrue(hts.contains("office:extended-properties:AppVersion: 12.0000"));
             assertTrue(hts.contains("office:extended-properties:Application: Microsoft Office Word"));
             assertTrue(hts.contains("office:extended-properties:DocSecurityString: None"));
             assertTrue(hts.contains("office:extended-properties:Template: Normal.dotm"));
             assertTrue(hts.contains("office:meta:character-count: 2724"));
             assertTrue(hts.contains("office:meta:character-count-with-spaces: 3222"));
-            assertTrue(hts.contains("common:meta:last-author: Guilherme Andreúce Sobreira Monteiro"));
             assertTrue(hts.contains("office:meta:line-count: 22"));
             assertTrue(hts.contains("office:meta:page-count: 1"));
             assertTrue(hts.contains("office:meta:paragraph-count: 6"));
@@ -188,10 +183,10 @@ public class IndexerDefaultParserTest extends TestCase {
 
             assertTrue(hts.contains("Content-Encoding: UTF-8"));
             assertTrue(hts.contains("Indexer-Content-Type: text/plain"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.csv.TextAndCSVParser"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.csv.TextAndCSVParser"));
 
             assertTrue(mts.contains("Content-Type=text/plain"));
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.csv.TextAndCSVParser"));
+            assertTrue(mts.contains(PARSED_BY + "=org.apache.tika.parser.csv.TextAndCSVParser"));
             assertTrue(mts.contains("charset=UTF-8"));
 
         }
@@ -232,10 +227,10 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("mockdoc5.docx"));
 
             assertTrue(hts.contains("Indexer-Content-Type: application/x-rar-compressed; version=4"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.pkg.RarParser"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.pkg.RarParser"));
 
             assertTrue(mts.contains("Indexer-Content-Type=application/x-rar-compressed; version=4"));
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.pkg.RarParser"));
+            assertTrue(mts.contains(PARSED_BY + "=org.apache.tika.parser.pkg.RarParser"));
             assertTrue(mts.contains("Content-Type=application/x-rar-compressed; version=4"));
 
         }
@@ -260,7 +255,7 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("UROP-Diabetes Management Project February 2016-Present"));
 
             assertTrue(hts.contains("Indexer-Content-Type: application/pdf"));
-            assertTrue(hts.contains("X-Parsed-By: org.apache.tika.parser.pdf.PDFParser"));
+            assertTrue(hts.contains(PARSED_BY + ": org.apache.tika.parser.pdf.PDFParser"));
             assertTrue(hts.contains("pdf:PDFExtensionVersion: 1.7 Adobe Extension Level 8"));
             assertTrue(hts.contains("pdf:PDFVersion: 1.7"));
             assertTrue(hts.contains("pdf:access_permission:assemble_document: true"));
@@ -271,11 +266,8 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("pdf:access_permission:extract_for_accessibility: true"));
             assertTrue(hts.contains("pdf:access_permission:fill_in_form: true"));
             assertTrue(hts.contains("pdf:access_permission:modify_annotations: true"));
-            assertTrue(hts
-                    .contains("pdf:charsPerPage: 2767 2772 2990 3056 3204 3614 3627 3796 3971 3988 4242 4462 4683 64"));
-            assertTrue(hts.contains("pdf:created: 2017-08-29T19:12:20Z"));
-            assertTrue(hts.contains(
-                    "pdf:dc:format: application/pdf; version=\"1.7 Adobe Extension Level 8\" application/pdf; version=1.7"));
+            assertTrue(hts.contains("pdf:charsPerPage: 2767 2772 2990 3056 3204 3614 3627 3796 3971 3988 4242 4462 4683 64"));
+            assertTrue(hts.contains("pdf:dc:format: application/pdf; version=\"1.7 Adobe Extension Level 8\" application/pdf; version=1.7"));
             assertTrue(hts.contains("common:dc:language: en-US"));
             assertTrue(hts.contains("common:dcterms:created: 2017-08-29T19:12:20Z"));
             assertTrue(hts.contains("common:dcterms:modified: 2017-09-12T19:12:44Z"));
@@ -289,7 +281,6 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("pdf:hasXFA: false"));
             assertTrue(hts.contains("pdf:hasXMP: true"));
             assertTrue(hts.contains("pdf:producer: Adobe PDF Library 15.0"));
-            assertTrue(hts.contains("pdf:trapped: False"));
             assertTrue(hts.contains("pdf:unmappedUnicodeCharsPerPage: 0"));
             assertTrue(hts.contains("pdf:xmp:CreateDate: 2017-08-29T14:12:20Z"));
             assertTrue(hts.contains("common:xmp:CreatorTool: Adobe InDesign CC 2017 (Macintosh)"));
@@ -301,7 +292,7 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("pdf:xmpTPg:NPages: 14"));
 
             assertTrue(mts.contains("Content-Type=application/pdf"));
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.pdf.PDFParser"));
+            assertTrue(mts.contains(PARSED_BY + "=org.apache.tika.parser.pdf.PDFParser"));
             assertTrue(mts.contains("pdf:PDFVersion=1.7"));
 
         }
@@ -326,7 +317,7 @@ public class IndexerDefaultParserTest extends TestCase {
             assertTrue(hts.contains("OnATTACK_OBJECT_CMD (id)"));
 
             assertTrue(mts.contains("Content-Type=text/plain; charset=EUC-KR"));
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.csv.TextAndCSVParser"));
+            assertTrue(mts.contains(PARSED_BY + "=org.apache.tika.parser.csv.TextAndCSVParser"));
             assertTrue(mts.contains("Content-Encoding=EUC-KR"));
 
         }
@@ -347,7 +338,7 @@ public class IndexerDefaultParserTest extends TestCase {
 
             String mts = metadata.toString();
 
-            assertTrue(mts.contains("X-Parsed-By=dpf.sp.gpinf.indexer.parsers.RawStringParser"));
+            assertEquals("dpf.sp.gpinf.indexer.parsers.RawStringParser", metadata.get(PARSED_BY));
             assertTrue(mts.contains("compressRatioLZ4=0.5720935240387917"));
             assertTrue(mts.contains("Content-Type=application/octet-stream"));
 
@@ -366,7 +357,7 @@ public class IndexerDefaultParserTest extends TestCase {
             parser.parse(stream, handler, metadata, context);
 
             String mts = metadata.toString();
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.microsoft.OfficeParser"));
+            assertTrue(mts.contains(PARSED_BY + "=org.apache.tika.parser.microsoft.OfficeParser"));
             assertTrue(mts.contains("Indexer-Content-Type=application/x-tika-ooxml-protected"));
             assertTrue(mts.contains("encryptedDocument=true"));
             assertTrue(mts.contains("Content-Type=application/x-tika-ooxml-protected"));

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MSAccessParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MSAccessParserTest.java
@@ -2,10 +2,12 @@ package dpf.sp.gpinf.indexer.parsers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaMetadataKeys;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.sax.BodyContentHandler;
@@ -45,15 +47,14 @@ public class MSAccessParserTest extends TestCase {
         Metadata metadata = new Metadata();
         BodyContentHandler handler = new BodyContentHandler();
         ParseContext context = new ParseContext();
-        metadata.add(TikaMetadataKeys.RESOURCE_NAME_KEY, filepath);
+        metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, filepath);
         context.set(Parser.class, parser);
         try (InputStream stream = getStream(filepath)) {
             parser.parse(stream, handler, metadata, context);
-
-            assertEquals("Arial Software", metadata.get(metadata.COMPANY));
-            assertEquals("Arial Software", metadata.get(metadata.AUTHOR));
+            assertEquals("Arial Software", metadata.get("Company"));
+            assertEquals("Arial Software", metadata.get("Author"));
             assertEquals("application/x-msaccess", metadata.get(metadata.CONTENT_TYPE));
-            assertEquals("Campaign_Template", metadata.get(StringUtils.capitalize(metadata.TITLE)));
+            assertEquals("Campaign_Template", metadata.get("Title"));
 
         }
     }

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MSGParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MSGParserTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.junit.Test;
 import org.xml.sax.ContentHandler;
@@ -49,7 +50,7 @@ public class MSGParserTest extends AbstractPkgTest {
         msgContext.set(EmbeddedDocumentExtractor.class, embeddedTracker);
         try (InputStream stream = getStream("test-files/test_msgSample.msg")) {
             parser.parse(stream, handler, metadata, msgContext);
-            assertEquals("Aula 02 No Ar! Semana Javascript Expert", metadata.get(Metadata.SUBJECT));
+            assertEquals("Aula 02 No Ar! Semana Javascript Expert", metadata.get(TikaCoreProperties.SUBJECT));
             assertEquals("Erick Wendel", metadata.get(Metadata.MESSAGE_FROM));
             assertEquals("Guilherme Monteiro", metadata.get(Metadata.MESSAGE_TO));
             assertEquals(0, embeddedTracker.attachmentsMeta.size());
@@ -72,7 +73,7 @@ public class MSGParserTest extends AbstractPkgTest {
             parser.parse(stream, handler, metadata, msgContext);
 
             assertEquals("[cic-bcc-l] Passe Estudantil - Atividades em Per?odo de F?rias",
-                    metadata.get(Metadata.SUBJECT));
+                    metadata.get(TikaCoreProperties.SUBJECT));
             assertEquals("Lista Informativa do Curso de Bacharelado em Ciência da Computação",
                     metadata.get(Metadata.MESSAGE_FROM));
             assertEquals(

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MultipleParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/MultipleParserTest.java
@@ -4,12 +4,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.executable.ExecutableParser;
 import org.apache.tika.sax.BodyContentHandler;
 import org.junit.Test;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+
+import iped3.util.ExtraProperties;
 import junit.framework.TestCase;
 
 public class MultipleParserTest extends TestCase {
@@ -46,8 +49,8 @@ public class MultipleParserTest extends TestCase {
             assertTrue(hts.contains("C:\\ARJ\\ -m -b -x"));
             assertTrue(hts.contains("ARJ32 v 3.10/Win32"));
 
-            assertTrue(mts.contains("X-Parsed-By=org.apache.tika.parser.executable.ExecutableParser"));
-            assertTrue(mts.contains("X-Parsed-By=dpf.sp.gpinf.indexer.parsers.RawStringParser"));
+            assertTrue(mts.contains(ExtraProperties.TIKA_PARSER_USED + "=org.apache.tika.parser.executable.ExecutableParser"));
+            assertTrue(mts.contains(ExtraProperties.TIKA_PARSER_USED + "=dpf.sp.gpinf.indexer.parsers.RawStringParser"));
             assertTrue(mts.contains("machine:endian=Little"));
             assertTrue(mts.contains("machine:platform=Windows"));
             assertTrue(mts.contains("machine:architectureBits=32"));

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/PDFOCRTextParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/PDFOCRTextParserTest.java
@@ -48,13 +48,14 @@ public class PDFOCRTextParserTest extends TestCase {
 
             String mts = metadata.toString();
 
-            assertEquals("PScript5.dll Version 5.2", metadata.get(Metadata.CREATOR));
-            assertEquals("Speeches by Andrew G Haldane", metadata.get(Metadata.SUBJECT));
-            assertEquals("The Bank of England", metadata.get(Metadata.AUTHOR));
-            assertEquals("April 28, 2009 10:06:56 (UTC +01:00)", metadata.get(Metadata.CREATION_DATE));
+            assertEquals("PScript5.dll Version 5.2", metadata.getValues(TikaCoreProperties.CREATOR)[1]);
+            assertEquals("Acrobat Distiller 7.0.5 (Windows)", metadata.get(TikaCoreProperties.CREATOR_TOOL));
+            assertEquals("Speeches by Andrew G Haldane", metadata.get(TikaCoreProperties.SUBJECT));
+            assertEquals("The Bank of England", metadata.get(TikaCoreProperties.CREATOR));
+            assertEquals("April 28, 2009 10:06:56 (UTC +01:00)", metadata.get(TikaCoreProperties.CREATED));
             assertEquals(
                     "Rethinking the Financial Network, Speech by Andrew G Haldane, Executive Director, Financial Stability delivered at the Financial Student Association, Amsterdam on 28 April 2009",
-                    metadata.get(Metadata.TITLE));
+                    metadata.get(TikaCoreProperties.TITLE));
             assertEquals("application/pdf", metadata.get(Metadata.CONTENT_TYPE));
             assertTrue(mts.contains("Content-Type=application/pdf"));
         }
@@ -77,10 +78,10 @@ public class PDFOCRTextParserTest extends TestCase {
                             + " Executive Director, Financial Stability delivered at the Financial"
                             + " Student Association, Amsterdam on 28 April 2009",
                     metadata.get(TikaCoreProperties.TITLE));
-            assertEquals("Speeches by Andrew G Haldane", metadata.get(Metadata.SUBJECT));
+            assertEquals("Speeches by Andrew G Haldane", metadata.get(TikaCoreProperties.SUBJECT));
             assertEquals("The Bank of England", metadata.get(TikaCoreProperties.CREATOR));
-            assertEquals(metadata.get(TikaCoreProperties.CREATOR), metadata.get(metadata.AUTHOR));
-            assertEquals("Speeches by Andrew G Haldane", metadata.get(metadata.DESCRIPTION));
+            assertEquals("PScript5.dll Version 5.2", metadata.get(TikaCoreProperties.CREATOR_TOOL));
+            assertEquals("Speeches by Andrew G Haldane", metadata.get(TikaCoreProperties.DESCRIPTION));
         }
 
     }
@@ -161,8 +162,7 @@ public class PDFOCRTextParserTest extends TestCase {
             assertEquals("g2free.lo", metadata.get(TikaCoreProperties.TITLE));
             assertEquals("QuarkXPress(tm) 4.11", metadata.get(TikaCoreProperties.CREATOR_TOOL));
             assertEquals("E", metadata.get(TikaCoreProperties.CREATOR));
-            assertEquals(metadata.get(TikaCoreProperties.CREATOR), metadata.get(metadata.AUTHOR));
-            assertEquals("2002-02-21", metadata.get(metadata.CREATION_DATE).substring(0, 10));
+            assertEquals("2002-02-21", metadata.get(TikaCoreProperties.CREATED).substring(0, 10));
         }
     }
 

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RARParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RARParserTest.java
@@ -100,7 +100,7 @@ public class RARParserTest extends AbstractPkgTest {
 
             assertEquals("mockfolder", tracker.filenames.get(0));
             Date date = parseFromDefaultDateFormat(tracker.modifieddate.get(0));
-            assertEquals(df.parse("09/04/2021 08:26:10"), date);
+            assertEquals(df.parse("09/04/2021 08:26:11"), date);
             assertEquals("D41D8CD98F00B204E9800998ECF8427E", tracker.itensmd5.get(0));
             assertEquals("true", tracker.isfolder.get(0));
 
@@ -136,13 +136,13 @@ public class RARParserTest extends AbstractPkgTest {
 
             assertEquals("mocksheets3.xlsx", tracker.filenames.get(6));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(6));
-            assertEquals(df.parse("09/04/2021 09:24:00"), date);
+            assertEquals(df.parse("09/04/2021 09:24:01"), date);
             assertEquals("70699181ACE6063C5565C1655E5F8661", tracker.itensmd5.get(6));
             assertEquals("false", tracker.isfolder.get(6));
 
             assertEquals("mocksheets4.xlsx", tracker.filenames.get(7));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(7));
-            assertEquals(df.parse("09/04/2021 09:23:48"), date);
+            assertEquals(df.parse("09/04/2021 09:23:49"), date);
             assertEquals("5EB65E9DE8B5C7756101AE7D81CA4A50", tracker.itensmd5.get(7));
             assertEquals("false", tracker.isfolder.get(7));
 
@@ -166,13 +166,13 @@ public class RARParserTest extends AbstractPkgTest {
 
             assertEquals("mocktext3.txt", tracker.filenames.get(11));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(11));
-            assertEquals(df.parse("09/04/2021 09:22:40"), date);
+            assertEquals(df.parse("09/04/2021 09:22:41"), date);
             assertEquals("C03511CB57B7B5D71D0B0848D26EB6FE", tracker.itensmd5.get(11));
             assertEquals("false", tracker.isfolder.get(11));
 
             assertEquals("mocktext4.txt", tracker.filenames.get(12));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(12));
-            assertEquals(df.parse("09/04/2021 09:22:46"), date);
+            assertEquals(df.parse("09/04/2021 09:22:47"), date);
             assertEquals("C2186D0182395690DC449FB589423050", tracker.itensmd5.get(12));
             assertEquals("false", tracker.isfolder.get(12));
 
@@ -196,7 +196,7 @@ public class RARParserTest extends AbstractPkgTest {
 
             assertEquals("mockfolder/mocktext5.txt", tracker.filenames.get(16));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(16));
-            assertEquals(df.parse("09/04/2021 09:26:00"), date);
+            assertEquals(df.parse("09/04/2021 09:26:01"), date);
             assertEquals("6212E7FBA5A8FE2FFF5EEA267D4009BE", tracker.itensmd5.get(16));
             assertEquals("false", tracker.isfolder.get(16));
 
@@ -208,7 +208,7 @@ public class RARParserTest extends AbstractPkgTest {
 
             assertEquals("mockfolder/mocksheets5.xlsx", tracker.filenames.get(18));
             date = parseFromDefaultDateFormat(tracker.modifieddate.get(18));
-            assertEquals(df.parse("09/04/2021 09:26:16"), date);
+            assertEquals(df.parse("09/04/2021 09:26:17"), date);
             assertEquals("0E3FD8870A4F85F0975DEBD0C8E24ECF", tracker.itensmd5.get(18));
             assertEquals("false", tracker.isfolder.get(18));
         }

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RFC822ParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RFC822ParserTest.java
@@ -52,7 +52,7 @@ public class RFC822ParserTest extends TestCase {
                             + "test=test#test ] Guilherme Andreuce com(...)",
                     metadata.get(ExtraProperties.MESSAGE_BODY));
             assertEquals("2021-04-12T08:25:34Z", metadata.get(ExtraProperties.MESSAGE_DATE));
-            assertEquals("Guilherme Andreuce <guilhermeandreuce@gmail.com>", metadata.get(Metadata.AUTHOR));
+            assertEquals("Guilherme Andreuce <guilhermeandreuce@gmail.com>", metadata.get(TikaCoreProperties.CREATOR));
             assertEquals("test@test.pf.gov", metadata.get(Metadata.MESSAGE_TO));
             assertEquals("0", metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT));
             assertEquals(null, metadata.get(ExtraProperties.MESSAGE_IS_ATTACHMENT));
@@ -84,14 +84,13 @@ public class RFC822ParserTest extends TestCase {
             String hts = handler.toString();
             assertTrue(hts.contains("logo.gif"));
             assertEquals("DigitalPebble <julien@digitalpebble.com>", metadata.get(TikaCoreProperties.CREATOR));
-            assertEquals("DigitalPebble <julien@digitalpebble.com>", metadata.get(Metadata.AUTHOR));
             assertEquals("This is a test for parsing multi-part mails. "
                     + "With some funky HTML code an a picture attached. " + "Text specific to body 1. -- ** *(...)",
                     metadata.get(ExtraProperties.MESSAGE_BODY));
             assertEquals(null, metadata.get(ExtraProperties.MESSAGE_IS_ATTACHMENT));
             assertEquals("lists.digitalpebble@gmail.com", metadata.get(Metadata.MESSAGE_TO));
             assertEquals("1", metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT));
-            assertEquals("Test Multi Part Message", metadata.get(Metadata.TITLE));
+            assertEquals("Test Multi Part Message", metadata.get(TikaCoreProperties.TITLE));
         }
 
     }
@@ -110,13 +109,12 @@ public class RFC822ParserTest extends TestCase {
             // Unicode
             assertEquals("Another Person <another.person@another-example.com>",
                     metadata.get(TikaCoreProperties.CREATOR));
-            assertEquals("Another Person <another.person@another-example.com>", metadata.get(Metadata.AUTHOR));
             assertEquals("Düsseldorf has non-ascii. Lines can be split like this. Spaces at the end of a line \r\n"
                     + "must be encoded.", metadata.get(ExtraProperties.MESSAGE_BODY));
             assertEquals(null, metadata.get(ExtraProperties.MESSAGE_IS_ATTACHMENT));
             assertEquals("A. Person <a.person@example.com>", metadata.get(Metadata.MESSAGE_TO));
             assertEquals("0", metadata.get(ExtraProperties.MESSAGE_ATTACHMENT_COUNT));
-            assertEquals("Sample with Quoted Printable Text", metadata.get(Metadata.TITLE));
+            assertEquals("Sample with Quoted Printable Text", metadata.get(TikaCoreProperties.TITLE));
         }
 
     }

--- a/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RegistryParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/dpf/sp/gpinf/indexer/parsers/RegistryParserTest.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.BodyContentHandler;
 import org.junit.BeforeClass;
@@ -35,7 +36,7 @@ public class RegistryParserTest {
         Metadata metadata = new Metadata();
         ContentHandler handler = new BodyContentHandler(28000000);
         ParseContext context = new ParseContext();
-        metadata.set(Metadata.RESOURCE_NAME_KEY, "software");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "software");
         parser.getSupportedTypes(context);
         try (InputStream stream = getStream("test-files/test_software")) {
             parser.parse(stream, handler, metadata, context);
@@ -56,7 +57,7 @@ public class RegistryParserTest {
         ContentHandler handler = new BodyContentHandler();
         ParseContext context = new ParseContext();
         parser.getSupportedTypes(context);
-        metadata.set(Metadata.RESOURCE_NAME_KEY, "sam");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "sam");
         try (InputStream stream = getStream("test-files/test_sam")) {
             parser.parse(stream, handler, metadata, context);
             String hts = handler.toString();
@@ -75,7 +76,7 @@ public class RegistryParserTest {
         Metadata metadata = new Metadata();
         ContentHandler handler = new BodyContentHandler();
         ParseContext context = new ParseContext();
-        metadata.set(Metadata.RESOURCE_NAME_KEY, "security");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "security");
         parser.getSupportedTypes(context);
         try (InputStream stream = getStream("test-files/test_security")) {
             parser.parse(stream, handler, metadata, context);
@@ -95,7 +96,7 @@ public class RegistryParserTest {
         Metadata metadata = new Metadata();
         ContentHandler handler = new BodyContentHandler(6000000);
         ParseContext context = new ParseContext();
-        metadata.set(Metadata.RESOURCE_NAME_KEY, "system");
+        metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, "system");
         parser.getSupportedTypes(context);
         try (InputStream stream = getStream("test-files/test_system")) {
             parser.parse(stream, handler, metadata, context);

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/EmailViewer.java
@@ -63,6 +63,7 @@ import dpf.sp.gpinf.indexer.util.IOUtil;
 import dpf.sp.gpinf.indexer.util.LuceneSimpleHTMLEncoder;
 import iped3.IItemBase;
 import iped3.io.IStreamSource;
+import iped3.util.ExtraProperties;
 
 public class EmailViewer extends HtmlViewer {
 
@@ -235,8 +236,7 @@ public class EmailViewer extends HtmlViewer {
             writer.write("<div class=\"ipedtheme\">");
             
             String[][] names = {
-                    { TikaCoreProperties.TRANSITION_SUBJECT_TO_DC_TITLE.getName(),
-                            Messages.getString("EmailViewer.Subject") }, //$NON-NLS-1$
+                    { ExtraProperties.MESSAGE_SUBJECT, Messages.getString("EmailViewer.Subject") }, //$NON-NLS-1$
                     { Message.MESSAGE_FROM, Messages.getString("EmailViewer.From") }, //$NON-NLS-1$
                     { Message.MESSAGE_TO, Messages.getString("EmailViewer.To") }, //$NON-NLS-1$
                     { Message.MESSAGE_CC, Messages.getString("EmailViewer.Cc") }, //$NON-NLS-1$
@@ -497,7 +497,7 @@ public class EmailViewer extends HtmlViewer {
                     }
                 } else if (fieldname.equalsIgnoreCase("Subject")) { //$NON-NLS-1$
                     String subject = decodeIfUtf8(((UnstructuredField) parsedField).getValue());
-                    metadata.add(TikaCoreProperties.TRANSITION_SUBJECT_TO_DC_TITLE, subject);
+                    metadata.add(ExtraProperties.MESSAGE_SUBJECT, subject);
 
                 } else if (fieldname.equalsIgnoreCase("To")) { //$NON-NLS-1$
                     processAddressList(parsedField, "To:", Message.MESSAGE_TO); //$NON-NLS-1$

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/MsgViewer.java
@@ -34,7 +34,7 @@ import org.apache.tika.Tika;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.html.HtmlEncodingDetector;
-import org.apache.tika.parser.rtf.RTFParser;
+import org.apache.tika.parser.microsoft.rtf.RTFParser;
 import org.bbottema.rtftohtml.RTF2HTMLConverter;
 import org.bbottema.rtftohtml.impl.RTF2HTMLConverterRFCCompliant;
 import org.slf4j.Logger;

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <plugin.rsc>${basedir}/resources/plugins</plugin.rsc>
         
         <!--dependencies-->
-        <tika.version>1.26</tika.version>
+        <tika.version>2.4.0</tika.version>
         <lucene.version>9.0.0</lucene.version>
         <sleuthkit.version>4.11.1-p2</sleuthkit.version>
         <libreoffice.version>7.2.2</libreoffice.version>
@@ -108,6 +108,14 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <forceJavacCompilerUse>false</forceJavacCompilerUse>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This will close #1029 and should fix #843, fix #1017 and fix #1071 when finished. TODOs:

- [ ] Check if email parsers and viewers are still extracting 'subject' correctly, since old deprecated metadata was removed
- [ ] Fix aborting "LinkageError: loader constraint violation", caused by our custom class loader, this may need #1083
- [ ] Run on a large dataset and compare results with previous version looking for regressions
- [ ] Look for ClassNotFound, NoClassDefFound and NoSuchMethodError in log of previous run to verify updated dependencies compatibilities
- [ ] Collect new common properties and update metadataTypes.txt