### PR TITLE
BUG: the new memory month index needs the list of timeperiod cached entries sorted

### DIFF
--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
@@ -1,6 +1,7 @@
 package iped.app.timelinegraph.cache;
 
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -94,6 +95,9 @@ public class TimeIndexedMap extends HashMap<String, List<CacheTimePeriodEntry>> 
             if (maxDate == null) {
                 maxDate = new Date(0);
             }
+            
+            Collections.sort(value);
+            
             int i = 0;
             for (Iterator iterator = value.iterator(); iterator.hasNext();) {
                 CacheTimePeriodEntry cacheTimePeriodEntry = (CacheTimePeriodEntry) iterator.next();


### PR DESCRIPTION
The new memory month index needs the list of timeperiod cached entries sorted.

Some bars weren't showing when changing filters on high zoom in levels.
