### PR TITLE
Upgrade TwelveMonkeys to 3.9.4 (#1531)

### DIFF
--- a/iped-api/src/main/java/iped/properties/MediaTypes.java
+++ b/iped-api/src/main/java/iped/properties/MediaTypes.java
@@ -19,8 +19,6 @@ public class MediaTypes {
     public static final MediaType UFED_CONTACT_MIME = MediaType.application("x-ufed-contact"); //$NON-NLS-1$
     public static final MediaType UFED_DEVICE_INFO = MediaType.application("x-ufed-deviceinfo"); //$NON-NLS-1$
     public static final MediaType UNALLOCATED = MediaType.application("x-unallocated"); //$NON-NLS-1$
-    public static final MediaType JBIG2 = MediaType.image("x-jbig2");
-    public static final MediaType ICO = MediaType.image("vnd.microsoft.icon");
     public static final MediaType OUTLOOK_MSG = MediaType.application("vnd.ms-outlook");
     public static final MediaType DISK_IMAGE = MediaType.application("x-disk-image"); //$NON-NLS-1$
     public static final MediaType RAW_IMAGE = MediaType.application("x-raw-image"); //$NON-NLS-1$
@@ -79,9 +77,9 @@ public class MediaTypes {
         return false;
     }
 
-    public static String getMimeTypeIfJBIG2(IItemReader item) {
-        if (item.getMediaType() != null && item.getMediaType().equals(JBIG2)) {
-            return JBIG2.toString();
+    public static String getMimeTypeString(IItemReader item) {
+        if (item.getMediaType() != null) {
+            return item.getMediaType().toString();
         }
         return null;
     }

--- a/iped-api/src/main/java/iped/properties/MediaTypes.java
+++ b/iped-api/src/main/java/iped/properties/MediaTypes.java
@@ -20,6 +20,7 @@ public class MediaTypes {
     public static final MediaType UFED_DEVICE_INFO = MediaType.application("x-ufed-deviceinfo"); //$NON-NLS-1$
     public static final MediaType UNALLOCATED = MediaType.application("x-unallocated"); //$NON-NLS-1$
     public static final MediaType JBIG2 = MediaType.image("x-jbig2");
+    public static final MediaType ICO = MediaType.image("vnd.microsoft.icon");
     public static final MediaType OUTLOOK_MSG = MediaType.application("vnd.ms-outlook");
     public static final MediaType DISK_IMAGE = MediaType.application("x-disk-image"); //$NON-NLS-1$
     public static final MediaType RAW_IMAGE = MediaType.application("x-raw-image"); //$NON-NLS-1$

--- a/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
@@ -293,7 +293,7 @@ public class ImageThumbTask extends ThumbTask {
                 try (BufferedInputStream stream = evidence.getBufferedInputStream()) {
                     BooleanWrapper renderException = new BooleanWrapper();
                     img = ImageUtil.getSubSampledImage(stream, thumbSize * samplingRatio, thumbSize * samplingRatio,
-                            renderException, MediaTypes.getMimeTypeIfJBIG2(evidence));
+                            renderException, MediaTypes.getMimeTypeString(evidence));
                     if (img != null && renderException.value)
                         evidence.setExtraAttribute("thumbException", "true"); //$NON-NLS-1$ //$NON-NLS-2$
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ocr/OCRParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ocr/OCRParser.java
@@ -66,7 +66,6 @@ import iped.parsers.util.CharCountContentHandler;
 import iped.parsers.util.ItemInfo;
 import iped.parsers.util.OCROutputFolder;
 import iped.parsers.util.PDFToImage;
-import iped.properties.MediaTypes;
 import iped.utils.ExternalImageConverter;
 import iped.utils.IOUtil;
 import iped.utils.ImageUtil;
@@ -211,7 +210,7 @@ public class OCRParser extends AbstractParser implements AutoCloseable {
         types.add(MediaType.image("x-jp2-codestream")); //$NON-NLS-1$
         types.add(MediaType.image("x-rgb")); //$NON-NLS-1$
         types.add(MediaType.image("x-xbitmap")); //$NON-NLS-1$
-        types.add(MediaTypes.JBIG2);
+        types.add(MediaType.image("x-jbig2"));
         
         return types;
     }
@@ -542,9 +541,6 @@ public class OCRParser extends AbstractParser implements AutoCloseable {
             throws IOException, SAXException, TikaException {
         File imageFile = null;
         try {
-            if (!MediaTypes.JBIG2.toString().equals(mediaType)) {
-                mediaType = null; // just use mediaType for jbig2
-            }
             BufferedImage img = ImageUtil.getSubSampledImage(input, MAX_CONV_IMAGE_SIZE * 2, MAX_CONV_IMAGE_SIZE * 2,
                     mediaType);
             if (img == null) {

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -43,6 +43,9 @@ import org.w3c.dom.NodeList;
 public class ImageUtil {
     private static final int[] orientations = new int[] { 1, 5, 3, 7 };
 
+    private static final String JBIG2 = "image/x-jbig2";
+    private static final String ICO = "image/vnd.microsoft.icon";
+    
     public static BufferedImage resizeImage(BufferedImage img, int maxW, int maxH) {
         return resizeImage(img, maxW, maxH, BufferedImage.TYPE_INT_ARGB);
     }
@@ -151,8 +154,9 @@ public class ImageUtil {
         BufferedImage image = null;
         try {
             iis = ImageIO.createImageInputStream(source);
-            Iterator<ImageReader> iter = mimeType == null ? ImageIO.getImageReaders(iis)
-                    : ImageIO.getImageReadersByMIMEType(mimeType);
+            // JBIG2 needs that reader is get by mime type
+            Iterator<ImageReader> iter = JBIG2.equals(mimeType) ? ImageIO.getImageReadersByMIMEType(mimeType)
+                    : ImageIO.getImageReaders(iis);
             if (!iter.hasNext())
                 return null;
             reader = iter.next();

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -162,21 +162,23 @@ public class ImageUtil {
             reader = iter.next();
             reader.setInput(iis, false, true);
             
-            // For sources that contains multiple images (e.g. ICO), get the largest one
             int idx = 0;
-            try {
-                int n = reader.getNumImages(false);
-                if (n > 1) {
-                    int max = -1;
-                    for (int i = 0; i < n; i++) {
-                        int wi = reader.getWidth(i);
-                        if (wi > max) {
-                            max = wi;
-                            idx = i;
+            // ICO may contains multiple images, get the largest one
+            if (ICO.equals(mimeType)) {
+                try {
+                    int n = reader.getNumImages(false);
+                    if (n > 1) {
+                        int max = -1;
+                        for (int i = 0; i < n; i++) {
+                            int wi = reader.getWidth(i);
+                            if (wi > max) {
+                                max = wi;
+                                idx = i;
+                            }
                         }
                     }
+                } catch (Exception e) {
                 }
-            } catch (Exception e) {
             }
 
             int w0 = reader.getWidth(idx);

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -216,16 +216,24 @@ public class ImageUtil {
         int h = image.getHeight();
         int[] pixels = new int[w * h];
         image.getRGB(0, 0, w, h, pixels, 0, w);
-        int color;
+        int color = -1;
         if (pixels.length > 0) {
-            color = pixels[0];
-        } else {
-            return true;
+            // Starts at ~5% of the pixels
+            for (int i = pixels.length/20; i < pixels.length; i++) {
+                int p = pixels[i];
+                // Consider only non-transparent pixels
+                if ((p & 0xFF000000) != 0) {
+                    int c = p & 0xFFFFFF;
+                    if (color == -1) {
+                        // Store first color found 
+                        color = c;
+                    } else if (color != c) {
+                        // Has different colors
+                        return false;
+                    }
+                }
+            }
         }
-        for (int p : pixels)
-            if (p != color)
-                return false;
-
         return true;
     }
 

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -45,13 +45,14 @@ public class ImageUtil {
 
     private static final String JBIG2 = "image/x-jbig2";
     private static final String ICO = "image/vnd.microsoft.icon";
-    
+
     public static BufferedImage resizeImage(BufferedImage img, int maxW, int maxH) {
         return resizeImage(img, maxW, maxH, BufferedImage.TYPE_INT_ARGB);
     }
 
     /**
-     * Redimensiona um imagem, mantendo sua proporção original se possível, mas utilizando mantendo dimensões mínimas.
+     * Redimensiona um imagem, mantendo sua proporção original se possível, mas
+     * utilizando mantendo dimensões mínimas.
      */
     public static BufferedImage resizeImage(BufferedImage img, int maxW, int maxH, int minW, int minH, int imageType) {
         int imgW = img.getWidth();
@@ -161,7 +162,7 @@ public class ImageUtil {
                 return null;
             reader = iter.next();
             reader.setInput(iis, false, true);
-            
+
             int idx = 0;
             // ICO may contains multiple images, get the largest one
             if (ICO.equals(mimeType)) {
@@ -225,13 +226,13 @@ public class ImageUtil {
         int color = -1;
         if (pixels.length > 0) {
             // Starts at ~5% of the pixels
-            for (int i = pixels.length/20; i < pixels.length; i++) {
+            for (int i = pixels.length / 20; i < pixels.length; i++) {
                 int p = pixels[i];
                 // Consider only non-transparent pixels
                 if ((p & 0xFF000000) != 0) {
                     int c = p & 0xFFFFFF;
                     if (color == -1) {
-                        // Store first color found 
+                        // Store first color found
                         color = c;
                     } else if (color != c) {
                         // Has different colors
@@ -352,7 +353,7 @@ public class ImageUtil {
         g2.dispose();
         return out;
     }
-    
+
     public static BufferedImage getImageFromType(BufferedImage img, int type) {
         if (img == null || img.getType() == type) {
             return img;
@@ -544,7 +545,8 @@ public class ImageUtil {
                 nCols = Integer.parseInt(comment.substring(p2 + 1));
             }
         }
-        if (nRows <= 0 || nCols <= 0) return null;
+        if (nRows <= 0 || nCols <= 0)
+            return null;
 
         int imgWidth = img.getWidth();
         int imgHeight = img.getHeight();
@@ -552,7 +554,8 @@ public class ImageUtil {
         final int border = 2;
         int frameWidth = (imgWidth - 2 - border * (nCols + 1)) / nCols;
         int frameHeight = (imgHeight - 2 - border * (nRows + 1)) / nRows;
-        if (frameWidth <= 2 || frameHeight <= 2) return null;
+        if (frameWidth <= 2 || frameHeight <= 2)
+            return null;
 
         List<BufferedImage> frames = new ArrayList<BufferedImage>();
         for (int row = 0; row < nRows; row++) {
@@ -564,7 +567,7 @@ public class ImageUtil {
         }
         return frames;
     }
-    
+
     /**
      * Método auxiliar que percorre uma árvore buscando o valor de um nó com
      * determinado nome.
@@ -645,7 +648,7 @@ public class ImageUtil {
         g.dispose();
         return dest;
     }
-    
+
     public static boolean isCompressedBMP(File file) throws FileNotFoundException, IOException {
         byte[] b = new byte[34];
         if (file.length() >= b.length) {
@@ -659,8 +662,9 @@ public class ImageUtil {
     }
 
     /**
-     * @param intensity A proportion between the blurring window and the image dimensions. 
-     * Typical values are between 0.01 and 0.05.
+     * @param intensity
+     *            A proportion between the blurring window and the image dimensions.
+     *            Typical values are between 0.01 and 0.05.
      */
     public static BufferedImage blur(BufferedImage image, int maxSize, double intensity) {
         int w = image.getWidth();
@@ -680,8 +684,8 @@ public class ImageUtil {
         g.dispose();
         int radius = (int) Math.ceil(intensity * (newImage.getWidth() + newImage.getHeight()) / 2);
         byte[] pixels = ((DataBufferByte) newImage.getRaster().getDataBuffer()).getData();
-        int[] len = {newImage.getWidth(),newImage.getHeight()};
-        int[] step = {1,newImage.getWidth()};
+        int[] len = { newImage.getWidth(), newImage.getHeight() };
+        int[] step = { 1, newImage.getWidth() };
         for (int pass = 0; pass <= 1; pass++) {
             int len1 = len[pass];
             int len2 = len[1 - pass];
@@ -727,7 +731,9 @@ public class ImageUtil {
     }
 
     public static BufferedImage grayscale(BufferedImage image) {
-        if (image == null || image.getType() == BufferedImage.TYPE_BYTE_GRAY || image.getType() == BufferedImage.TYPE_USHORT_GRAY) return image;
+        if (image == null || image.getType() == BufferedImage.TYPE_BYTE_GRAY
+                || image.getType() == BufferedImage.TYPE_USHORT_GRAY)
+            return image;
         if (image.getColorModel().hasAlpha()) {
             ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_GRAY);
             ColorConvertOp op = new ColorConvertOp(cs, null);

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -219,9 +219,9 @@ public class ImageUtil {
         int color;
         if (pixels.length > 0) {
             color = pixels[0];
-        } else
-            return false;
-
+        } else {
+            return true;
+        }
         for (int p : pixels)
             if (p != color)
                 return false;

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -110,23 +110,23 @@
         <dependency>
     		<groupId>com.twelvemonkeys.imageio</groupId>
     		<artifactId>imageio-psd</artifactId>
-    		<version>3.8.2</version>
+    		<version>${twelvemonkeys.version}</version>
 	  	</dependency>
         <dependency>
     		<groupId>com.twelvemonkeys.imageio</groupId>
     		<artifactId>imageio-webp</artifactId>
-    		<version>3.8.3</version>
+    		<version>${twelvemonkeys.version}</version>
 	  	</dependency>
         <dependency>
     		<groupId>com.twelvemonkeys.imageio</groupId>
     		<artifactId>imageio-bmp</artifactId>
-    		<version>3.8.3</version>
+    		<version>${twelvemonkeys.version}</version>
 	  	</dependency>
 	  	<dependency>
 	  	    <!--See https://github.com/sepinf-inc/IPED/issues/1530-->
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-tiff</artifactId>
-            <version>3.8.2</version>
+            <version>${twelvemonkeys.version}</version>
         </dependency>
 	</dependencies>
 

--- a/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/ImageViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/iped/viewers/ImageViewer.java
@@ -119,7 +119,7 @@ public class ImageViewer extends AbstractViewer implements ActionListener {
                 in = new BufferedInputStream(content.getSeekableInputStream());
                 // needed for embedded jbig2
                 String mimeType = content instanceof IItemReader
-                        ? MediaTypes.getMimeTypeIfJBIG2((IItemReader) content)
+                        ? MediaTypes.getMimeTypeString((IItemReader) content)
                         : null;
                 image = ImageUtil.getSubSampledImage(in, maxDim, maxDim, mimeType);
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <xerial.sqlite.version>3.34.0</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>
         <telegram.impl.version>1.0.9-SNAPSHOT</telegram.impl.version>
+        <twelvemonkeys.version>3.9.4</twelvemonkeys.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Closes #1531.

Also includes minor changes to improve: 
- The handling of files with multiple images is restricted to ICOs now, to avoid undesired side effects in other formats.
- The detection of "empty" images when the reading process is interrupted by an exception.
 