### PR TITLE
Sqlite split

### DIFF
--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -275,7 +275,11 @@
         </parser>
         <parser class="iped.parsers.mail.OutlookDBXParser"></parser>
         <parser class="iped.parsers.database.XBaseParser"></parser>
-        <parser class="iped.parsers.sqlite.SQLite3Parser"></parser>
+        <parser class="iped.parsers.sqlite.SQLite3Parser">
+            <params>
+                <param name="tableRowsPerItem" type="int">300</param>
+            </params>
+        </parser>
         <parser class="iped.parsers.usnjrnl.UsnJrnlParser">
             <params>
                 <param name="extractEntries" type="bool">false</param>

--- a/iped-app/src/main/java/iped/app/ui/ViewerController.java
+++ b/iped-app/src/main/java/iped/app/ui/ViewerController.java
@@ -101,7 +101,6 @@ public class ViewerController {
         viewersRepository.addViewer(new MsgViewer());
         linkViewer = new HtmlLinkViewer(new AttachmentSearcherImpl());
         viewersRepository.addViewer(linkViewer);
-        viewersRepository.addViewer(new TikaHtmlViewer());
         viewersRepository.addViewer(new IcePDFViewer());
         viewersRepository.addViewer(new TiffViewer());
         viewersRepository.addViewer(new ReferencedFileViewer(viewersRepository, new AttachmentSearcherImpl()));

--- a/iped-engine/src/main/java/iped/engine/data/Item.java
+++ b/iped-engine/src/main/java/iped/engine/data/Item.java
@@ -34,7 +34,6 @@ import iped.datasource.IDataSource;
 import iped.engine.core.Statistics;
 import iped.engine.lucene.analysis.CategoryTokenizer;
 import iped.engine.task.index.IndexItem;
-import iped.engine.tika.SyncMetadata;
 import iped.engine.util.ParentInfo;
 import iped.engine.util.TextCache;
 import iped.engine.util.Util;
@@ -46,6 +45,7 @@ import iped.utils.IOUtil;
 import iped.utils.LimitedSeekableInputStream;
 import iped.utils.SeekableByteChannelImpl;
 import iped.utils.SeekableFileInputStream;
+import iped.utils.tika.SyncMetadata;
 
 /**
  * Classe que define um arquivo de evidência, que é um arquivo do caso,

--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -74,7 +74,6 @@ import iped.engine.io.ParsingReader;
 import iped.engine.search.ItemSearcher;
 import iped.engine.task.carver.CarverTask;
 import iped.engine.task.index.IndexItem;
-import iped.engine.tika.SyncMetadata;
 import iped.engine.util.ItemInfoFactory;
 import iped.engine.util.ParentInfo;
 import iped.engine.util.TextCache;
@@ -114,6 +113,7 @@ import iped.properties.MediaTypes;
 import iped.search.IItemSearcher;
 import iped.utils.EmptyInputStream;
 import iped.utils.IOUtil;
+import iped.utils.tika.SyncMetadata;
 
 /**
  * TAREFA DE PARSING DE ALGUNS TIPOS DE ARQUIVOS. ARMAZENA O TEXTO EXTRAÍDO,

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
@@ -54,7 +54,7 @@ public abstract class AbstractDBParser extends AbstractParser {
 
     public static final int HTML_MAX_ROWS = Integer.MAX_VALUE;
 
-    private Connection connection;
+    protected Connection connection;
     int tableRowsPerItem = 100;
 
     @Override

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
@@ -40,7 +40,7 @@ import org.xml.sax.SAXException;
 
 import iped.parsers.standard.StandardParser;
 import iped.properties.ExtraProperties;
-import iped.utils.tika.SyncMetadata;
+import iped.utils.tika.IpedMetadata;
 
 /**
  * Abstract class that handles iterating through tables within a database.
@@ -80,7 +80,7 @@ public abstract class AbstractDBParser extends AbstractParser {
         do {
             EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,
                     new ParsingEmbeddedDocumentExtractor(context));
-            SyncMetadata tableM = new SyncMetadata();
+            IpedMetadata tableM = new IpedMetadata();
             do {            	
                 try(InputStream is = trg.createHtmlReport(tableRowsPerItem, handler, context, tmp, tableM)) {
                     ++table_fragment;
@@ -149,10 +149,6 @@ public abstract class AbstractDBParser extends AbstractParser {
 
             for (String tableName : tableNames) {
                 JDBCTableReader reader = getTableReader(connection, tableName, context);
-                /*
-                long rowCount = reader.getRowCount();
-                metadata.set(Database.ROW_COUNT, rowCount);
-                */
                 
                 int row_count = parseTables(xHandler, context, reader);
                 xHandler.startElement("tr");

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
@@ -40,6 +40,7 @@ import org.xml.sax.SAXException;
 
 import iped.parsers.standard.StandardParser;
 import iped.properties.ExtraProperties;
+import iped.utils.tika.SyncMetadata;
 
 /**
  * Abstract class that handles iterating through tables within a database.
@@ -79,7 +80,7 @@ public abstract class AbstractDBParser extends AbstractParser {
         do {
             EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,
                     new ParsingEmbeddedDocumentExtractor(context));
-            Metadata tableM = new Metadata();
+            SyncMetadata tableM = new SyncMetadata();
             do {            	
                 try(InputStream is = trg.createHtmlReport(tableRowsPerItem, handler, context, tmp, tableM)) {
                     ++table_fragment;
@@ -148,6 +149,11 @@ public abstract class AbstractDBParser extends AbstractParser {
 
             for (String tableName : tableNames) {
                 JDBCTableReader reader = getTableReader(connection, tableName, context);
+                /*
+                long rowCount = reader.getRowCount();
+                metadata.set(Database.ROW_COUNT, rowCount);
+                */
+                
                 int row_count = parseTables(xHandler, context, reader);
                 xHandler.startElement("tr");
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractDBParser.java
@@ -53,6 +53,9 @@ public abstract class AbstractDBParser extends AbstractParser {
     public static final MediaType TABLE_REPORT = MediaType.application("x-database-table");
 
     public static final int HTML_MAX_ROWS = Integer.MAX_VALUE;
+    
+    public static final String DATETIME_MARKUP_START = "<time datetime=\"";
+    public static final String DATABASEDATECOLUMN_PREFIX = "DatabaseDate"+TikaCoreProperties.NAMESPACE_PREFIX_DELIMITER;
 
     protected Connection connection;
     int tableRowsPerItem = 100;
@@ -68,6 +71,7 @@ public abstract class AbstractDBParser extends AbstractParser {
 
     private int parseTables(ContentHandler handler, ParseContext context, JDBCTableReader reader)
             throws SAXException, IOException, SQLException {
+
         TableReportGenerator trg = new TableReportGenerator(reader);
         int table_fragment = 0;
         TemporaryResources tmp = new TemporaryResources();
@@ -77,7 +81,7 @@ public abstract class AbstractDBParser extends AbstractParser {
                     new ParsingEmbeddedDocumentExtractor(context));
             Metadata tableM = new Metadata();
             do {            	
-                try(InputStream is = trg.createHtmlReport(tableRowsPerItem, handler, context, tmp)) {
+                try(InputStream is = trg.createHtmlReport(tableRowsPerItem, handler, context, tmp, tableM)) {
                     ++table_fragment;
                     hasNext = trg.hasNext();
                     String title = reader.getTableName();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractMetadataColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractMetadataColumnExtractor.java
@@ -2,7 +2,7 @@ package iped.parsers.jdbc;
 
 import java.util.ArrayList;
 
-import iped.utils.tika.SyncMetadata;
+import iped.utils.tika.IpedMetadata;
 
 public abstract class AbstractMetadataColumnExtractor implements MetadataColumnExtractor {
 	ArrayList<String> extractedValues = new ArrayList<String>();
@@ -35,8 +35,8 @@ public abstract class AbstractMetadataColumnExtractor implements MetadataColumnE
 	}
 
 	@Override
-	public void applyExtractedMetadatas(SyncMetadata metadata) {
-		metadata.set(getMetadataName(), extractedValues);
+	public void applyExtractedMetadatas(IpedMetadata tableM) {
+		tableM.set(getMetadataName(), extractedValues);
 	}
 	
 	@Override

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractMetadataColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/AbstractMetadataColumnExtractor.java
@@ -1,0 +1,52 @@
+package iped.parsers.jdbc;
+
+import java.util.ArrayList;
+
+import iped.utils.tika.SyncMetadata;
+
+public abstract class AbstractMetadataColumnExtractor implements MetadataColumnExtractor {
+	ArrayList<String> extractedValues = new ArrayList<String>();
+
+	protected boolean isCompatibleColName(String colName) {
+		String[] columnNames = getColumnNames();
+		for (int i = 0; i < columnNames.length; i++) {
+			boolean found=false;
+			String columnName = columnNames[i].toLowerCase();
+			if(columnName.startsWith("*")&&columnNames[i].endsWith("*")) {
+				found=colName.contains(columnName.substring(1));
+			}
+			if(found) {
+				return true;
+			}
+			if(columnName.startsWith("*")) {
+				found=colName.endsWith(columnName.substring(1));
+			}
+			if(columnName.endsWith("*")) {
+				found=colName.endsWith(columnName.substring(0,columnName.length()-2));
+			}
+			if(found) {
+				return true;
+			}
+			if(columnName.equals(colName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public void applyExtractedMetadatas(SyncMetadata metadata) {
+		metadata.set(getMetadataName(), extractedValues);
+	}
+	
+	@Override
+	public void cancelLastExtraction() {
+		extractedValues.remove(extractedValues.size()-1);
+	}
+	
+	@Override
+	public String getLastExtraction() {
+		return extractedValues.get(extractedValues.size()-1);
+	}
+
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/JDBCTableReader.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/JDBCTableReader.java
@@ -60,7 +60,7 @@ import iped.utils.IOUtil;
 public class JDBCTableReader {
 
     private final static Attributes EMPTY_ATTRIBUTES = new AttributesImpl();
-    private final Connection connection;
+    protected final Connection connection;
     private final String tableName;
     int maxClobLength = 1000000;
     private ResultSet results = null;
@@ -124,7 +124,10 @@ public class JDBCTableReader {
             ParseContext context, int rows)
             throws SQLException, IOException, SAXException {
         String text = null;
-        switch (rsmd.getColumnType(i)) {
+
+        int ct = rsmd.getColumnType(i);
+
+        switch (ct) {
             case Types.BLOB:
                 text = handleBlob(tableName, rsmd.getColumnName(i), rows, results, i, handler, context);
                 break;
@@ -138,7 +141,7 @@ public class JDBCTableReader {
                 text = handleDate(results, i, handler);
                 break;
             case Types.TIMESTAMP:
-                text = handleTimeStamp(results, i, handler);
+                text = handleTimestamp(rsmd, results, i, handler);
                 break;
             case Types.INTEGER:
                 text = handleInteger(rsmd, results, i, handler);
@@ -146,7 +149,7 @@ public class JDBCTableReader {
             case Types.FLOAT:
                 // this is necessary to handle rounding issues in presentation
                 // Should we just use getString(i)?
-                text = Float.toString(results.getFloat(i));
+                text = handleFloat(rsmd, results, i, handler);
                 break;
             case Types.DOUBLE:
                 text = Double.toString(results.getDouble(i));
@@ -158,7 +161,15 @@ public class JDBCTableReader {
         return text;
     }
 
-    public List<String> getHeaders() throws IOException {
+    private String handleTimestamp(ResultSetMetaData rsmd, ResultSet results2, int i, ContentHandler handler) throws SQLException, SAXException {
+		return handleInteger(rsmd, results2, i, handler);
+	}
+
+	protected String handleFloat(ResultSetMetaData rsmd, ResultSet results, int i, ContentHandler handler) throws SQLException, SAXException {
+		return Float.toString(results.getFloat(i));
+	}
+
+	public List<String> getHeaders() throws IOException {
         List<String> headers = new LinkedList<String>();
         // lazy initialization
         if (results == null) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/LatColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/LatColumnExtractor.java
@@ -1,0 +1,40 @@
+package iped.parsers.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.apache.tika.metadata.Metadata;
+
+import iped.properties.ExtraProperties;
+
+public class LatColumnExtractor extends AbstractMetadataColumnExtractor{
+	protected String[] columnNames= {"*LATITUDE", "LAT"};
+	protected double min=-90;
+	protected double max=90;
+
+	@Override
+	public String[] getColumnNames() {
+		return columnNames;
+	}
+
+	@Override
+	public boolean extractMetadata(ResultSet rs, int columnIndex) throws SQLException {
+		ResultSetMetaData rsmd = rs.getMetaData();
+		String colName = rsmd.getColumnName(columnIndex);
+		if(isCompatibleColName(colName) && (rsmd.getColumnType(columnIndex)==Types.REAL ||rsmd.getColumnType(columnIndex)==Types.DOUBLE||rsmd.getColumnType(columnIndex)==Types.FLOAT)) {
+        	Double d = rs.getDouble(columnIndex);//try to parse as double
+        	if(d>=min && d<=max) {
+    			extractedValues.add(rs.getString(columnIndex));
+    			return true;
+        	}
+		}
+		return false;
+	}
+
+	@Override
+	public String getMetadataName() {
+		return ExtraProperties.COMMON_META_PREFIX+Metadata.LATITUDE.getName();
+	}
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/LngColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/LngColumnExtractor.java
@@ -1,0 +1,41 @@
+package iped.parsers.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.apache.tika.metadata.Metadata;
+
+import iped.properties.ExtraProperties;
+
+public class LngColumnExtractor extends AbstractMetadataColumnExtractor{
+	protected String[] columnNames= {"*LONGITUDE", "LON", "LNG", "LONG"};
+	protected double min=-180;
+	protected double max=180;
+
+	@Override
+	public String[] getColumnNames() {
+		return columnNames;
+	}
+
+	@Override
+	public boolean extractMetadata(ResultSet rs, int columnIndex) throws SQLException {
+		ResultSetMetaData rsmd = rs.getMetaData();
+		String colName = rsmd.getColumnName(columnIndex);
+		if(isCompatibleColName(colName) && (rsmd.getColumnType(columnIndex)==Types.REAL ||rsmd.getColumnType(columnIndex)==Types.DOUBLE||rsmd.getColumnType(columnIndex)==Types.FLOAT)) {
+        	Double d = rs.getDouble(columnIndex);//try to parse as double
+        	if(d>=min && d<=max) {
+    			extractedValues.add(rs.getString(columnIndex));
+    			return true;
+        	}
+		}
+		return false;
+	}
+
+	@Override
+	public String getMetadataName() {
+		return ExtraProperties.COMMON_META_PREFIX+Metadata.LONGITUDE.getName();
+	}
+
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/MetadataColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/MetadataColumnExtractor.java
@@ -1,0 +1,16 @@
+package iped.parsers.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import iped.utils.tika.SyncMetadata;
+
+public interface MetadataColumnExtractor {
+	String[] getColumnNames();
+
+	public boolean extractMetadata(ResultSet rs, int columnIndex) throws SQLException;
+	public void applyExtractedMetadatas(SyncMetadata metadata);
+	public String getMetadataName();
+	public void cancelLastExtraction();
+	public String getLastExtraction();
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/MetadataColumnExtractor.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/MetadataColumnExtractor.java
@@ -3,13 +3,13 @@ package iped.parsers.jdbc;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import iped.utils.tika.SyncMetadata;
+import iped.utils.tika.IpedMetadata;
 
 public interface MetadataColumnExtractor {
 	String[] getColumnNames();
 
 	public boolean extractMetadata(ResultSet rs, int columnIndex) throws SQLException;
-	public void applyExtractedMetadatas(SyncMetadata metadata);
+	public void applyExtractedMetadatas(IpedMetadata metadata);
 	public String getMetadataName();
 	public void cancelLastExtraction();
 	public String getLastExtraction();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
@@ -90,6 +90,8 @@ public class TableReportGenerator {
 
             if (totRows == 0) {
                 next();
+            }else {
+            	hasNext=true;
             }
 
             if (hasNext) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
@@ -10,9 +10,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -37,17 +39,29 @@ public class TableReportGenerator {
     private JDBCTableReader tableReader;
 
     private static final String newCol(String value, String tag) {
+    	return newCol(value, tag, true);
+    }
+    
+    private static final String newCol(String value, String tag, boolean encodeHTML) {
         StringBuilder sb = new StringBuilder();
         sb.append("<").append(tag).append(">");
         if (value != null) {
-            sb.append(SimpleHTMLEncoder.htmlEncode(value));
+        	if(encodeHTML) {
+                sb.append(SimpleHTMLEncoder.htmlEncode(value));
+        	}else {
+                sb.append(value);
+        	}
         }
         sb.append("</").append(tag).append(">");
         return sb.toString();
     }
 
     private static final String newCol(String value) {
-        return newCol(value, "td");
+        return newCol(value, "td", true);
+    }
+
+    private static final String newCol(String value, boolean encodeHTML) {
+        return newCol(value, "td", encodeHTML);
     }
 
     public TableReportGenerator(JDBCTableReader tableReader) {
@@ -56,7 +70,7 @@ public class TableReportGenerator {
     }
 
     public InputStream createHtmlReport(int maxRows, ContentHandler handler,
-            ParseContext context, TemporaryResources tmp)
+            ParseContext context, TemporaryResources tmp, Metadata metadata)
             throws IOException, SQLException, SAXException {
         rows = 0;
         Path path = tmp.createTempFile();
@@ -98,9 +112,27 @@ public class TableReportGenerator {
                 do {
                     rows++;
                     out.print("<tr>");
+                	ResultSetMetaData rsmd = data.getMetaData();
                     for (int i = 1; i <= cols; i++) {
-                        String text = tableReader.handleCell(data, data.getMetaData(), i, handler, context, rows);
-                        out.print(newCol(text));
+                        String text = tableReader.handleCell(data, rsmd, i, handler, context, rows);
+                        boolean isTime = false;
+                        try {
+                            int datePos = text.indexOf(AbstractDBParser.DATETIME_MARKUP_START);
+                            if(datePos!=-1) {
+                            	String datetext = text.substring(datePos+AbstractDBParser.DATETIME_MARKUP_START.length());
+                            	datetext = datetext.substring(0,datetext.indexOf("\">"));
+                            	metadata.add(AbstractDBParser.DATABASEDATECOLUMN_PREFIX+rsmd.getTableName(i)+rsmd.getColumnName(i), datetext);
+                            	isTime=true;
+                            }
+                        }catch(Exception e) {
+                        	e.printStackTrace();
+                        }
+                        
+                        if(isTime) {
+                            out.print(newCol(text,false));//does not encode html
+                        }else {
+                            out.print(newCol(text));
+                        }
                     }
                     out.print("</tr>");
                 } while (next() && rows < maxRows);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/TableReportGenerator.java
@@ -23,6 +23,7 @@ import org.xml.sax.SAXException;
 import iped.parsers.util.Messages;
 import iped.properties.ExtraProperties;
 import iped.utils.SimpleHTMLEncoder;
+import iped.utils.tika.IpedMetadata;
 import iped.utils.tika.SyncMetadata;
 
 public class TableReportGenerator {
@@ -73,7 +74,7 @@ public class TableReportGenerator {
     }
 
     public InputStream createHtmlReport(int maxRows, ContentHandler handler,
-            ParseContext context, TemporaryResources tmp, SyncMetadata metadata)
+            ParseContext context, TemporaryResources tmp, IpedMetadata tableM)
             throws IOException, SQLException, SAXException {
         rows = 0;
         Path path = tmp.createTempFile();
@@ -135,7 +136,7 @@ public class TableReportGenerator {
                                 if(datePos!=-1) {
                                 	String datetext = text.substring(datePos+AbstractDBParser.DATETIME_MARKUP_START.length());
                                 	datetext = datetext.substring(0,datetext.indexOf("\">"));
-                                	metadata.add(AbstractDBParser.DATABASEDATECOLUMN_PREFIX+rsmd.getTableName(i)+":"+rsmd.getColumnName(i), datetext);
+                                	tableM.add(AbstractDBParser.DATABASEDATECOLUMN_PREFIX+rsmd.getTableName(i)+":"+rsmd.getColumnName(i), datetext);
                                 	isTime=true;
                                 }
                             }catch(Exception e) {
@@ -175,10 +176,11 @@ public class TableReportGenerator {
                     
                 } while (next() && rows < maxRows);
             }
+
             if(locations.size()>0) {
-            	latExtractor.applyExtractedMetadatas(metadata);
-            	lngExtractor.applyExtractedMetadatas(metadata);
-            	metadata.set(ExtraProperties.LOCATIONS, locations);
+            	latExtractor.applyExtractedMetadatas(tableM);
+            	lngExtractor.applyExtractedMetadatas(tableM);
+            	tableM.set(ExtraProperties.LOCATIONS, locations);
             }
 
             totRows += rows;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/AppleORMUtils.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/AppleORMUtils.java
@@ -1,0 +1,26 @@
+package iped.parsers.sqlite;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class AppleORMUtils {
+    static public boolean isAppleORMMetadata(Connection connection) throws SQLException {
+		boolean isApple = true;
+    	DatabaseMetaData dbm = connection.getMetaData();
+    	try(ResultSet rsTables = dbm.getTables(null, null, null, new String[]{"TABLE"})) {
+        	while(rsTables.next()) {
+        		String tableName = rsTables.getString("TABLE_NAME");
+        		try(ResultSet columns = dbm.getColumns(null,null, tableName, "Z%")){
+        			if(!columns.next()) {            				
+        				//if there is no columns with Z prefix
+        				isApple=false;
+        				return isApple;
+        			}
+        		}
+        	}
+    	}
+    	return isApple;
+    }
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3DBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3DBParser.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -55,6 +56,7 @@ import iped.utils.IOUtil;
 public class SQLite3DBParser extends AbstractDBParser {
 
     protected static final String SQLITE_CLASS_NAME = "org.sqlite.JDBC"; //$NON-NLS-1$
+	private Boolean isApple = null;
 
     /**
      *
@@ -115,6 +117,8 @@ public class SQLite3DBParser extends AbstractDBParser {
                     }
                 }
             };
+            
+            isApple = AppleORMUtils.isAppleORMMetadata(connection);
 
         } catch (SQLException e) {
             throw new IOException(e.getMessage());
@@ -207,7 +211,7 @@ public class SQLite3DBParser extends AbstractDBParser {
 
     @Override
     public JDBCTableReader getTableReader(Connection connection, String tableName, ParseContext context) {
-        return new SQLite3TableReader(connection, tableName, context);
+        return new SQLite3TableReader(connection, tableName, context, this);
     }
 
     public static boolean checkIfColumnExists(Connection connection, String table, String column) throws SQLException  {
@@ -254,4 +258,9 @@ public class SQLite3DBParser extends AbstractDBParser {
         }
         return result;
     }
+
+	public Boolean isAppleORM() {
+		return isApple;
+	}
+
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3Parser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3Parser.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.tika.config.Field;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
@@ -53,6 +54,8 @@ public class SQLite3Parser extends AbstractParser {
 
     private final Set<MediaType> SUPPORTED_TYPES;
 
+	private int tableRowsPerItem;
+
     /**
      * Checks to see if class is available for org.sqlite.JDBC.
      * <p>
@@ -68,6 +71,11 @@ public class SQLite3Parser extends AbstractParser {
         }
         SUPPORTED_TYPES = tmp;
     }
+    
+    @Field
+    public void setTableRowsPerItem(int value) {
+    	this.tableRowsPerItem = value;
+    }
 
     @Override
     public Set<MediaType> getSupportedTypes(ParseContext context) {
@@ -78,6 +86,7 @@ public class SQLite3Parser extends AbstractParser {
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
             throws IOException, SAXException, TikaException {
         SQLite3DBParser p = new SQLite3DBParser();
+        p.setTableRowsPerItem(tableRowsPerItem);
         p.parse(stream, handler, metadata, context);
     }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3TableReader.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3TableReader.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.TreeSet;
 
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -63,6 +64,7 @@ class SQLite3TableReader extends JDBCTableReader {
 	
 	private static final long APPLEORM_EPOCH = 978307200;
 	SQLite3DBParser dbparser;
+	TreeSet<Integer> notADate = new TreeSet<>();
 
 	DateFormat df = new SimpleDateFormat(Messages.getString("SQLite3TableReader.DateFormat"), Locale.ROOT); //$NON-NLS-1$
 
@@ -261,7 +263,6 @@ class SQLite3TableReader extends JDBCTableReader {
         }
 
         return text;
-
     }
 
     @Override
@@ -289,7 +290,7 @@ class SQLite3TableReader extends JDBCTableReader {
             	text=AbstractDBParser.DATETIME_MARKUP_START+datetext+"\">"+datetext+"</time>";
         	}
         } else {
-        	super.handleFloat(rsmd, rs, col, handler);
+        	return super.handleFloat(rsmd, rs, col, handler);
         }
 
         return text;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3TableReader.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3TableReader.java
@@ -37,6 +37,7 @@ import org.apache.tika.parser.ParseContext;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import iped.parsers.jdbc.AbstractDBParser;
 import iped.parsers.jdbc.JDBCTableReader;
 import iped.parsers.util.Messages;
 import iped.utils.TimeConverter;
@@ -234,24 +235,27 @@ class SQLite3TableReader extends JDBCTableReader {
         // stored as a column of type Integer, but the columnTypeName is TIMESTAMP, and
         // the
         // value is a string representing a Long.
+		String datetext="";
         if (rsmd.getColumnTypeName(col).equals("TIMESTAMP")) { //$NON-NLS-1$
         	long longValue = rs.getLong(col);
         	if(rs.wasNull()) {
         		text = null;
         	}else {
                 if(dbparser.isAppleORM()) {
-                	//Apple ORM date format            	
-                    text = parseDateFromLong((longValue+ APPLEORM_EPOCH)*1000l);
+                	//Apple ORM date format
+                	datetext = parseDateFromLong((longValue+ APPLEORM_EPOCH)*1000l);
                 }else {
-                    text = parseDateFromLong(longValue);
+                	datetext = parseDateFromLong(longValue);
                 }            
+            	text=AbstractDBParser.DATETIME_MARKUP_START+datetext+"\">"+datetext+"</time>";
         	}
         } else {
             long val = rs.getLong(col);
             text = Long.toString(val);
 
             if (val > 0 && dateFormats[col] != 0) {
-                text += " (*" + df.format(decodeDate(val, dateFormats[col])) + ")";
+            	datetext = df.format(decodeDate(val, dateFormats[col]));
+                text += AbstractDBParser.DATETIME_MARKUP_START+datetext+"\"> (*" + datetext + ")</time>";
                 dateGuessed = true;
             }
         }
@@ -270,17 +274,19 @@ class SQLite3TableReader extends JDBCTableReader {
         // stored as a column of type Integer, but the columnTypeName is TIMESTAMP, and
         // the
         // value is a string representing a Long.
+		String datetext="";
         if (rsmd.getColumnTypeName(col).equals("TIMESTAMP")) { //$NON-NLS-1$
         	long longValue = rs.getLong(col);
         	if(rs.wasNull()) {
         		text = null;
         	}else {
-                if(dbparser.isAppleORM()){
-                	//Apple ORM date format            	
-                    text = parseDateFromLong((longValue+ APPLEORM_EPOCH)*1000l);
+                if(dbparser.isAppleORM()) {
+                	//Apple ORM date format
+                	datetext = parseDateFromLong((longValue+ APPLEORM_EPOCH)*1000l);
                 }else {
-                    text = parseDateFromLong(longValue);
+                	datetext = parseDateFromLong(longValue);
                 }            
+            	text=AbstractDBParser.DATETIME_MARKUP_START+datetext+"\">"+datetext+"</time>";
         	}
         } else {
         	super.handleFloat(rsmd, rs, col, handler);

--- a/iped-utils/src/main/java/iped/utils/tika/IpedMetadata.java
+++ b/iped-utils/src/main/java/iped/utils/tika/IpedMetadata.java
@@ -1,0 +1,20 @@
+package iped.utils.tika;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.apache.tika.metadata.Metadata;
+
+public class IpedMetadata extends Metadata{
+    
+	public void set(String arg0, ArrayList<String> list) {
+		String[] arr= new String[list.size()];
+		int i=0;
+		for (Iterator iterator = list.iterator(); iterator.hasNext();) {
+			arr[i++]=(String) iterator.next();
+		}
+		
+		super.set(arg0, arr);
+	}
+
+}

--- a/iped-utils/src/main/java/iped/utils/tika/SyncMetadata.java
+++ b/iped-utils/src/main/java/iped/utils/tika/SyncMetadata.java
@@ -1,7 +1,9 @@
-package iped.engine.tika;
+package iped.utils.tika;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Properties;
 
 import org.apache.tika.metadata.Metadata;
@@ -202,5 +204,14 @@ public class SyncMetadata extends Metadata {
     public synchronized String toString() {
         return super.toString();
     }
-
+    
+	public void set(String arg0, ArrayList<String> list) {
+		String[] arr= new String[list.size()];
+		int i=0;
+		for (Iterator iterator = list.iterator(); iterator.hasNext();) {
+			arr[i++]=(String) iterator.next();
+		}
+		
+		super.set(arg0, arr);
+	}
 }

--- a/iped-utils/src/main/java/iped/utils/tika/SyncMetadata.java
+++ b/iped-utils/src/main/java/iped/utils/tika/SyncMetadata.java
@@ -16,7 +16,7 @@ import org.apache.tika.metadata.Property;
  * @author Nassif
  *
  */
-public class SyncMetadata extends Metadata {
+public class SyncMetadata extends IpedMetadata {
 
     /**
      * 
@@ -204,14 +204,4 @@ public class SyncMetadata extends Metadata {
     public synchronized String toString() {
         return super.toString();
     }
-    
-	public void set(String arg0, ArrayList<String> list) {
-		String[] arr= new String[list.size()];
-		int i=0;
-		for (Iterator iterator = list.iterator(); iterator.hasNext();) {
-			arr[i++]=(String) iterator.next();
-		}
-		
-		super.set(arg0, arr);
-	}
 }


### PR DESCRIPTION
Improvement in SQLite Parser, so it split large tables in pieces of size configured in a parser configuration parameter, and extract date metadata from REAL columns (apple most common format) and geolocations based on column names.