### PR TITLE
Remove and force exclusion of TwelveMonkeys TIFF plugin (#1530)

### DIFF
--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -109,6 +109,10 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-ext-jdk15on</artifactId>
                 </exclusion>
+				<exclusion>
+					<groupId>com.twelvemonkeys.imageio</groupId>
+					<artifactId>imageio-tiff</artifactId>
+				</exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -109,10 +109,6 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-ext-jdk15on</artifactId>
                 </exclusion>
-				<exclusion>
-					<groupId>com.twelvemonkeys.imageio</groupId>
-					<artifactId>imageio-tiff</artifactId>
-				</exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -122,6 +122,12 @@
     		<artifactId>imageio-bmp</artifactId>
     		<version>3.8.3</version>
 	  	</dependency>
+	  	<dependency>
+	  	    <!--See https://github.com/sepinf-inc/IPED/issues/1530-->
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-tiff</artifactId>
+            <version>3.8.2</version>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -122,12 +122,6 @@
     		<artifactId>imageio-bmp</artifactId>
     		<version>3.8.3</version>
 	  	</dependency>
-	  	<dependency>
-	  	    <!--Used by IcePDF-7.0-->
-            <groupId>com.twelvemonkeys.imageio</groupId>
-            <artifactId>imageio-tiff</artifactId>
-            <version>3.8.3</version>
-        </dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
As discussed in #1530, removing the TIFF plugin (this PR) is an option to be evaluated. 
Another option would be chaging the plugin version to 3.8.2.
