### PR TITLE
Handle Windows unmapped network paths (#1336)

### DIFF
--- a/iped-api/src/main/java/iped/io/URLUtil.java
+++ b/iped-api/src/main/java/iped/io/URLUtil.java
@@ -1,0 +1,34 @@
+package iped.io;
+
+import java.net.URL;
+import java.security.ProtectionDomain;
+
+public class URLUtil {
+    /**
+     * Return a URL from a Class. This method was created to handle Windows unmapped
+     * network paths, like \\server\case. It adds another "//" before the actual
+     * path name, to avoid an IllegalArgumentException: URI has an authority
+     * component. See issue #1336.
+     */
+    public static URL getURL(Class<?> clazz) {
+        return getURL(clazz.getProtectionDomain());
+    }
+
+    /**
+     * Return a URL from a ProtectionDomain.
+     */
+    public static URL getURL(ProtectionDomain domain) {
+        URL url = domain.getCodeSource().getLocation();
+        if (url != null && "file".equalsIgnoreCase(url.getProtocol()) && url.getPath() != null
+                && url.getPath().startsWith("//")) {
+            try {
+                URL newUrl = new URL("file://" + url.getPath());
+                if (newUrl != null) {
+                    url = newUrl;
+                }
+            } catch (Exception e) {
+            }
+        }
+        return url;
+    }
+}

--- a/iped-api/src/main/java/iped/localization/Messages.java
+++ b/iped-api/src/main/java/iped/localization/Messages.java
@@ -15,6 +15,8 @@ import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.ResourceBundle.Control;
 
+import iped.io.URLUtil;
+
 public class Messages {
 
     public static final String LOCALE_SYS_PROP = "iped-locale";
@@ -27,7 +29,7 @@ public class Messages {
     public static ResourceBundle getExternalBundle(String bundleName, Locale locale) {
         File file = null;
         try {
-            URL url = Messages.class.getProtectionDomain().getCodeSource().getLocation();
+            URL url = URLUtil.getURL(Messages.class);
             file = new File(new File(url.toURI()).getParentFile().getParentFile(), BUNDLES_FOLDER);
         } catch (URISyntaxException e1) {
             e1.printStackTrace();

--- a/iped-app/src/main/java/iped/app/processing/Main.java
+++ b/iped-app/src/main/java/iped/app/processing/Main.java
@@ -37,6 +37,7 @@ import iped.engine.core.Manager;
 import iped.engine.localization.Messages;
 import iped.engine.util.UIPropertyListenerProvider;
 import iped.exception.IPEDException;
+import iped.io.URLUtil;
 import iped.parsers.ocr.OCRParser;
 
 /**
@@ -143,7 +144,7 @@ public class Main {
      * Define o caminho onde será encontrado o arquivo de configuração principal.
      */
     public void setConfigPath() throws Exception {
-        URL url = Main.class.getProtectionDomain().getCodeSource().getLocation();
+        URL url = URLUtil.getURL(Main.class);
 
         if ("true".equals(System.getProperty("Debugging"))) {
             rootPath = System.getProperty("user.dir");

--- a/iped-app/src/main/java/iped/app/ui/AppMain.java
+++ b/iped-app/src/main/java/iped/app/ui/AppMain.java
@@ -18,6 +18,7 @@ import iped.engine.Version;
 import iped.engine.config.Configuration;
 import iped.engine.core.Manager;
 import iped.engine.util.Util;
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 
 public class AppMain {
@@ -92,7 +93,7 @@ public class AppMain {
     }
 
     private File detectLibDir() throws URISyntaxException {
-        URL url = AppMain.class.getProtectionDomain().getCodeSource().getLocation();
+        URL url = URLUtil.getURL(AppMain.class);
         File jarFile = null;
         if (url.toURI().getAuthority() == null)
             jarFile = new File(url.toURI());

--- a/iped-app/src/main/java/iped/app/ui/ReportDialog.java
+++ b/iped-app/src/main/java/iped/app/ui/ReportDialog.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import iped.app.bootstrap.Bootstrap;
 import iped.app.processing.CmdLineArgsImpl;
+import iped.io.URLUtil;
 
 public class ReportDialog implements ActionListener, TableModelListener {
 
@@ -263,7 +264,7 @@ public class ReportDialog implements ActionListener, TableModelListener {
         String output = this.output.getText().trim();
         logger.info("Generating report to " + output); //$NON-NLS-1$
 
-        URL url = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+        URL url = URLUtil.getURL(this.getClass());
         try {
             String classpath = new File(url.toURI()).getAbsolutePath();
             if (!classpath.endsWith(".jar")) //$NON-NLS-1$

--- a/iped-app/src/main/java/iped/app/ui/ViewerController.java
+++ b/iped-app/src/main/java/iped/app/ui/ViewerController.java
@@ -30,6 +30,7 @@ import iped.app.ui.viewers.HexSearcherImpl;
 import iped.app.ui.viewers.TextViewer;
 import iped.engine.task.index.IndexItem;
 import iped.io.IStreamSource;
+import iped.io.URLUtil;
 import iped.viewers.ATextViewer;
 import iped.viewers.CADViewer;
 import iped.viewers.EmailViewer;
@@ -112,7 +113,7 @@ public class ViewerController {
                     }
 
                     // LibreOffice viewer initialization
-                    URI jarUri = LibreOfficeViewer.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+                    URI jarUri = URLUtil.getURL(LibreOfficeViewer.class).toURI();
                     File moduledir = new File(jarUri).getParentFile().getParentFile();
                     LibreOfficeFinder loFinder = new LibreOfficeFinder(moduledir);
                     final String pathLO = loFinder.getLOPath();

--- a/iped-engine/src/main/java/iped/engine/graph/GraphImportRunner.java
+++ b/iped-engine/src/main/java/iped/engine/graph/GraphImportRunner.java
@@ -21,6 +21,8 @@ import org.neo4j.cli.AdminTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import iped.io.URLUtil;
+
 public class GraphImportRunner {
 
     private static Logger LOGGER = LoggerFactory.getLogger(GraphImportRunner.class);
@@ -76,7 +78,7 @@ public class GraphImportRunner {
         args.add(getJreExecutable().getAbsolutePath());
         args.add("-cp");
         try {
-            URL url = AdminTool.class.getProtectionDomain().getCodeSource().getLocation();
+            URL url = URLUtil.getURL(AdminTool.class);
             args.add(new File(url.toURI()).getParentFile().getAbsolutePath() + "/*");
         } catch (URISyntaxException e1) {
             throw new IOException(e1);

--- a/iped-engine/src/main/java/iped/engine/graph/links/SearchLinksQueryProvider.java
+++ b/iped-engine/src/main/java/iped/engine/graph/links/SearchLinksQueryProvider.java
@@ -10,6 +10,8 @@ import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import iped.io.URLUtil;
+
 public class SearchLinksQueryProvider {
 
     private Logger LOGGER = LoggerFactory.getLogger(SearchLinksQueryProvider.class);
@@ -51,7 +53,7 @@ public class SearchLinksQueryProvider {
 
     private String getLocation(SearchLinksQuery query) {
         try {
-            URL location = query.getClass().getProtectionDomain().getCodeSource().getLocation();
+            URL location = URLUtil.getURL(query.getClass());
             return location.toString();
         } catch (SecurityException e) {
             return null;

--- a/iped-engine/src/main/java/iped/engine/task/DocThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/DocThumbTask.java
@@ -38,6 +38,7 @@ import iped.engine.config.ConfigurationManager;
 import iped.engine.config.DocThumbTaskConfig;
 import iped.engine.config.ParsingTaskConfig;
 import iped.engine.task.carver.BaseCarveTask;
+import iped.io.URLUtil;
 import iped.parsers.misc.PDFTextParser;
 import iped.parsers.standard.StandardParser;
 import iped.parsers.util.PDFToThumb;
@@ -90,7 +91,7 @@ public class DocThumbTask extends ThumbTask {
                     logger.info("Thumb Size: " + docThumbsConfig.getThumbSize());
                     logger.info("LibreOffice Conversion: " + (docThumbsConfig.isLoEnabled() ? "enabled" : "disabled"));
                     if (docThumbsConfig.isLoEnabled()) {
-                        URL url = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+                        URL url = URLUtil.getURL(this.getClass());
                         File jarDir = new File(url.toURI()).getParentFile();
                         LibreOfficeFinder loFinder = new LibreOfficeFinder(jarDir);
                         loPath = loFinder.getLOPath();
@@ -282,7 +283,7 @@ public class DocThumbTask extends ThumbTask {
             try {
                 Exception exception = null;
                 if (docThumbsConfig.isExternalPdfConversion()) {
-                    URL url = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+                    URL url = URLUtil.getURL(this.getClass());
                     String jarDir = new File(url.toURI()).getParent();
                     String classpath = jarDir + "/*";
                     File file = item.getTempFile();

--- a/iped-engine/src/main/java/iped/engine/task/regex/RegexValidator.java
+++ b/iped-engine/src/main/java/iped/engine/task/regex/RegexValidator.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import iped.engine.task.regex.RegexTask.Regex;
+import iped.io.URLUtil;
 
 public class RegexValidator {
 
@@ -83,7 +84,7 @@ public class RegexValidator {
 
     private String getLocation(RegexValidatorService service) {
         try {
-            URL location = service.getClass().getProtectionDomain().getCodeSource().getLocation();
+            URL location = URLUtil.getURL(service.getClass());
             return location.toString();
         } catch (SecurityException e) {
             return null;

--- a/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
+++ b/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
@@ -28,6 +28,7 @@ import iped.engine.config.Configuration;
 import iped.engine.config.ConfigurationManager;
 import iped.engine.config.LocalConfig;
 import iped.engine.task.transcript.AbstractTranscriptTask.TextAndScore;
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 
 public class RemoteWav2Vec2Service {
@@ -89,7 +90,7 @@ public class RemoteWav2Vec2Service {
             printHelpAndExit();
         }
 
-        File jar = new File(RemoteWav2Vec2Service.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        File jar = new File(URLUtil.getURL(RemoteWav2Vec2Service.class).toURI());
         File root = jar.getParentFile().getParentFile();
 
         System.setProperty("org.apache.logging.log4j.level", "INFO");

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/external/ExternalParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/external/ExternalParser.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 
 /**
@@ -238,7 +239,7 @@ public class ExternalParser extends AbstractParser {
         if (rootFolder != null)
             return rootFolder;
 
-        URL url = ExternalParser.class.getProtectionDomain().getCodeSource().getLocation();
+        URL url = URLUtil.getURL(ExternalParser.class);
         try {
             rootFolder = new File(url.toURI()).getParentFile().getParentFile().getAbsolutePath();
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/fork/ForkParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/fork/ForkParser.java
@@ -45,6 +45,7 @@ import org.apache.tika.sax.AbstractRecursiveParserWrapperHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 
 public class ForkParser extends AbstractParser {
@@ -136,7 +137,7 @@ public class ForkParser extends AbstractParser {
     }
 
     private static Path getMainJarsPath() {
-        URL url = ForkParser.class.getProtectionDomain().getCodeSource().getLocation();
+        URL url = URLUtil.getURL(ForkParser.class);
         Path jarPath = null;
         try {
             jarPath = new File(url.toURI()).getParentFile().toPath();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/PDFToImage.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/PDFToImage.java
@@ -42,6 +42,7 @@ import org.icepdf.core.util.GraphicsRenderingHints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 
 /**
@@ -164,7 +165,7 @@ public class PDFToImage implements Closeable {
                     throw new IOException("Error: no writer found for image format '" + EXT + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 
             } else {
-                URL url = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+                URL url = URLUtil.getURL(this.getClass());
                 String jarDir = new File(url.toURI()).getParent();
                 String classpath = jarDir + "/*"; //$NON-NLS-1$
                 String[] cmd = { "java", "-cp", classpath, "-Xmx" + externalConvMaxMem, //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/CADViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/CADViewer.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import iped.io.IStreamSource;
+import iped.io.URLUtil;
 import iped.utils.IOUtil;
 import iped.viewers.api.AbstractViewer;
 import iped.viewers.localization.Messages;
@@ -45,7 +46,7 @@ public class CADViewer extends AbstractViewer {
         this.getPanel().add(externalViewerPanel);
 
         try {
-            basePath = new File(CADViewer.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            basePath = new File(URLUtil.getURL(CADViewer.class).toURI());
             basePath = basePath.getParentFile().getParentFile();
 
         } catch (URISyntaxException e) {

--- a/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/util/DefaultPolicy.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/util/DefaultPolicy.java
@@ -10,6 +10,7 @@ import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.List;
 
+import iped.io.URLUtil;
 import iped.viewers.HtmlViewer;
 
 /**
@@ -27,7 +28,7 @@ public class DefaultPolicy extends Policy {
 
     private static URI getHtmlViewerURI() {
         try {
-            return HtmlViewer.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            return URLUtil.getURL(HtmlViewer.class).toURI();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -42,7 +43,7 @@ public class DefaultPolicy extends Policy {
 
         try {
 
-            if (domain.getCodeSource() == null || domain.getCodeSource().getLocation() == null) {
+            if (domain.getCodeSource() == null || URLUtil.getURL(domain) == null) {
                 return true;
             }
 
@@ -52,7 +53,7 @@ public class DefaultPolicy extends Policy {
                 }
             }
 
-            URI from = domain.getCodeSource().getLocation().toURI();
+            URI from = URLUtil.getURL(domain).toURI();
             if (from.equals(viewer) && (perm instanceof SocketPermission || perm instanceof URLPermission)) {
                 return false;
             }


### PR DESCRIPTION
### Issue Cause

Opening a case from an unmapped network path (e.g. `\\myserver\case123`) wasn't working because of calls like the following one:
```
URL url = XyzClass.class.getProtectionDomain().getCodeSource().getLocation();
File file = new File(url.toURI());
```
The `URL` returned in the first line starts with something like `file://myserver/case123`.
The conversion to a `URI` (second line) fails with this kind of input.

### Proposed Solution

I created an utility method that builds a new URL when it detects the "file" protocol and starting with "//", using "file:////" as the beginning.
All calls throughout the code were replaced, so the new utility method is used.

A project organization detail: I created the new method in `iped-api` subproject. Initially I placed it in `iped-utils`, but as there is localization-related code in `iped-api` that needs to use the new function, I ended up moving it to `iped-api`.