### PR TITLE
fixes #1187 & closes #1188:

### DIFF
--- a/iped-engine/src/main/java/iped/engine/sleuthkit/SleuthkitClient.java
+++ b/iped-engine/src/main/java/iped/engine/sleuthkit/SleuthkitClient.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tika.utils.SystemUtils;
@@ -44,7 +45,7 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
 
     private static List<SleuthkitClient> clientsList = new ArrayList<>();
 
-    public static int NUM_TSK_SERVERS;
+    public static final int NUM_TSK_SERVERS;
 
     private static final HashMap<String, String> newEnvVars = new HashMap<>();
 
@@ -56,19 +57,18 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         NUM_TSK_SERVERS = config.getNumImageReaders();
     }
 
-    Process process;
     int id = idStart.getAndIncrement();;
+    Process process;
     InputStream is;
     FileChannel fc;
     File pipe;
-    MappedByteBuffer out;
+    MappedByteBuffer mbb;
     OutputStream os;
     Random rand = new Random();
 
-    volatile boolean serverError = false;
-
+    private boolean serverError = false;
     private int openedStreams = 0;
-    private Set<Long> currentStreams = new HashSet<>();
+    private Set<SleuthkitClientInputStream> currentStreams = new HashSet<>();
     private int priority = 0;
     private long requestTime = 0;
 
@@ -86,24 +86,30 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         }
     }
 
+    synchronized boolean isServerError() {
+        return serverError;
+    }
+
+    synchronized void setServerError(boolean error) {
+        serverError = error;
+    }
+
     private synchronized void checkTimeout() {
         if (requestTime == 0)
             return;
-        if (SleuthkitServer.getByte(out, 0) != FLAGS.SQLITE_READ) {
+        if (SleuthkitServer.getByte(mbb, 0) != FLAGS.SQLITE_READ) {
             logger.info("Waiting SleuthkitServer {} database read...", id); //$NON-NLS-1$
             return;
         }
         if (System.currentTimeMillis() / 1000 - requestTime >= TIMEOUT_SECONDS) {
             logger.error("Timeout waiting SleuthkitServer " + id + " response! Restarting...");
-            if (process != null) {
-                process.destroyForcibly();
-            }
             serverError = true;
             requestTime = 0;
+            finishProcess(false);
         }
     }
 
-    public synchronized void enableTimeoutCheck(boolean enable) {
+    synchronized void enableTimeoutCheck(boolean enable) {
         if (enable)
             requestTime = System.currentTimeMillis() / 1000;
         else
@@ -152,7 +158,7 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
 
     public static void shutDownServers() {
         for (SleuthkitClient sc : clientsList)
-            sc.finishProcessAndClearMmap();
+            sc.finishProcess(true);
     }
 
     private SleuthkitClient() {
@@ -161,7 +167,7 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         }
     }
 
-    private void start() {
+    private synchronized void start() {
 
         LocalConfig localConfig = ConfigurationManager.get().findObject(LocalConfig.class);
         String pipePath = localConfig.getIndexerTemp() + "/pipe-" + id; //$NON-NLS-1$
@@ -194,8 +200,8 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
             try (RandomAccessFile raf = new RandomAccessFile(pipePath, "rw")) { //$NON-NLS-1$
                 raf.setLength(size);
                 fc = raf.getChannel();
-                out = fc.map(MapMode.READ_WRITE, 0, size);
-                out.load();
+                mbb = fc.map(MapMode.READ_WRITE, 0, size);
+                mbb.load();
             } catch (ClosedByInterruptException e) {
                 // clear interrupt status
                 Thread.interrupted();
@@ -204,8 +210,8 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
 
             is.read();
             boolean ok = false;
-            while (!(ok = SleuthkitServer.getByte(out, 0) == FLAGS.DONE)
-                    && SleuthkitServer.getByte(out, 0) != FLAGS.ERROR) {
+            while (!(ok = SleuthkitServer.getByte(mbb, 0) == FLAGS.DONE)
+                    && SleuthkitServer.getByte(mbb, 0) != FLAGS.ERROR) {
                 Thread.sleep(1);
             }
 
@@ -213,16 +219,15 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
                 throw new Exception("Error starting SleuthkitServer " + id); //$NON-NLS-1$
             }
 
+            logger.info("Starting SleuthkitServer {} started.", id);
+
         } catch (Exception e) {
             e.printStackTrace();
-            if (process != null) {
-                process.destroyForcibly();
-            }
-            process = null;
+            finishProcess(false);
         }
     }
 
-    private void logStdErr(final InputStream is, final int id) {
+    private static void logStdErr(final InputStream is, final int id) {
         new Thread() {
             public void run() {
                 byte[] b = new byte[1024 * 1024];
@@ -241,7 +246,7 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         }.start();
     }
 
-    private boolean ping() {
+    private synchronized boolean ping() {
         int i = rand.nextInt(255) + 1;
         try {
             os.write(i);
@@ -256,42 +261,48 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         return false;
     }
 
+    private synchronized boolean isFineToUse() {
+        if (serverError) {
+            return false;
+        }
+        if (!ping()) {
+            logger.warn("Ping SleuthkitServer " + this.id + " failed! Restarting..."); //$NON-NLS-1$ //$NON-NLS-2$
+            return false;
+        }
+        if (openedStreams > MAX_STREAMS && currentStreams.size() == 0) {
+            logger.info("Restarting SleuthkitServer {} to clean possible resource leaks.", id); //$NON-NLS-1$
+            return false;
+        }
+        return true;
+    }
+
     public synchronized SeekableInputStream getInputStream(int id, String path) throws IOException {
 
-        if (!serverError && !ping()) {
-            logger.warn("Ping SleuthkitServer " + this.id + " failed! Restarting..."); //$NON-NLS-1$ //$NON-NLS-2$
-            serverError = true;
+        if (!isFineToUse()) {
+            restartServer();
         }
 
-        if (serverError || (openedStreams > MAX_STREAMS && currentStreams.size() == 0)) {
-            if (process != null) {
-                process.destroyForcibly();
-            }
-            process = null;
-            if (!serverError)
-                logger.info("Restarting SleuthkitServer {} to clean possible resource leaks.", id); //$NON-NLS-1$
-            serverError = false;
-            openedStreams = 0;
-            currentStreams.clear();
-            synchronized (lock) {
-                priority = 1;
-            }
-        }
+        SleuthkitClientInputStream stream = new SleuthkitClientInputStream(id, path, this);
+        currentStreams.add(stream);
+        openedStreams++;
+        return stream;
+    }
+
+    synchronized void restartServer() throws IOException {
+
+        finishProcess(false);
 
         while (process == null || !isAlive(process)) {
             start();
         }
 
-        SleuthkitClientInputStream stream = new SleuthkitClientInputStream(id, path, this);
-
-        currentStreams.add(stream.streamId);
-        openedStreams++;
-
-        return stream;
+        openedStreams = 0;
+        currentStreams.forEach(s -> s.seekAfterRestart = true);
+        serverError = false;
     }
 
-    public synchronized void removeStream(long streamID) {
-        boolean removed = currentStreams.remove(streamID);
+    synchronized void removeStream(SleuthkitClientInputStream stream) {
+        boolean removed = currentStreams.remove(stream);
         if (removed) {
             synchronized (lock) {
                 clientPriorityQueue.remove(this);
@@ -301,23 +312,36 @@ public class SleuthkitClient implements Comparable<SleuthkitClient> {
         }
     }
 
-    private void finishProcessAndClearMmap() {
-        process.destroyForcibly();
+    private synchronized void finishProcess(boolean deletemmapFile) {
+        if (process != null) {
+            process.destroyForcibly();
+            try {
+                process.waitFor(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            process = null;
+        }
         try {
-            fc.close();
+            if (fc != null) {
+                fc.close();
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }
         fc = null;
-        out = null;
-        int tries = 10;
-        do {
-            System.gc();
-            logger.info("Trying to delete " + pipe.getAbsolutePath());
-        } while (!pipe.delete() && tries-- > 0);
+        mbb = null;
+
+        if (deletemmapFile) {
+            int tries = 10;
+            do {
+                System.gc();
+                logger.info("Trying to delete " + pipe.getAbsolutePath());
+            } while (!pipe.delete() && tries-- > 0);
+        }
     }
 
-    private boolean isAlive(Process p) {
+    private static boolean isAlive(Process p) {
         try {
             p.exitValue();
             return false;

--- a/iped-engine/src/main/java/iped/engine/sleuthkit/SleuthkitClientInputStream.java
+++ b/iped-engine/src/main/java/iped/engine/sleuthkit/SleuthkitClientInputStream.java
@@ -1,11 +1,8 @@
 package iped.engine.sleuthkit;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InterruptedIOException;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.MappedByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
@@ -26,22 +23,17 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
     String path;
     SleuthkitClient client;
     long streamId = next.getAndIncrement();
-    private InputStream in;
-    OutputStream os;
     int bufPos = 0;
     byte[] buf;
-    MappedByteBuffer mbb;
     boolean closed = false, empty = true;
     long position = 0;
     Long size;
+    boolean seekAfterRestart = false;
 
     public SleuthkitClientInputStream(int id, String path, SleuthkitClient client) {
         this.sleuthId = id;
         this.path = path;
         this.client = client;
-        this.mbb = client.out;
-        this.in = client.is;
-        this.os = client.os;
     }
 
     private String getServerId() {
@@ -54,9 +46,6 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
         if (closed) {
             throw new IOException("Stream is closed!"); //$NON-NLS-1$
         }
-        if (client.serverError) {
-            throw new IOException(getServerId() + " returned an error before."); //$NON-NLS-1$
-        }
 
         int read = readIn(b, off, len);
         return read;
@@ -67,14 +56,21 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
 
         if (empty) {
             synchronized (client) {
+                if (client.isServerError()) {
+                    client.restartServer();
+                }
+                if (seekAfterRestart) {
+                    seek(position);
+                    seekAfterRestart = false;
+                }
                 byte cmd = sendRead(len);
                 if (cmd == FLAGS.EOF) {
                     return -1;
                 }
-                int size = mbb.getInt(13);
+                int size = client.mbb.getInt(13);
                 buf = new byte[size];
-                mbb.position(17);
-                mbb.get(buf, 0, size);
+                client.mbb.position(17);
+                client.mbb.get(buf, 0, size);
                 bufPos = 0;
                 empty = false;
             }
@@ -93,10 +89,10 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
     }
 
     private byte sendRead(int len) throws IOException {
-        mbb.putInt(1, sleuthId);
-        mbb.putLong(5, streamId);
-        mbb.putInt(13, len);
-        SleuthkitServer.commitByte(mbb, 0, FLAGS.READ);
+        client.mbb.putInt(1, sleuthId);
+        client.mbb.putLong(5, streamId);
+        client.mbb.putInt(13, len);
+        SleuthkitServer.commitByte(client.mbb, 0, FLAGS.READ);
         notifyServer();
         return waitServerResponse();
     }
@@ -105,12 +101,12 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
 
         client.enableTimeoutCheck(true);
         try {
-            int b = in.read();
+            int b = client.is.read();
             if (b == -1)
                 throw new IOException(getServerId() + " pipe closed!"); //$NON-NLS-1$
 
         } catch (IOException e) {
-            client.serverError = true;
+            client.setServerError(true);
             LOGGER.error("Wait response error: " + getCrashMsg());
             throw e;
 
@@ -120,7 +116,7 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
 
         byte cmd;
         long time = 0;
-        while (FLAGS.isClientCmd(cmd = SleuthkitServer.getByte(mbb, 0)) || cmd == FLAGS.SQLITE_READ) {
+        while (FLAGS.isClientCmd(cmd = SleuthkitServer.getByte(client.mbb, 0)) || cmd == FLAGS.SQLITE_READ) {
             try {
                 if (time == 0) {
                     time = System.currentTimeMillis();
@@ -129,7 +125,7 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
                 LOGGER.warn("Waiting " + getServerId() + " memory write..."); //$NON-NLS-1$
 
                 if (System.currentTimeMillis() - time >= TIMEOUT) {
-                    client.serverError = true;
+                    client.setServerError(true);
                     LOGGER.error("MemoryReadTimeout waiting " + getServerId() + ": " + path); //$NON-NLS-1$
                     throw new IOException("MemoryReadTimeout waiting " + getServerId() + ": " + path); //$NON-NLS-1$
                 }
@@ -140,10 +136,10 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
         }
 
         if (cmd == FLAGS.EXCEPTION) {
-            int len = mbb.getInt(13);
+            int len = client.mbb.getInt(13);
             byte[] b = new byte[len];
-            mbb.position(17);
-            mbb.get(b);
+            client.mbb.position(17);
+            client.mbb.get(b);
             try {
                 throw new IOException(getServerId() + " error: " + new String(b, "UTF-8")); //$NON-NLS-1$ //$NON-NLS-2$
             } catch (UnsupportedEncodingException e) {
@@ -155,9 +151,9 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
 
     private void notifyServer() throws IOException {
         try {
-            SleuthkitServer.notify(os);
+            SleuthkitServer.notify(client.os);
         } catch (IOException e) {
-            client.serverError = true;
+            client.setServerError(true);
             LOGGER.error("Notify error: " + getCrashMsg());
             throw e;
         }
@@ -173,26 +169,27 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
         if (closed) {
             throw new IOException("Stream is closed!"); //$NON-NLS-1$
         }
-        if (client.serverError) {
-            throw new IOException(getServerId() + " returned an error before."); //$NON-NLS-1$
-        }
 
         long dif = pos - position;
         if (!empty && bufPos + dif >= 0 && bufPos + dif < buf.length) {
             bufPos += dif;
 
-        } else
+        } else {
             synchronized (client) {
-                mbb.putInt(1, sleuthId);
-                mbb.putLong(5, streamId);
-                mbb.putLong(13, pos);
-                SleuthkitServer.commitByte(mbb, 0, FLAGS.SEEK);
+                if (client.isServerError()) {
+                    client.restartServer();
+                }
+                client.mbb.putInt(1, sleuthId);
+                client.mbb.putLong(5, streamId);
+                client.mbb.putLong(13, pos);
+                SleuthkitServer.commitByte(client.mbb, 0, FLAGS.SEEK);
                 notifyServer();
                 waitServerResponse();
                 empty = true;
                 bufPos = 0;
+                seekAfterRestart = false;
             }
-
+        }
         position = pos;
 
     }
@@ -211,17 +208,17 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
         if (closed) {
             throw new IOException("Stream is closed!"); //$NON-NLS-1$
         }
-        if (client.serverError) {
-            throw new IOException(getServerId() + " returned an error before."); //$NON-NLS-1$
-        }
 
         synchronized (client) {
-            mbb.putInt(1, sleuthId);
-            mbb.putLong(5, streamId);
-            SleuthkitServer.commitByte(mbb, 0, FLAGS.SIZE);
+            if (client.isServerError()) {
+                client.restartServer();
+            }
+            client.mbb.putInt(1, sleuthId);
+            client.mbb.putLong(5, streamId);
+            SleuthkitServer.commitByte(client.mbb, 0, FLAGS.SIZE);
             notifyServer();
             waitServerResponse();
-            size = mbb.getLong(13);
+            size = client.mbb.getLong(13);
             return size;
         }
 
@@ -229,11 +226,9 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
 
     @Override
     public int read() throws IOException {
+
         if (closed) {
             throw new IOException("Stream is closed!"); //$NON-NLS-1$
-        }
-        if (client.serverError) {
-            throw new IOException(getServerId() + " returned an error before."); //$NON-NLS-1$
         }
 
         byte[] b = new byte[1];
@@ -252,16 +247,19 @@ public class SleuthkitClientInputStream extends SeekableInputStream {
     @Override
     public void close() throws IOException {
 
+        if (closed) {
+            return;
+        }
         synchronized (client) {
-            if (!closed && !client.serverError) {
-                mbb.putInt(1, sleuthId);
-                mbb.putLong(5, streamId);
-                SleuthkitServer.commitByte(mbb, 0, FLAGS.CLOSE);
+            if (!client.isServerError()) {
+                client.mbb.putInt(1, sleuthId);
+                client.mbb.putLong(5, streamId);
+                SleuthkitServer.commitByte(client.mbb, 0, FLAGS.CLOSE);
                 notifyServer();
                 waitServerResponse();
             }
+            client.removeStream(this);
         }
-        client.removeStream(streamId);
         empty = true;
         closed = true;
 


### PR DESCRIPTION
Fixes #1187 & closes #1188:
- avoid reading old streams causing restarting loop after some crash
occurs;
- resume reading non problematic files from new process from their
previous position
- better code organization and synchronization usage