### PR TITLE
fix #1258: don't load default types early to load them from source case

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/index/IndexTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/index/IndexTask.java
@@ -254,7 +254,11 @@ public class IndexTask extends AbstractTask {
             }
         }
 
-        IndexItem.loadMetadataTypes(new File(output, "conf")); //$NON-NLS-1$
+        // Don't load default types if generating report, they will be loaded later.
+        // See https://github.com/sepinf-inc/IPED/issues/1258
+        if (!caseData.isIpedReport()) {
+            IndexItem.loadMetadataTypes(new File(output, "conf")); //$NON-NLS-1$
+        }
         loadExtraAttributes();
 
         this.autoParser = new StandardParser();


### PR DESCRIPTION
Fix #1258. User just confirmed report creation from cmd line worked with the triggering case.