### PR TITLE
Small adjustments in WhatsApp and Telegram generated HTMLs

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -124,7 +124,6 @@ div.deletedIcon {
 	float: left;
 	display:block;
 	margin:0.5em;
-	background:#475959;
 	color: #ffffff;
 	font-family: 'Roboto-Medium';
 }

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/wachat-html-template.txt
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/wachat-html-template.txt
@@ -20,11 +20,11 @@
     <body>
         <div id="topbar">
           <span class="left">
-            <img src="${avatar}" width="40" height="40" />
+            <img src="${avatar}" width="64" height="64" />
             ${title}
           </span>
         </div>
-        <div id="conversation"><br><br><br>
+        <div id="conversation"><br><br><br><br><br>
         ${deleted}
         ${messages}
         <br><br><br>


### PR DESCRIPTION
Two very minor suggestions:

- Contact image (avatar) displayed in WhatsApp and Telegram HTMLs generated by the parsers could be a bit larger. Sometimes it contains an useful image, but it is too small (currently limited to 40x40 pixels). I suggest increasing it a bit, to 64. 

- There is a small detail in the CSS used by the WhatsApp and Telegram parsers that is keeping the background color used by WhatsApp chats in Telegram chats, in the contact name/picture. Example:

![image](https://user-images.githubusercontent.com/7217001/217516382-3d7a5d83-7764-4ff8-82e4-edaeb4ebe88c.png)

After the change:
![image](https://user-images.githubusercontent.com/7217001/217517296-355f6ee5-c3f4-4bc4-82d9-23620ff3b308.png)

