### PR TITLE
Fix mimes that were swapped between Ares and Shareaza categories

### DIFF
--- a/iped-app/resources/config/conf/CategoriesConfig.json
+++ b/iped-app/resources/config/conf/CategoriesConfig.json
@@ -90,9 +90,9 @@
     ]},
     {"name": "Other files", "mimes": ["application/octet-stream", "application/x-nls"]},
     {"name": "Peer-to-peer", "categories":[
-      {"name": "Ares Galaxy", "mimes": ["application/x-shareaza-searches-dat", "application/x-shareaza-library-dat"]},
+      {"name": "Ares Galaxy", "mimes": ["application/x-ares-galaxy"]},
       {"name": "E-Mule", "mimes": ["application/x-emule", "application/x-emule-part-met", "application/x-emule-searches", "application/x-emule-preferences-ini", "application/x-emule-preferences-dat"]},
-      {"name": "Shareaza", "mimes": ["application/x-ares-galaxy"]},
+      {"name": "Shareaza", "mimes": ["application/x-shareaza-searches-dat", "application/x-shareaza-library-dat"]},
       {"name": "Torrent", "mimes": ["application/x-bittorrent-resume-dat", "application/x-bittorrent"]},
       {"name": "Other Peer-to-peer", "mimes": ["application/x-p2p"]}
     ]},


### PR DESCRIPTION
@lfcnassif, I just noticed that mime types were swapped between Ares Galaxy and Shareaza in CategoriesConfig.json, in the PR #1367 I submitted (already merged).
I am sorry about that!