### PR TITLE
VideoThumbs as Subitems

### DIFF
--- a/iped-app/resources/config/conf/VideoThumbsConfig.txt
+++ b/iped-app/resources/config/conf/VideoThumbsConfig.txt
@@ -25,7 +25,13 @@ Verbose = false
 # Format: <gallery image width in pixels, minimum number of frames, maximum of frames frames>.
 GalleryThumbs = 320,2,3
 
-# Enables video frames extraction using original video resolution.
+# Enables video frames extraction as video subitems.
+# If enabled, parallel to videoThumbs creation, video frames are to be created
+# as video subitems, so video frames will able to participate of the 
+# image processing pipeline (ocr, image similarity, and others)
+enableVideoThumbsSubitems = false
+
+# Enables video frames extraction using original video resolution to be applied on Video Thumbs Subitems.
 # If enabled, first value of 'Layout' option above will be ignored.
 # This should help face detection on videos and other future features (like video ocr, so on...)
 enableVideoThumbsOriginalDimension = false

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/VideoThumbsConfig.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/config/VideoThumbsConfig.java
@@ -29,6 +29,8 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     private static final String ORIGINAL_DIMENSION = "enableVideoThumbsOriginalDimension";
 
+    private static final String THUMBS_SUBITEMS = "enableVideoThumbsSubitems";
+
     private static final String MAX_DIMENSION_SIZE = "maxDimensionSize";
 
     /**
@@ -74,6 +76,11 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
      * Extracts video frames using original video resolution.
      */
     private Boolean videoThumbsOriginalDimension = false;
+
+    /**
+     * Extracts video frames as video subitems, for video frame pipelining purpouse .
+     */
+    private Boolean videoThumbsSubitems = false;
 
     /**
      * Max dimension size to use when extracting frames. Currently this has
@@ -125,6 +132,10 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         return videoThumbsOriginalDimension;
     }
 
+    public Boolean getVideoThumbsSubitems() {
+        return videoThumbsSubitems;
+    }
+
     public int getMaxDimensionSize() {
         return maxDimensionSize;
     }
@@ -159,10 +170,16 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
             verbose = true;
         }
 
-        // Verbose do MPlayer
+        // VideoThumbsOriginalDimension
         value = properties.getProperty(ORIGINAL_DIMENSION); // $NON-NLS-1$
         if (value != null && value.trim().equalsIgnoreCase("true")) { //$NON-NLS-1$
             videoThumbsOriginalDimension = true;
+        }
+
+        // VideoThumbsSubitems
+        value = properties.getProperty(THUMBS_SUBITEMS); // $NON-NLS-1$
+        if (value != null && value.trim().equalsIgnoreCase("true")) { //$NON-NLS-1$
+            videoThumbsSubitems = true;
         }
 
         // Timeouts

--- a/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
+++ b/iped-engine/src/main/java/dpf/sp/gpinf/indexer/process/task/VideoThumbTask.java
@@ -257,7 +257,8 @@ public class VideoThumbTask extends ThumbTask {
         videoThumbsMaker.setTimeoutInfo(videoConfig.getTimeoutInfo());
         videoThumbsMaker.setVideoThumbsOriginalDimension(videoConfig.getVideoThumbsOriginalDimension());
         videoThumbsMaker.setMaxDimensionSize(videoConfig.getMaxDimensionSize());
-
+        videoThumbsMaker.setVideoThumbsSubitems(videoConfig.getVideoThumbsSubitems());
+  
         // Cria configurações de extração de cenas
         configs = new ArrayList<VideoThumbsOutputConfig>();
         configs.add(mainConfig = new VideoThumbsOutputConfig(null, videoConfig.getWidth(), videoConfig.getColumns(), videoConfig.getRows(), 2));
@@ -382,7 +383,9 @@ public class VideoThumbTask extends ThumbTask {
                 }
 
                 long t = System.currentTimeMillis();
-                r = videoThumbsMaker.createThumbs(evidence.getTempFile(), tmpFolder, configs, numFrames);
+                
+                r = videoThumbsMaker.createThumbs(this.worker, evidence, tmpFolder, configs, numFrames);
+                
                 t = System.currentTimeMillis() - t;
                 if (r != null && isAnimated) {
                     //Clear video duration for animated images


### PR DESCRIPTION
This PR makes videoThumbs images as subitems of the video, making frames as images that would be automatically added to image processing pipeline (OCR, Image Similarity, face similarity, and others).
 
Also it removes VideoThumbsOriginalDimension from video mosaic and it only applies the original dimension option on the video subitems images (@tc-wleite suggestion). 