### PR TITLE
PDF Rendering Quality (#1426)

### DIFF
--- a/iped-engine/pom.xml
+++ b/iped-engine/pom.xml
@@ -263,7 +263,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.64</version>
+			<version>1.70</version>
 		</dependency>
 		<dependency>
             <groupId>de.ruedigermoeller</groupId>

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -96,7 +96,7 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.icepdf</groupId>
+            <groupId>com.github.pcorless.icepdf</groupId>
             <artifactId>icepdf-core</artifactId>
             <version>${icepdf.version}</version>
             <type>jar</type>

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -100,6 +100,16 @@
             <artifactId>icepdf-core</artifactId>
             <version>${icepdf.version}</version>
             <type>jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jai-imageio</groupId>
+                    <artifactId>jai-imageio-jpeg2000</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-ext-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>iped</groupId>

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -122,6 +122,12 @@
     		<artifactId>imageio-bmp</artifactId>
     		<version>3.8.3</version>
 	  	</dependency>
+	  	<dependency>
+	  	    <!--Used by IcePDF-7.0-->
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-tiff</artifactId>
+            <version>3.8.3</version>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -97,7 +97,7 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.icepdf</groupId>
+            <groupId>com.github.pcorless.icepdf</groupId>
             <artifactId>icepdf-viewer</artifactId>
             <version>${icepdf.version}</version>
             <type>jar</type>

--- a/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/IcePDFViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/IcePDFViewer.java
@@ -21,7 +21,7 @@ import org.icepdf.ri.common.SwingViewBuilder;
 import org.icepdf.ri.common.views.DocumentViewController;
 import org.icepdf.ri.common.views.DocumentViewControllerImpl;
 import org.icepdf.ri.common.views.DocumentViewModelImpl;
-import org.icepdf.ri.util.PropertiesManager;
+import org.icepdf.ri.util.ViewerPropertiesManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,13 +113,15 @@ public class IcePDFViewer extends AbstractViewer {
         pdfController.getDocumentViewController().setAnnotationCallback(
                 new org.icepdf.ri.common.MyAnnotationCallback(pdfController.getDocumentViewController()));
 
-        PropertiesManager propManager = PropertiesManager.getInstance();
-        propManager.set(PropertiesManager.PROPERTY_SHOW_TOOLBAR_ANNOTATION, "false"); //$NON-NLS-1$
-        propManager.set(PropertiesManager.PROPERTY_SHOW_TOOLBAR_TOOL, "false"); //$NON-NLS-1$
-        propManager.set(PropertiesManager.PROPERTY_SHOW_TOOLBAR_ZOOM, "true"); //$NON-NLS-1$
-        propManager.set(PropertiesManager.PROPERTY_SHOW_STATUSBAR, "false"); //$NON-NLS-1$
-        propManager.set(PropertiesManager.PROPERTY_HIDE_UTILITYPANE, "true"); //$NON-NLS-1$
-        propManager.set(PropertiesManager.PROPERTY_DEFAULT_PAGEFIT, Integer.toString(fitMode));
+        ViewerPropertiesManager propManager = ViewerPropertiesManager.getInstance();
+        propManager.set(ViewerPropertiesManager.PROPERTY_SHOW_TOOLBAR_ANNOTATION, "false"); //$NON-NLS-1$
+        propManager.set(ViewerPropertiesManager.PROPERTY_SHOW_TOOLBAR_TOOL, "false"); //$NON-NLS-1$
+        propManager.set(ViewerPropertiesManager.PROPERTY_SHOW_TOOLBAR_ZOOM, "true"); //$NON-NLS-1$
+        propManager.set(ViewerPropertiesManager.PROPERTY_SHOW_STATUSBAR, "false"); //$NON-NLS-1$
+        propManager.set(ViewerPropertiesManager.PROPERTY_HIDE_UTILITYPANE, "true"); //$NON-NLS-1$
+        propManager.set(ViewerPropertiesManager.PROPERTY_DEFAULT_PAGEFIT, Integer.toString(fitMode));
+        propManager.set(ViewerPropertiesManager.PROPERTY_SHOW_TOOLBAR_SEARCH, "false"); //$NON-NLS-1$
+        
 
         SwingViewBuilder factory = new SwingViewBuilder(pdfController, viewMode, fitMode);
         viewerPanel = factory.buildViewerPanel();

--- a/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/IcePDFViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/IcePDFViewer.java
@@ -64,6 +64,13 @@ public class IcePDFViewer extends AbstractViewer {
         System.setProperty("org.icepdf.core.ccittfax.jai", "true"); //$NON-NLS-1$ //$NON-NLS-2$
         System.setProperty("org.icepdf.core.minMemory", "150M"); //$NON-NLS-1$ //$NON-NLS-2$
         System.setProperty("org.icepdf.core.views.page.text.highlightColor", "0xFFFF00"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        // Set rendering hints to improve rendering quality
+        System.setProperty("org.icepdf.core.screen.alphaInterpolation","VALUE_ALPHA_INTERPOLATION_QUALITY"); //$NON-NLS-1$ //$NON-NLS-2$
+        System.setProperty("org.icepdf.core.screen.colorRender","VALUE_COLOR_RENDER_QUALITY"); //$NON-NLS-1$ //$NON-NLS-2$
+        System.setProperty("org.icepdf.core.screen.interpolation","VALUE_INTERPOLATION_BILINEAR"); //$NON-NLS-1$ //$NON-NLS-2$
+        System.setProperty("org.icepdf.core.screen.render","VALUE_RENDER_QUALITY"); //$NON-NLS-1$ //$NON-NLS-2$
+        
         // pode provocar crash da jvm
         // System.setProperty("org.icepdf.core.awtFontLoading", "true");
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <junit.version>4.13.1</junit.version>
-        <icepdf.version>6.3.2</icepdf.version>
+        <icepdf.version>7.0.0</icepdf.version>
         <java.dbx.version>1.1-p6</java.dbx.version>
         <xerial.sqlite.version>3.34.0</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>


### PR DESCRIPTION
As discussed in #1426, if it is not possible to upgrade IcePDF because of its dependencies, maybe we could apply only the second commit (https://github.com/sepinf-inc/IPED/commit/c9244853c8196fc58f44349e0e0ad5b16c644493), which should help when using a UI scale != 1.0.