### PR TITLE
#1611 update tests to pass with tesseract 5

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,8 +38,8 @@ jobs:
           libmsiecf-utils=20181227-1.1 \
           pff-tools=20180714-2 \
           libesedb-utils=20181229-3.1 \
-          tesseract-ocr=4.1.1-2build2 \
-          tesseract-ocr-por=1:4.00~git30-7274cfa-1 \
+          tesseract-ocr \
+          tesseract-ocr-por \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'
@@ -97,8 +97,8 @@ jobs:
           libmsiecf-utils=20181227-1.1 \
           pff-tools=20180714-2 \
           libesedb-utils=20181229-3.1 \
-          tesseract-ocr=4.1.1-2build2 \
-          tesseract-ocr-por=1:4.00~git30-7274cfa-1 \
+          tesseract-ocr \
+          tesseract-ocr-por \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Install External Tools
       run: |        
-          sudo apt-get update && sudo apt-get && sudo apt install \
+          sudo add-apt-repository ppa:alex-p/tesseract-ocr-devel && sudo apt-get update && sudo apt-get && sudo apt install \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
           libmsiecf-utils \
           pff-tools \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install External Tools
       run: |
-          sudo apt-get update && sudo apt-get && sudo apt install \
+          sudo apt-get update && sudo apt-get install \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
           libmsiecf-utils \
           pff-tools \
@@ -92,7 +92,7 @@ jobs:
 
     - name: Install External Tools
       run: |        
-          sudo add-apt-repository ppa:alex-p/tesseract-ocr-devel && sudo apt-get update && sudo apt-get && sudo apt install \
+          sudo add-apt-repository ppa:alex-p/tesseract-ocr-devel && sudo apt-get update && sudo apt-get install \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
           libmsiecf-utils \
           pff-tools \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,13 +33,14 @@ jobs:
 
     - name: Install External Tools
       run: |
-          sudo apt-get update && sudo apt install \
+          sudo apt-get update && sudo apt-get remove librsvg2-dev && sudo apt install --allow-downgrades \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
           libmsiecf-utils=20181227-1.1 \
           pff-tools=20180714-2 \
           libesedb-utils=20181229-3.1 \
           tesseract-ocr \
           tesseract-ocr-por \
+          gir1.2-rsvg-2.0=2.48.2-1 librsvg2-2=2.48.2-1 librsvg2-common=2.48.2-1 librsvg2-dev=2.48.2-1 \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'
@@ -92,13 +93,14 @@ jobs:
 
     - name: Install External Tools
       run: |        
-          sudo apt-get update && sudo apt install \
+          sudo apt-get update && sudo apt-get remove librsvg2-dev && sudo apt install --allow-downgrades \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
           libmsiecf-utils=20181227-1.1 \
           pff-tools=20180714-2 \
           libesedb-utils=20181229-3.1 \
           tesseract-ocr \
           tesseract-ocr-por \
+          gir1.2-rsvg-2.0=2.48.2-1 librsvg2-2=2.48.2-1 librsvg2-common=2.48.2-1 librsvg2-dev=2.48.2-1 \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ jobs:
 
   build-java11:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
@@ -33,14 +33,13 @@ jobs:
 
     - name: Install External Tools
       run: |
-          sudo apt-get update && sudo apt-get remove librsvg2-dev && sudo apt install --allow-downgrades \
+          sudo apt-get update && sudo apt-get && sudo apt install \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
-          libmsiecf-utils=20181227-1.1 \
-          pff-tools=20180714-2 \
-          libesedb-utils=20181229-3.1 \
+          libmsiecf-utils \
+          pff-tools \
+          libesedb-utils \
           tesseract-ocr \
           tesseract-ocr-por \
-          gir1.2-rsvg-2.0=2.48.2-1 librsvg2-2=2.48.2-1 librsvg2-common=2.48.2-1 librsvg2-dev=2.48.2-1 \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'
@@ -65,7 +64,7 @@ jobs:
 
   build-java14:
     
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
@@ -93,14 +92,13 @@ jobs:
 
     - name: Install External Tools
       run: |        
-          sudo apt-get update && sudo apt-get remove librsvg2-dev && sudo apt install --allow-downgrades \
+          sudo apt-get update && sudo apt-get && sudo apt install \
           libscca-utils rifiuti2 libevtx-utils libevt-utils \
-          libmsiecf-utils=20181227-1.1 \
-          pff-tools=20180714-2 \
-          libesedb-utils=20181229-3.1 \
+          libmsiecf-utils \
+          pff-tools \
+          libesedb-utils \
           tesseract-ocr \
           tesseract-ocr-por \
-          gir1.2-rsvg-2.0=2.48.2-1 librsvg2-2=2.48.2-1 librsvg2-common=2.48.2-1 librsvg2-dev=2.48.2-1 \
           imagemagick \
           python3-pip
           sudo perl -MCPAN -e 'install Parse::Win32Registry'

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
@@ -115,7 +115,7 @@ public class OCRParserTest {
             assertTrue(hts.contains("RISC-V UNICICLO"));
             assertTrue(hts.contains("Instruction [31-0]"));
             assertTrue(hts.contains("MemtoReg"));
-            assertTrue(hts.contains("Lógico-Aritméticas com imediato: ADDi, ANDi, ORi, XORi, SLLi, SRLi"));
+            assertTrue(hts.contains("Lógico-Aritméticas com imediato:"));
             assertTrue(hts.contains("and s6, s5, s4"));
             assertTrue(hts.contains("00000048 005324b3"));
             assertTrue(hts.contains("as memórias de instruções e dados."));

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.tika.exception.TikaException;
@@ -50,7 +51,8 @@ public class OCRParserTest {
         // Checks if tesseract is present to then enable OCR parsing property
         try {
             String tesseractPath = System.getProperty(OCRParser.TOOL_PATH_PROP, "") + "tesseract";
-            OCRParser.checkVersionInfo(tesseractPath, "-v");
+            List<String> tessInfo = OCRParser.checkVersionInfo(tesseractPath, "-v");
+            System.out.println("Detected tesseract version " + tessInfo.get(0));
             System.setProperty(OCRParser.ENABLE_PROP, "true");
         } catch (IOException | InterruptedException e) {
             LOGGER.error("Skipping tesseract tests...");

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
@@ -197,7 +197,6 @@ public class OCRParserTest {
             parser.parse(stream, handler, metadata, context);
             String hts = handler.toString();
 
-            assertTrue(Integer.parseInt(metadata.get(OCRParser.OCR_CHAR_COUNT)) >= 60);
             assertTrue(hts.contains("Parsing non-standard file format"));
             assertTrue(hts.contains("SAMPLE TEXT"));
             assertTrue(hts.contains("Centered Text"));
@@ -227,7 +226,6 @@ public class OCRParserTest {
             parser.parse(stream, handler, metadata, context);
             String hts = handler.toString();
 
-            assertTrue(Integer.parseInt(metadata.get(OCRParser.OCR_CHAR_COUNT)) >= 70);
             assertTrue(hts.contains("Transport"));
             assertTrue(hts.contains("Aa Ee Qq"));
             assertTrue(hts.contains("Rr Ss Tt"));

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
@@ -54,6 +54,7 @@ public class OCRParserTest {
             System.setProperty(OCRParser.ENABLE_PROP, "true");
         } catch (IOException | InterruptedException e) {
             LOGGER.error("Skipping tesseract tests...");
+            e.printStackTrace();
         }
     }
 
@@ -78,12 +79,13 @@ public class OCRParserTest {
         context.set(OCROutputFolder.class, new OCROutputFolder(new File(OCR_OUTPUT_FOLDER_NAME)));
         System.setProperty(OCRParser.LANGUAGE_PROP, "por");
 
+        String hts = "";
         try (OCRParser parser = new OCRParser();
             InputStream stream = this.getClass().getResourceAsStream("/test-files/test_OCR.png")) {
             assumeTrue(parser.isEnabled());
 
             parser.parse(stream, handler, metadata, context);
-            String hts = handler.toString();
+            hts = handler.toString();
 
             assertTrue(hts.contains("Oi, tudo bem?"));
             assertTrue(hts.contains("Tudo certo, o que estamos fazendo"));
@@ -92,6 +94,9 @@ public class OCRParserTest {
             assertTrue(hts.contains("OCRParser"));
             assertTrue(hts.contains("2:51 PM"));
             assertTrue(hts.toLowerCase().contains("boa sorte galera"));
+        } catch (Throwable e) {
+            System.out.println(hts);
+            throw e;
         }
     }
 
@@ -105,12 +110,13 @@ public class OCRParserTest {
         context.set(OCROutputFolder.class, new OCROutputFolder(new File(OCR_OUTPUT_FOLDER_NAME)));
         System.setProperty(OCRParser.LANGUAGE_PROP, "por");
         
+        String hts = "";
         try (OCRParser parser = new OCRParser();
             InputStream stream = this.getClass().getResourceAsStream("/test-files/test_OCR.pdf")) {
             assumeTrue(parser.isEnabled());
             
             parser.parse(stream, handler, metadata, context);
-            String hts = handler.toString();
+            hts = handler.toString();
 
             assertTrue(hts.contains("RISC-V UNICICLO"));
             assertTrue(hts.contains("Instruction [31-0]"));
@@ -119,6 +125,9 @@ public class OCRParserTest {
             assertTrue(hts.contains("and s6, s5, s4"));
             assertTrue(hts.contains("00000048 005324b3"));
             assertTrue(hts.contains("as memórias de instruções e dados."));
+        } catch (Throwable e) {
+            System.out.println(hts);
+            throw e;
         }
     }
 
@@ -147,12 +156,13 @@ public class OCRParserTest {
         context.set(OCROutputFolder.class, new OCROutputFolder(new File(OCR_OUTPUT_FOLDER_NAME)));
         System.setProperty(OCRParser.LANGUAGE_PROP, "eng");
 
+        String hts = "";
         try (OCRParser parser = new OCRParser();
             InputStream stream = this.getClass().getResourceAsStream("/test-files/test_OCR.tiff")) {
             assumeTrue(parser.isEnabled());
 
             parser.parse(stream, handler, metadata, context);
-            String hts = handler.toString();
+            hts = handler.toString();
 
             assertTrue(hts.contains("Literature must rest always on a principle"));
             assertTrue(hts.contains("times and places are one; the stuff he deals with"));
@@ -172,6 +182,9 @@ public class OCRParserTest {
             assertTrue(ocrCopy.exists() && ocrResults.exists());
             boolean copySucceeded = FileUtils.contentEquals(ocrCopy, ocrResults);
             assertTrue(copySucceeded);
+        } catch (Throwable e) {
+            System.out.println(hts);
+            throw e;
         }
     }
 
@@ -186,6 +199,7 @@ public class OCRParserTest {
         context.set(OCROutputFolder.class, new OCROutputFolder(new File(OCR_OUTPUT_FOLDER_NAME)));
         System.setProperty(OCRParser.LANGUAGE_PROP, "eng");
 
+        String hts = "";
         try (OCRParser parser = new OCRParser();
             InputStream stream = this.getClass().getResourceAsStream("/test-files/test_OCR.psd")) {
             assumeTrue(parser.isEnabled());
@@ -195,12 +209,15 @@ public class OCRParserTest {
             assumeTrue(isImageMagickInstalled(magickDir));
 
             parser.parse(stream, handler, metadata, context);
-            String hts = handler.toString();
+            hts = handler.toString();
 
             assertTrue(hts.contains("Parsing non-standard file format"));
             assertTrue(hts.contains("SAMPLE TEXT"));
             assertTrue(hts.contains("Centered Text"));
             assertTrue(hts.contains("sample .psd file"));
+        } catch (Throwable e) {
+            System.out.println(hts);
+            throw e;
         }
     }
 
@@ -215,6 +232,7 @@ public class OCRParserTest {
         context.set(OCROutputFolder.class, new OCROutputFolder(new File(OCR_OUTPUT_FOLDER_NAME)));
         System.setProperty(OCRParser.LANGUAGE_PROP, "eng");
 
+        String hts = "";
         try (OCRParser parser = new OCRParser();
             InputStream stream = this.getClass().getResourceAsStream("/test-files/test_OCR.svg")) {
             assumeTrue(parser.isEnabled());
@@ -224,7 +242,7 @@ public class OCRParserTest {
             assumeTrue(isImageMagickInstalled(magickDir));
 
             parser.parse(stream, handler, metadata, context);
-            String hts = handler.toString();
+            hts = handler.toString();
 
             assertTrue(hts.contains("Transport"));
             assertTrue(hts.contains("Aa Ee Qq"));
@@ -232,6 +250,9 @@ public class OCRParserTest {
             assertTrue(hts.contains("Manchester"));
             assertTrue(hts.contains("abcdefghijklm"));
             assertTrue(hts.contains("0123456789"));
+        } catch (Throwable e) {
+            System.out.println(hts);
+            throw e;
         }
     }
 

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/ocr/OCRParserTest.java
@@ -85,14 +85,13 @@ public class OCRParserTest {
             parser.parse(stream, handler, metadata, context);
             String hts = handler.toString();
 
-            assertTrue(hts.contains("57%"));
-            assertTrue(hts.contains("10:04 am"));
             assertTrue(hts.contains("Oi, tudo bem?"));
             assertTrue(hts.contains("Tudo certo, o que estamos fazendo"));
             assertTrue(hts.contains("aqui?"));
             assertTrue(hts.contains("Isso é um print para testar o"));
             assertTrue(hts.contains("OCRParser"));
-            assertTrue(hts.contains("Boa sOrte GALeRa"));
+            assertTrue(hts.contains("2:51 PM"));
+            assertTrue(hts.toLowerCase().contains("boa sorte galera"));
         }
     }
 


### PR DESCRIPTION
Fix #1611 simplifying some tests to pass with different tesseract versions. Also downgrade an imagemagick dependency causing SVG image conversion to fail.

PS: I'll wait feedback from a Linux user with tesseract-5.3 that got OCR test failures locally before merging.