### PR TITLE
#1358 fix

### DIFF
--- a/iped-engine/src/main/java/iped/engine/config/LocalConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/LocalConfig.java
@@ -22,6 +22,8 @@ public class LocalConfig extends AbstractPropertiesConfigurable {
 
     public static final String SYS_PROP_APPEND = "iped.appending"; //$NON-NLS-1$
 
+    public static final String NUM_THREADS = "numThreads";
+
     private static final String HASH_DB = "hashesDB";
 
     public static final DirectoryStream.Filter<Path> filter = new Filter<Path>() {
@@ -87,7 +89,7 @@ public class LocalConfig extends AbstractPropertiesConfigurable {
             ipedTemp.mkdirs();
         }
 
-        value = properties.getProperty("numThreads"); //$NON-NLS-1$
+        value = properties.getProperty(NUM_THREADS); // $NON-NLS-1$
         if (value != null) {
             value = value.trim();
         }

--- a/iped-engine/src/main/java/iped/engine/config/ParsingTaskConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/ParsingTaskConfig.java
@@ -12,8 +12,10 @@ public class ParsingTaskConfig extends AbstractTaskPropertiesConfig {
     public static final String ENABLE_PARAM = "enableFileParsing";
     private static final String CONF_FILE = "ParsingTaskConfig.txt";
 
+    public static final String NUM_EXTERNAL_PARSERS = "numExternalParsers";
+
     private boolean enableExternalParsing = false;
-    private int numExternalParsers;;
+    private int numExternalParsers;
     private String externalParsingMaxMem = "512";
     private boolean parseCorruptedFiles = true;
     private boolean parseUnknownFiles = true;
@@ -53,7 +55,7 @@ public class ParsingTaskConfig extends AbstractTaskPropertiesConfig {
             enableExternalParsing = Boolean.valueOf(value.trim());
         }
 
-        value = properties.getProperty("numExternalParsers"); //$NON-NLS-1$
+        value = properties.getProperty(NUM_EXTERNAL_PARSERS); // $NON-NLS-1$
         if (value != null && !value.trim().equalsIgnoreCase("auto")) { //$NON-NLS-1$
             numExternalParsers = Integer.valueOf(value.trim());
         } else {
@@ -63,7 +65,7 @@ public class ParsingTaskConfig extends AbstractTaskPropertiesConfig {
                         + this.getClass().getSimpleName());
             }
             int div = ocrconfig.isOCREnabled() ? 1 : 2;
-            numExternalParsers = (int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / div);
+            numExternalParsers = Math.max((int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / div), 2);
         }
 
         value = properties.getProperty("externalParsingMaxMem"); //$NON-NLS-1$

--- a/iped-engine/src/main/java/iped/engine/core/Worker.java
+++ b/iped-engine/src/main/java/iped/engine/core/Worker.java
@@ -212,8 +212,7 @@ public class Worker extends Thread {
         caseData.incDiscoveredEvidences(1);
         // Se a fila está pequena, enfileira
         if (time == ProcessTime.LATER
-                || (time == ProcessTime.AUTO
-                        && manager.getProcessingQueues().getCurrentQueueSize() < 10 * manager.getWorkers().length)) {
+                || (time == ProcessTime.AUTO && manager.getProcessingQueues().getCurrentQueueSize() < 100 * manager.getNumWorkers())) {
             manager.getProcessingQueues().addItemFirstNonBlocking(evidence);
         } // caso contrário processa o item no worker atual
         else {

--- a/iped-engine/src/main/java/iped/engine/task/AbstractTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/AbstractTask.java
@@ -151,6 +151,15 @@ public abstract class AbstractTask {
      */
     abstract protected void process(IItem evidence) throws Exception;
 
+    private static class ItemReEnqueuedException extends RuntimeException {
+
+        /**
+         * 
+         */
+        private static final long serialVersionUID = 1L;
+
+    }
+
     /**
      * Realiza o processamento do item na tarefa e o envia para a próxima tarefa.
      *
@@ -175,9 +184,16 @@ public abstract class AbstractTask {
         worker.runningTask = this;
         worker.evidence = evidence;
 
+        boolean sendToNextTask = true;
+
         if (this.isEnabled() && (!evidence.isToIgnore() || processIgnoredItem())) {
             long t = System.nanoTime() / 1000;
-            processMonitorTimeout(evidence);
+            try {
+                processMonitorTimeout(evidence);
+
+            } catch (ItemReEnqueuedException e) {
+                sendToNextTask = false;
+            }
             Long subitensTime = subitemProcessingTime.remove(evidence.getId());
             if (subitensTime == null) {
                 subitensTime = 0L;
@@ -185,7 +201,9 @@ public abstract class AbstractTask {
             taskTime += System.nanoTime() / 1000 - t - subitensTime;
         }
 
-        sendToNextTask(evidence);
+        if (sendToNextTask) {
+            sendToNextTask(evidence);
+        }
 
         worker.evidence = prevEvidence;
         worker.runningTask = prevTask;
@@ -206,12 +224,7 @@ public abstract class AbstractTask {
             if (evidence.isRoot() || priority <= worker.manager.getProcessingQueues().getCurrentQueuePriority())
                 nextTask.processAndSendToNextTask(evidence);
             else {
-                evidence.dispose();
-                SkipCommitedTask.checkAgainLaterProcessedParents(evidence);
-                worker.manager.getProcessingQueues().addItemToQueue(evidence, priority);
-                if (!evidence.isQueueEnd()) {
-                    worker.decItemsBeingProcessed();
-                }
+                reEnqueueItem(evidence, priority);
             }
         } else if (!evidence.isQueueEnd()) {
             // dec items being processed counter if this is last task
@@ -232,6 +245,20 @@ public abstract class AbstractTask {
                 }
                 stats.addVolume(len);
             }
+        }
+    }
+
+    protected void reEnqueueItem(IItem item) throws InterruptedException {
+        reEnqueueItem(item, worker.manager.getProcessingQueues().getCurrentQueuePriority());
+        throw new ItemReEnqueuedException();
+    }
+
+    private void reEnqueueItem(IItem item, int queue) throws InterruptedException {
+        item.dispose();
+        SkipCommitedTask.checkAgainLaterProcessedParents(item);
+        worker.manager.getProcessingQueues().addItemToQueue(item, queue);
+        if (!item.isQueueEnd()) {
+            worker.decItemsBeingProcessed();
         }
     }
 

--- a/iped-engine/src/main/java/iped/engine/task/EmbeddedDiskProcessTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/EmbeddedDiskProcessTask.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil;
 import org.apache.tika.mime.MediaType;
@@ -20,11 +21,13 @@ import iped.data.IItem;
 import iped.data.IItemReader;
 import iped.engine.config.ConfigurationManager;
 import iped.engine.config.EnableTaskProperty;
+import iped.engine.core.Manager;
 import iped.engine.data.Item;
 import iped.engine.datasource.SleuthkitReader;
 import iped.engine.search.ItemSearcher;
 import iped.engine.task.carver.BaseCarveTask;
 import iped.engine.util.TextCache;
+import iped.exception.IPEDException;
 import iped.parsers.standard.StandardParser;
 import iped.properties.BasicProps;
 import iped.properties.MediaTypes;
@@ -47,6 +50,8 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
 
     private static Set<File> exportedDisks = Collections.synchronizedSet(new HashSet<>());
 
+    private static AtomicBoolean embeddedDiskBeingExpanded = new AtomicBoolean();
+
     private boolean enabled = true;
 
     @Override
@@ -62,6 +67,11 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
     @Override
     public void init(ConfigurationManager configurationManager) throws Exception {
         enabled = configurationManager.getEnableTaskProperty(ENABLE_PARAM);
+
+        if (enabled && Manager.getInstance().getNumWorkers() == 1) {
+            // abort and warn user because this can cause a deadlock
+            throw new IPEDException("To enable '" + ENABLE_PARAM + "' you should have more than 1 Worker thread!");
+        }
     }
 
     @Override
@@ -124,6 +134,11 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
         // export first part if not done
         File imageFile = exportItem(item);
 
+        if (embeddedDiskBeingExpanded.getAndSet(true)) {
+            super.reEnqueueItem(item);
+            return;
+        }
+
         try (SleuthkitReader reader = new SleuthkitReader(true, caseData, output)) {
             logger.info("Decoding embedded disk image {} -> {}", item.getPath(), imageFile.getAbsolutePath());
             reader.read(imageFile, (Item) item);
@@ -139,6 +154,8 @@ public class EmbeddedDiskProcessTask extends AbstractTask {
             } else {
                 ((Item) item).setParsedTextCache(new TextCache());
             }
+        } finally {
+            embeddedDiskBeingExpanded.set(false);
         }
 
     }

--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -59,12 +59,12 @@ import iped.engine.config.CategoryToExpandConfig;
 import iped.engine.config.Configuration;
 import iped.engine.config.ConfigurationManager;
 import iped.engine.config.ExternalParsersConfig;
+import iped.engine.config.LocalConfig;
 import iped.engine.config.OCRConfig;
 import iped.engine.config.ParsersConfig;
 import iped.engine.config.ParsingTaskConfig;
 import iped.engine.config.PluginConfig;
 import iped.engine.config.SplitLargeBinaryConfig;
-import iped.engine.core.Manager;
 import iped.engine.core.Statistics;
 import iped.engine.core.Worker;
 import iped.engine.core.Worker.ProcessTime;
@@ -802,7 +802,8 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
             // do not open extra processes for OCR if ForkParser is enabled
             System.setProperty(PDFToImage.EXTERNAL_CONV_PROP, "false");
         } else {
-            max_expanding_containers = Math.max(Manager.getInstance().getNumWorkers() / 2, 1);
+            LocalConfig localConfig = configurationManager.findObject(LocalConfig.class);
+            max_expanding_containers = Math.max(localConfig.getNumThreads() / 2, 1);
         }
 
         String appRoot = Configuration.getInstance().appRoot;

--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
@@ -63,6 +64,7 @@ import iped.engine.config.ParsersConfig;
 import iped.engine.config.ParsingTaskConfig;
 import iped.engine.config.PluginConfig;
 import iped.engine.config.SplitLargeBinaryConfig;
+import iped.engine.core.Manager;
 import iped.engine.core.Statistics;
 import iped.engine.core.Worker;
 import iped.engine.core.Worker.ProcessTime;
@@ -141,11 +143,20 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
     private static final int MAX_SUBITEM_DEPTH = 100;
     private static final String SUBITEM_DEPTH = "subitemDepth"; //$NON-NLS-1$
 
+    /**
+     * Max number of containers expanded concurrently. Configured to be half the
+     * number of workers or external parsing processes if enabled. See
+     * https://github.com/sepinf-inc/IPED/issues/1358
+     */
+    private static int max_expanding_containers;
+
     public static AtomicLong totalText = new AtomicLong();
     public static Map<String, AtomicLong> times = Collections.synchronizedMap(new TreeMap<String, AtomicLong>());
 
     private static Map<Integer, ZipBombStats> zipBombStatsMap = new ConcurrentHashMap<>();
     private static final Set<MediaType> typesToCheckZipBomb = getTypesToCheckZipbomb();
+
+    private static AtomicInteger containersBeingExpanded = new AtomicInteger();
 
     private CategoryToExpandConfig expandConfig;
     private ParsingTaskConfig parsingConfig;
@@ -279,7 +290,7 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
         ((Item) evidence).setParsedTextCache(new TextCache());
     }
 
-	public void process(IItem evidence) throws IOException {
+    public void process(IItem evidence) throws Exception {
 
         long start = System.nanoTime() / 1000;
 
@@ -340,9 +351,19 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
         return autoParser.hasSpecificParser(evidence.getMetadata());
     }
 
-    private void safeProcess(IItem evidence) throws IOException {
+    private void safeProcess(IItem evidence) throws Exception {
 
         this.evidence = evidence;
+
+        context = getTikaContext();
+
+        if (this.extractEmbedded) {
+            if (containersBeingExpanded.incrementAndGet() > max_expanding_containers) {
+                containersBeingExpanded.decrementAndGet();
+                super.reEnqueueItem(evidence);
+                return;
+            }
+        }
 
         TikaInputStream tis = null;
         try {
@@ -350,10 +371,12 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
 
         } catch (IOException e) {
             LOGGER.warn("{} Error opening: {} {}", Thread.currentThread().getName(), evidence.getPath(), e.toString()); //$NON-NLS-1$
+            if (this.extractEmbedded) {
+                containersBeingExpanded.decrementAndGet();
+            }
             return;
         }
 
-        context = getTikaContext();
         if (evidence.getHashValue() != null && evidence.getLength() != null && evidence.getLength() > 0) {
             try {
                 File thumbFile = getThumbFile(evidence);
@@ -371,10 +394,10 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
             zipBombStatsMap.put(evidence.getId(), new ZipBombStats(evidence.getLength()));
         }
 
-        reader = new ParsingReader(this.autoParser, tis, metadata, context);
-        reader.startBackgroundParsing();
-
         try {
+            reader = new ParsingReader(this.autoParser, tis, metadata, context);
+            reader.startBackgroundParsing();
+
             TextCache textCache = new TextCache();
             textCache.setEnableDiskCache(parsingConfig.isStoreTextCacheOnDisk());
             char[] cbuf = new char[128 * 1024];
@@ -398,7 +421,10 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
 
         } finally {
             // IOUtil.closeQuietly(tis);
-            reader.close();
+            if (this.extractEmbedded) {
+                containersBeingExpanded.decrementAndGet();
+            }
+            IOUtil.closeQuietly(reader);
             if (numSubitems > 0) {
                 evidence.setExtraAttribute(NUM_SUBITEMS, numSubitems);
             }
@@ -655,8 +681,7 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
                 try {
                     long start = System.nanoTime() / 1000;
 
-                    // If external parsing is on, items are sent to queue to avoid deadlock
-                    ProcessTime time = ForkParser.isEnabled() ? ProcessTime.LATER : ProcessTime.AUTO;
+                    ProcessTime time = ProcessTime.AUTO;
 
                     worker.processNewItem(subItem, time);
                     Statistics.get().incSubitemsDiscovered();
@@ -767,9 +792,12 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
             PluginConfig pluginConfig = configurationManager.findObject(PluginConfig.class);
             ForkParser.setPluginDir(pluginConfig.getPluginFolder().getAbsolutePath());
             ForkParser.setPoolSize(parsingConfig.getNumExternalParsers());
+            max_expanding_containers = parsingConfig.getNumExternalParsers() / 2;
             ForkParser.setServerMaxHeap(parsingConfig.getExternalParsingMaxMem());
             // do not open extra processes for OCR if ForkParser is enabled
             System.setProperty(PDFToImage.EXTERNAL_CONV_PROP, "false");
+        } else {
+            max_expanding_containers = Manager.getInstance().getNumWorkers() / 2;
         }
 
         String appRoot = Configuration.getInstance().appRoot;

--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -654,17 +654,10 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
             if (reader.setTimeoutPaused(true)) {
                 try {
                     long start = System.nanoTime() / 1000;
-                    // If external parsing is on, items are sent to queue to avoid deadlock
-                    // ProcessTime time = ForkParser2.enabled ? ProcessTime.LATER :
-                    // ProcessTime.AUTO;
 
-                    // Unfortunatelly AUTO value causes issues with JEP (python lib) too,
-                    // because items could be processed by Workers in a different thread (parsing
-                    // thread), instead of Worker default thread. So we are using LATER, which sends
-                    // items to queue and is a bit slower when expanding lots of containers at the
-                    // same time (causes a lot of IO instead mixing IO with CPU used to process
-                    // subitems)
-                    ProcessTime time = ProcessTime.LATER;
+                    // If external parsing is on, items are sent to queue to avoid deadlock
+                    ProcessTime time = ForkParser.isEnabled() ? ProcessTime.LATER : ProcessTime.AUTO;
+
                     worker.processNewItem(subItem, time);
                     Statistics.get().incSubitemsDiscovered();
                     numSubitems++;


### PR DESCRIPTION
Fix #1358. Proposed solution is:
- python tasks were improved to run from non worker threads, like parsing threads;
- number of containers being expanded simultaneously was limited to half the number of workers or half the number of external parsing processes (if they are enabled), re-enqueuing other containers. Then parsing threads or processes will be available to parse produced subitems immediately, so we don't need to enqueue them without bound;
- embedded virtual disks were already being decoded one by one, but the logic was changed to re-enqueue them in a similar way instead of blocking worker threads. This also allows to apply processing queue bounds when enqueuing their decoded items;