### PR TITLE
Corrects the bug of sequential folder stack in GeoFileParser

### DIFF
--- a/iped-geo/src/main/java/iped/geo/parsers/GeofileParser.java
+++ b/iped-geo/src/main/java/iped/geo/parsers/GeofileParser.java
@@ -137,7 +137,7 @@ public class GeofileParser extends AbstractParser {
                 kmeta.set(TikaCoreProperties.MODIFIED, metadata.get(TikaCoreProperties.MODIFIED));
                 kmeta.set(HttpHeaders.CONTENT_TYPE, "text/plain");
                 kmeta.set(TikaCoreProperties.TITLE, folder.getName());
-                int id = virtualId++;
+                int id = ++virtualId;
                 kmeta.set(ExtraProperties.ITEM_VIRTUAL_ID, Integer.toString(id));
                 kmeta.set(ExtraProperties.PARENT_VIRTUAL_ID, Integer.toString(parentId));
                 if (folder.isTrack()) {


### PR DESCRIPTION
Set the id to the incremented virtualID and updates it in method return so sequential folders are not recursivelly stacked on inside the other.