### PR TITLE
Do not reset media type (#1409)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/index/IndexItem.java
+++ b/iped-engine/src/main/java/iped/engine/task/index/IndexItem.java
@@ -884,7 +884,8 @@ public class IndexItem extends BasicProps {
                         evidence.setIdInDataSource("");
                         evidence.setInputStreamFactory(new FileInputStreamFactory(viewFile.toPath()));
                         evidence.setTempFile(viewFile);
-                        evidence.setMediaType(null);
+                        // Do not reset media type (see issue #1409)
+                        // evidence.setMediaType(null);
                     }
                 }
             }


### PR DESCRIPTION
Fix #1409.
I ran a few tests here, and not resetting media type fixes the issue and doesn't seem to affect the "viewing process" (i.e. the preferred viewer still works).