### PR TITLE
#1299 1300 gallery events

### DIFF
--- a/iped-app/src/main/java/iped/app/ui/GalleryListener.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryListener.java
@@ -39,8 +39,8 @@ public class GalleryListener implements ListSelectionListener, MouseListener, Ke
 
         if (!ResultTableListener.syncingSelectedItems && !e.getValueIsAdjusting()) {
             ResultTableListener.syncingSelectedItems = true;
-            App.get().resultsTable.clearSelection();
             App.get().resultsTable.getSelectionModel().setValueIsAdjusting(true);
+            App.get().resultsTable.clearSelection();
             int[] selRows = App.get().gallery.getSelectedCells();
             int start = 0;
             while (start < selRows.length) {

--- a/iped-app/src/main/java/iped/app/ui/GalleryTable.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryTable.java
@@ -1,11 +1,15 @@
 package iped.app.ui;
 
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.EventObject;
 
+import javax.swing.AbstractAction;
+import javax.swing.InputMap;
 import javax.swing.JTable;
+import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 import javax.swing.table.TableModel;
 
@@ -18,6 +22,11 @@ public class GalleryTable extends JTable {
 
     public GalleryTable(TableModel tableModel) {
         super(tableModel);
+        InputMap inputMap = getInputMap(JTable.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), "Right");
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0), "Left");
+        getActionMap().put("Right", new ArrowAction(1));
+        getActionMap().put("Left", new ArrowAction(-1));
     }
 
     @Override
@@ -110,4 +119,36 @@ public class GalleryTable extends JTable {
         return super.editCellAt(row, column, e);
     }
 
+}
+
+/**
+ * Auxiliary class to allow moving cell selection to the next/previous row when
+ * using right/left keys.
+ */
+class ArrowAction extends AbstractAction {
+    private static final long serialVersionUID = 1876354716105372284L;
+    private final int dir;
+
+    public ArrowAction(int dir) {
+        this.dir = dir;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        JTable tab = (JTable) e.getSource();
+        int row = tab.getSelectedRow();
+        int col = tab.getSelectedColumn();
+        if (col + dir >= 0 && col + dir < tab.getColumnCount()) {
+            if (row * tab.getColumnCount() + col + dir < App.get().ipedResult.getLength()) {
+                tab.getSelectionModel().setValueIsAdjusting(true);
+                tab.clearSelection();
+                tab.changeSelection(row, col + dir, false, false);
+                tab.getSelectionModel().setValueIsAdjusting(false);
+            }
+        } else if (row + dir >= 0 && row + dir < tab.getRowCount()) {
+            tab.getSelectionModel().setValueIsAdjusting(true);
+            tab.clearSelection();
+            tab.changeSelection(row + dir, dir > 0 ? 0 : tab.getColumnCount() - 1, false, false);
+            tab.getSelectionModel().setValueIsAdjusting(false);
+        }
+    }
 }

--- a/iped-app/src/main/java/iped/app/ui/GalleryTable.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryTable.java
@@ -18,7 +18,7 @@ public class GalleryTable extends JTable {
     private static final long serialVersionUID = 1L;
 
     private int lastCell = 0;
-    private BitSet selectedCells = new BitSet();
+    private BitSet selectedCells;
 
     public GalleryTable(TableModel tableModel) {
         super(tableModel);
@@ -101,7 +101,11 @@ public class GalleryTable extends JTable {
 
     @Override
     public void clearSelection() {
-        selectedCells = new BitSet();
+        if (selectedCells == null) {
+            selectedCells = new BitSet();
+        } else {
+            selectedCells.clear();
+        }
         super.clearSelection();
     }
 

--- a/iped-app/src/main/java/iped/app/ui/ResultTableListener.java
+++ b/iped-app/src/main/java/iped/app/ui/ResultTableListener.java
@@ -89,8 +89,8 @@ public class ResultTableListener implements ListSelectionListener, MouseListener
             int galleyCol = resultTableLeadSelIdx % App.get().getGalleryColCount();
             App.get().gallery.scrollRectToVisible(App.get().gallery.getCellRect(galleryRow, galleyCol, false));
 
-            App.get().gallery.clearSelection();
             App.get().gallery.getSelectionModel().setValueIsAdjusting(true);
+            App.get().gallery.clearSelection();
             int[] selRows = App.get().resultsTable.getSelectedRows();
             int start = 0;
             while (start < selRows.length) {


### PR DESCRIPTION
This implements #1299 and #1300.

When handling the arrow keys, only events with no modifiers (SHIFT, CTRL) are handled, as the goal was to make the navigation through gallery items easier. For selection, the current behavior was kept.