### PR TITLE
Don't include external if phoneParsersToUse is set to internal for WhatsApp Business (#1644)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
@@ -113,7 +113,7 @@ public class UfedXmlReader extends DataSourceReader {
     private static final String EMPTY_EXTRACTION_STR = "-";
 
     private final Set<String> supportedApps = new HashSet<String>(
-            Arrays.asList(WhatsAppParser.WHATSAPP, TelegramParser.TELEGRAM));
+            Arrays.asList(WhatsAppParser.WHATSAPP, TelegramParser.TELEGRAM, WhatsAppParser.WHATSAPP + " Business"));
 
     private static Random random = new Random();
 


### PR DESCRIPTION
In case the current behavior was not intentional, this fixes #1644.