### PR TITLE
#1281 aioobe indexing huge files

### DIFF
--- a/iped-app/resources/config/IPEDConfig.txt
+++ b/iped-app/resources/config/IPEDConfig.txt
@@ -81,12 +81,6 @@ enableGraphGeneration = true
 # May cause loss of hits surrounded by "random" content.
 entropyTest = true
 
-# Large binary files or those without a specific parser will be split before being processed. 
-# This makes hit/regex highlighting in large files (pagefile, VSS, unallocated...) a lot faster
-# and allows exporting relevant data chunks to reports without exporting the whole file.
-# The original file is kept in case, although it is not processed by most modules.
-enableSplitLargeBinary = true
-
 # Indexes files contents. If disabled, indexes only the properties of files.
 indexFileContents = true
 

--- a/iped-engine/src/main/java/iped/engine/config/SplitLargeBinaryConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/SplitLargeBinaryConfig.java
@@ -1,15 +1,18 @@
 package iped.engine.config;
 
+import java.io.IOException;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.Path;
+
 import iped.utils.UTF8Properties;
 
-public class SplitLargeBinaryConfig extends AbstractTaskPropertiesConfig {
+public class SplitLargeBinaryConfig extends AbstractPropertiesConfigurable {
 
     /**
      * 
      */
     private static final long serialVersionUID = 1L;
 
-    private static final String ENABLE_PARAM = "enableSplitLargeBinary";
     private static final String CONF_FILE = "SplitLargeBinaryConfig.txt";
 
     private long minItemSizeToFragment = 100 * 1024 * 1024;
@@ -26,16 +29,6 @@ public class SplitLargeBinaryConfig extends AbstractTaskPropertiesConfig {
 
     public int getFragmentOverlapSize() {
         return fragmentOverlapSize;
-    }
-
-    @Override
-    public String getTaskEnableProperty() {
-        return ENABLE_PARAM;
-    }
-
-    @Override
-    public String getTaskConfigFileName() {
-        return CONF_FILE;
     }
 
     @Override
@@ -56,6 +49,16 @@ public class SplitLargeBinaryConfig extends AbstractTaskPropertiesConfig {
             fragmentOverlapSize = Integer.valueOf(value.trim());
         }
 
+    }
+
+    @Override
+    public Filter<Path> getResourceLookupFilter() {
+        return new Filter<Path>() {
+            @Override
+            public boolean accept(Path entry) throws IOException {
+                return entry.endsWith(CONF_FILE);
+            }
+        };
     }
 
 }

--- a/iped-engine/src/main/java/iped/engine/task/FragmentLargeBinaryTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/FragmentLargeBinaryTask.java
@@ -12,7 +12,6 @@ import iped.engine.datasource.SleuthkitReader;
 import iped.engine.task.carver.BaseCarveTask;
 import iped.engine.util.TextCache;
 import iped.parsers.standard.StandardParser;
-import iped.parsers.util.MetadataUtil;
 
 /**
  * Breaks large binary files (indexed by strings) into smaller pieces to be
@@ -24,7 +23,7 @@ import iped.parsers.util.MetadataUtil;
 public class FragmentLargeBinaryTask extends BaseCarveTask {
 
     // workaround for https://github.com/sepinf-inc/IPED/issues/1281
-    private static final long MIN_SPLIT_SIZE_IF_XHTML_OR_ERROR = 1 << 30;
+    private static final int TEXT_SPLIT_SIZE = 1 << 30;
 
     private SplitLargeBinaryConfig splitConfig;
     private StandardParser autoParser;
@@ -51,21 +50,16 @@ public class FragmentLargeBinaryTask extends BaseCarveTask {
         return !caseData.isIpedReport() && splitConfig.isEnabled();
     }
 
-    public static boolean isXHtmlToSplit(IItem evidence) {
-        return evidence.getLength() != null && evidence.getLength() >= MIN_SPLIT_SIZE_IF_XHTML_OR_ERROR
-                && (MetadataUtil.isHtmlMediaType(evidence.getMediaType())
-                        || MetadataUtil.isHtmlSubType(evidence.getMediaType()));
-    }
-
     @Override
     protected void process(IItem evidence) throws Exception {
         
         boolean hasSpecificParser = ParsingTask.hasSpecificParser(autoParser, evidence);
         boolean hadParserException = Boolean.valueOf(evidence.getMetadata().get(StandardParser.PARSER_EXCEPTION));
 
+        TextCache textCache = ((Item) evidence).getTextCache();
+
         if (evidence.getLength() != null && evidence.getLength() >= splitConfig.getMinItemSizeToFragment()
-                && (evidence.isTimedOut() || isXHtmlToSplit(evidence)
-                        || (hasSpecificParser && hadParserException && evidence.getLength() >= MIN_SPLIT_SIZE_IF_XHTML_OR_ERROR)
+                && (evidence.isTimedOut()
                         || (!hasSpecificParser && (!EmbeddedDiskProcessTask.isSupported(evidence)
                                 || !EmbeddedDiskProcessTask.isFirstOrUniqueImagePart(evidence) || hadParserException)))
                 && evidence.getInputStreamFactory() != null
@@ -76,19 +70,32 @@ public class FragmentLargeBinaryTask extends BaseCarveTask {
             int overlap = splitConfig.getFragmentOverlapSize();
             for (long offset = 0; offset < evidence.getLength(); offset += fragSize - overlap) {
                 long len = offset + fragSize < evidence.getLength() ? fragSize : evidence.getLength() - offset;
-                this.addFragmentFile(evidence, offset, len, fragNum++);
+                this.addFragmentFile(evidence, offset, len, fragNum++, null);
                 if (Thread.currentThread().isInterrupted())
                     return;
             }
 
             // set an empty text in parent
-            TextCache textCache = new TextCache();
-            ((Item) evidence).setParsedTextCache(textCache);
+            ((Item) evidence).setParsedTextCache(new TextCache());
+
+        } else if (textCache != null && textCache.getSize() > TEXT_SPLIT_SIZE) {
+            int fragNum = 0;
+            long totalTextSize = textCache.getSize();
+            for (long textOffset = 0; textOffset < totalTextSize; textOffset += TEXT_SPLIT_SIZE - splitConfig.getFragmentOverlapSize()) {
+                TextCache textCacheChunk = textCache.clone();
+                int textSize = textOffset + TEXT_SPLIT_SIZE < totalTextSize ? TEXT_SPLIT_SIZE : (int) (totalTextSize - textOffset);
+                textCacheChunk.setTextBounds(textOffset, textSize);
+                this.addFragmentFile(evidence, 0, evidence.getLength(), fragNum++, textCacheChunk);
+            }
+            if (fragNum > 0) {
+                // set an empty text in parent
+                ((Item) evidence).setParsedTextCache(new TextCache());
+            }
         }
 
     }
 
-    private void addFragmentFile(IItem parentEvidence, long off, long len, int fragNum) {
+    private void addFragmentFile(IItem parentEvidence, long off, long len, int fragNum, TextCache textCache) {
         String name = parentEvidence.getName() + "_" + fragNum; //$NON-NLS-1$
         Item fragFile = getOffsetFile(parentEvidence, off, len, name, parentEvidence.getMediaType());
         configureOffsetItem(parentEvidence, fragFile, off);
@@ -100,6 +107,13 @@ public class FragmentLargeBinaryTask extends BaseCarveTask {
         fragFile.setModificationDate(parentEvidence.getModDate());
         fragFile.setChangeDate(parentEvidence.getChangeDate());
         fragFile.setExtraAttribute(FILE_FRAGMENT, true);
+        if (textCache != null) {
+            fragFile.setParsedTextCache(textCache);
+        }
+        // avoid computing hash for fragments again
+        if (parentEvidence.getHash() != null && !parentEvidence.getHash().isEmpty()) {
+            fragFile.setHash("");
+        }
         addOffsetFile(fragFile, parentEvidence);
     }
 

--- a/iped-engine/src/main/java/iped/engine/task/FragmentLargeBinaryTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/FragmentLargeBinaryTask.java
@@ -47,7 +47,7 @@ public class FragmentLargeBinaryTask extends BaseCarveTask {
 
     @Override
     public boolean isEnabled() {
-        return !caseData.isIpedReport() && splitConfig.isEnabled();
+        return !caseData.isIpedReport();
     }
 
     @Override

--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -316,7 +316,7 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
                 .findObject(SplitLargeBinaryConfig.class);
         if (((Item) evidence).getTextCache() == null
                 && ((evidence.getLength() == null || !splitConfig.isEnabled() || evidence.getLength() < splitConfig.getMinItemSizeToFragment())
-                || (StandardParser.isSpecificParser(parser) && !FragmentLargeBinaryTask.isXHtmlToSplit(evidence)))) {
+                || StandardParser.isSpecificParser(parser))) {
             try {
                 depth++;
                 ParsingTask task = new ParsingTask(worker, autoParser);


### PR DESCRIPTION
Closes #1281 by splitting huge decoded texts before indexing.

For advanced users, it is still possible to disable FragmentLargeBinaryTask commenting it in TaskInstaller.xml, but I don't recommend it.