### PR TITLE
'#1107: new option to extract video frames at a fixed time interval

### DIFF
--- a/iped-app/resources/config/conf/VideoThumbsConfig.txt
+++ b/iped-app/resources/config/conf/VideoThumbsConfig.txt
@@ -31,6 +31,11 @@ GalleryThumbs = 320,2,3
 # image processing pipeline (ocr, image similarity, and others)
 enableVideoThumbsSubitems = false
 
+# If enabled, set the milliseconds interval to extract frames from videos as subitems.
+# This applies just if 'enableVideoThumbsSubitems' is enabled.
+# At least a minimum of <columns> x <rows> frames from 'Layout' option are extracted.
+#framesMillisecondsInterval = 1000
+
 # Enables video frames extraction using original video resolution to be applied on Video Thumbs Subitems.
 # If enabled, first value of 'Layout' option above will be ignored.
 # This should help face detection on videos and other future features (like video ocr, so on...)

--- a/iped-app/resources/config/conf/VideoThumbsConfig.txt
+++ b/iped-app/resources/config/conf/VideoThumbsConfig.txt
@@ -31,10 +31,11 @@ GalleryThumbs = 320,2,3
 # image processing pipeline (ocr, image similarity, and others)
 enableVideoThumbsSubitems = false
 
-# If enabled, set the milliseconds interval to extract frames from videos as subitems.
+# If enabled, uses a javascript function to compute the number of frames to extract from videos as subitems.
+# You can use the 'duration' variable: the video duration in seconds.
 # This applies just if 'enableVideoThumbsSubitems' is enabled.
 # At least a minimum of <columns> x <rows> frames from 'Layout' option are extracted.
-#framesMillisecondsInterval = 1000
+#numFramesEquation = Math.sqrt(duration)
 
 # Enables video frames extraction using original video resolution to be applied on Video Thumbs Subitems.
 # If enabled, first value of 'Layout' option above will be ignored.

--- a/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
@@ -30,6 +30,8 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     private static final String MAX_DIMENSION_SIZE = "maxDimensionSize";
 
+    private static final String FRAMES_MILLIS_INTERVAL = "framesMillisecondsInterval";
+
     /**
      * Image width of extracted frame.
      */
@@ -86,6 +88,12 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
      */
     private int maxDimensionSize = 1024;
 
+    /**
+     * Milliseconds interval to extract frames. -1 means disabled.
+     */
+    private int framesMillisecondsInterval = -1;
+
+
     public int getWidth() {
         return width;
     }
@@ -136,6 +144,10 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     public int getMaxDimensionSize() {
         return maxDimensionSize;
+    }
+
+    public int getFramesMillisecondsInterval() {
+        return this.framesMillisecondsInterval;
     }
 
     @Override
@@ -205,6 +217,11 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         value = properties.getProperty(MAX_DIMENSION_SIZE);
         if (value != null) {
             maxDimensionSize = Integer.parseInt(value.trim());
+        }
+        
+        value = properties.getProperty(FRAMES_MILLIS_INTERVAL);
+        if (value != null) {
+            framesMillisecondsInterval = Integer.parseInt(value.trim());
         }
 
     }

--- a/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
@@ -30,7 +30,7 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     private static final String MAX_DIMENSION_SIZE = "maxDimensionSize";
 
-    private static final String FRAMES_MILLIS_INTERVAL = "framesMillisecondsInterval";
+    private static final String NUM_FRAMES_EQUATION = "numFramesEquation";
 
     /**
      * Image width of extracted frame.
@@ -89,9 +89,10 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
     private int maxDimensionSize = 1024;
 
     /**
-     * Milliseconds interval to extract frames. -1 means disabled.
+     * Javascript equation to compute number of extracted thumbs from video duration
+     * in seconds.
      */
-    private int framesMillisecondsInterval = -1;
+    private String numFramesEquation;
 
 
     public int getWidth() {
@@ -146,8 +147,8 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         return maxDimensionSize;
     }
 
-    public int getFramesMillisecondsInterval() {
-        return this.framesMillisecondsInterval;
+    public String getNumFramesEquation() {
+        return this.numFramesEquation;
     }
 
     @Override
@@ -219,9 +220,9 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
             maxDimensionSize = Integer.parseInt(value.trim());
         }
         
-        value = properties.getProperty(FRAMES_MILLIS_INTERVAL);
+        value = properties.getProperty(NUM_FRAMES_EQUATION);
         if (value != null) {
-            framesMillisecondsInterval = Integer.parseInt(value.trim());
+            numFramesEquation = value.trim();
         }
 
     }

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
@@ -272,6 +272,7 @@ public class VideoThumbTask extends ThumbTask {
         videoThumbsMaker.setTimeoutInfo(videoConfig.getTimeoutInfo());
         videoThumbsMaker.setVideoThumbsOriginalDimension(videoConfig.getVideoThumbsOriginalDimension());
         videoThumbsMaker.setMaxDimensionSize(videoConfig.getMaxDimensionSize());
+        videoThumbsMaker.setFramesMillisecondsInterval(videoConfig.getFramesMillisecondsInterval());
 
         // Cria configurações de extração de cenas
         configs = new ArrayList<VideoThumbsOutputConfig>();

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
@@ -272,7 +272,7 @@ public class VideoThumbTask extends ThumbTask {
         videoThumbsMaker.setTimeoutInfo(videoConfig.getTimeoutInfo());
         videoThumbsMaker.setVideoThumbsOriginalDimension(videoConfig.getVideoThumbsOriginalDimension());
         videoThumbsMaker.setMaxDimensionSize(videoConfig.getMaxDimensionSize());
-        videoThumbsMaker.setFramesMillisecondsInterval(videoConfig.getFramesMillisecondsInterval());
+        videoThumbsMaker.setNumFramesEquation(videoConfig.getNumFramesEquation());
 
         // Cria configurações de extração de cenas
         configs = new ArrayList<VideoThumbsOutputConfig>();

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
@@ -37,6 +37,7 @@ public class VideoThumbsMaker {
     private String mplayer = "mplayer.exe"; //$NON-NLS-1$
     private Boolean videoThumbsOriginalDimension = false;
     private int maxDimensionSize = 1024;
+    private int framesMillisecondsInterval = -1;
     private int timeoutProcess = 45000;
     private int timeoutInfo = 15000;
     private int timeoutFirstCall = 300000;
@@ -161,9 +162,18 @@ public class VideoThumbsMaker {
                 maxSize = config.getThumbWidth();
             }
         }
+
         int frequency = (int) ((result.getVideoDuration() - 1000) * 0.00095 / (maxThumbs + 2));
         if (frequency < 1) {
             frequency = 1;
+        }
+        
+        if (framesMillisecondsInterval > 0) {
+            int newMaxThumbs = (int) (result.getVideoDuration() / framesMillisecondsInterval) + 1;
+            if (newMaxThumbs > maxThumbs) {
+                maxThumbs = newMaxThumbs;
+                frequency = 1; // this will cause frameStep to be used below
+            }
         }
 
         File[] files = null;
@@ -534,6 +544,10 @@ public class VideoThumbsMaker {
 
     public String getMPlayer() {
         return mplayer;
+    }
+
+    public void setFramesMillisecondsInterval(int framesMillisecondsInterval) {
+        this.framesMillisecondsInterval = framesMillisecondsInterval;
     }
 
     public void setVideoThumbsOriginalDimension(Boolean videoThumbsOriginalDimension) {

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.imageio.ImageIO;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
 
 import iped.utils.ImageUtil;
 
@@ -37,7 +40,8 @@ public class VideoThumbsMaker {
     private String mplayer = "mplayer.exe"; //$NON-NLS-1$
     private Boolean videoThumbsOriginalDimension = false;
     private int maxDimensionSize = 1024;
-    private int framesMillisecondsInterval = -1;
+    private String numFramesEquation;
+    private ScriptEngine scriptEngine;
     private int timeoutProcess = 45000;
     private int timeoutInfo = 15000;
     private int timeoutFirstCall = 300000;
@@ -168,8 +172,8 @@ public class VideoThumbsMaker {
             frequency = 1;
         }
         
-        if (framesMillisecondsInterval > 0) {
-            int newMaxThumbs = (int) (result.getVideoDuration() / framesMillisecondsInterval) + 1;
+        if (numFramesEquation != null) {
+            int newMaxThumbs = getNumFramesFromJSEquation(result.getVideoDuration() / 1000) + 1;
             if (newMaxThumbs > maxThumbs) {
                 maxThumbs = newMaxThumbs;
                 frequency = 1; // this will cause frameStep to be used below
@@ -538,6 +542,21 @@ public class VideoThumbsMaker {
         return null;
     }
 
+    private int getNumFramesFromJSEquation(long duration) {
+        if (scriptEngine == null) {
+            ScriptEngineManager manager = new ScriptEngineManager();
+            scriptEngine = manager.getEngineByExtension("js"); // $NON-NLS-1$
+        }
+        scriptEngine.put("duration", duration);
+        try {
+            Object result = scriptEngine.eval(numFramesEquation);
+            return ((Number) result).intValue();
+
+        } catch (ScriptException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void setMPlayer(String mplayer) {
         this.mplayer = mplayer;
     }
@@ -546,8 +565,8 @@ public class VideoThumbsMaker {
         return mplayer;
     }
 
-    public void setFramesMillisecondsInterval(int framesMillisecondsInterval) {
-        this.framesMillisecondsInterval = framesMillisecondsInterval;
+    public void setNumFramesEquation(String numFramesEquation) {
+        this.numFramesEquation = numFramesEquation;
     }
 
     public void setVideoThumbsOriginalDimension(Boolean videoThumbsOriginalDimension) {


### PR DESCRIPTION
Closes #1107.

@tc-wleite I was a bit confused about this formula:
`int frequency = (int) ((result.getVideoDuration() - 1000) * 0.00095 / (maxThumbs + 2));`

Not sure about the 95% and also about `(maxThumbs + 2)` also present in frameStep computation. But I tried to not change previous logic, it seems ok, please take a look.

Should we also add another optional configuration to attenuate the number of frames extracted, like applying square root to the number of frames?