### PR TITLE
Allows k8s check state

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
+++ b/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
@@ -223,11 +223,21 @@ public class RemoteWav2Vec2Service {
                             writer = new PrintWriter(
                                     new OutputStreamWriter(client.getOutputStream(), StandardCharsets.UTF_8), true);
 
-                            writer.println(MESSAGES.ACCEPTED);
-                            requestsAccepted.incrementAndGet();
+
+
 
                             String clientName = "Client " + client.getInetAddress().getHostAddress() + ":" + client.getPort();
                             String prefix = clientName + " - ";
+
+                            bis.mark(5);
+                            if (bis.read() == -1) {
+                                logger.info(prefix + "Kubernetes live test");
+                                return;
+                            }
+                            bis.reset();
+
+                            writer.println(MESSAGES.ACCEPTED);
+                            requestsAccepted.incrementAndGet();
 
                             logger.info(prefix + "Accepted connection.");
 

--- a/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
+++ b/iped-engine/src/main/java/iped/engine/task/transcript/RemoteWav2Vec2Service.java
@@ -231,7 +231,7 @@ public class RemoteWav2Vec2Service {
 
                             bis.mark(5);
                             if (bis.read() == -1) {
-                                logger.info(prefix + "Kubernetes live test");
+                                logger.info(prefix + "Possible Kubernetes live test");
                                 return;
                             }
                             bis.reset();


### PR DESCRIPTION
Kubernetes has a feature to check if the container is running that opens a connection to the service and closes it immediately after it is opened. So I made a change to detect this and logs it correctly.