### PR TITLE
Reg ripper reports timestamp extraction

### DIFF
--- a/iped-app/resources/config/conf/CategoriesConfig.json
+++ b/iped-app/resources/config/conf/CategoriesConfig.json
@@ -46,6 +46,7 @@
 	      {"name": "Main Registry Files", "mimes": ["application/x-windows-registry-main"]},
 	      {"name": "Other Registry Files", "mimes": ["application/x-windows-registry"]},
 	      {"name": "Registry Full Reports", "mimes": ["application/x-windows-registry-report"]},
+          {"name": "Registry Timestamp Entries", "mimes": ["application/x-windows-registry-report-timestamp"]},
 	      {"name": "Registry Custom Reports", "categories":[
 	        {"name": "Registry OS Info"},
 	        {"name": "Registry Installed Apps"},

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
@@ -393,7 +393,7 @@ public class RegRipperParser extends AbstractParser {
                     if(dateStr.length()<=19) {
                         dateStr+="Z";
                     }
-                    if(!dateStr.startsWith("1970-01-01 00:00:00")){
+                    if(!dateStr.startsWith("1970")){
                         lastMatch=m.end();
                         String[] fieldNames = value.substring(0,m.start()).split(":");
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
@@ -47,6 +47,7 @@ import iped.parsers.registry.model.RegistryFileException;
 import iped.parsers.standard.RawStringParser;
 import iped.parsers.standard.StandardParser;
 import iped.parsers.util.ItemInfo;
+import iped.parsers.util.MetadataUtil;
 import iped.parsers.util.Util;
 import iped.properties.BasicProps;
 import iped.properties.ExtraProperties;
@@ -500,6 +501,7 @@ public class RegRipperParser extends AbstractParser {
                 Metadata kmeta = new Metadata();
                 kmeta.set(HttpHeaders.CONTENT_TYPE, "text/plain");
                 kmeta.set(TikaCoreProperties.TITLE, titletimeEvent);
+                MetadataUtil.setMetadataType(fieldTimeEvent, Date.class);
                 kmeta.set(fieldTimeEvent, dateStr);
                 int id = ++virtualId;
                 kmeta.set(ExtraProperties.ITEM_VIRTUAL_ID, Integer.toString(id));

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
@@ -373,27 +373,14 @@ public class RegRipperParser extends AbstractParser {
             String value = null;
             int i = 0;
             int lastMatch=-1;
-            for (; i < buff.length; i++) {
+            for (; i < buff.length - 1; i++) {
                 value = buff[i];
                 int len = value.trim().length();
                 if(len>0 && value.trim().equals("-".repeat(len))) {
-                    if(i==buff.length-1) {
-                        if(outStr.endsWith("\n")) {
-                            value+="\n";
-                        }
-                        return value;
-                    }
-
                     lastPlugin.name.replace(0, lastPlugin.name.length(), "");
                     lastPlugin.description.replace(0, lastPlugin.description.length(), "");
                     
                     continue;
-                }
-                if(lastPlugin.name.length()==0 && i==buff.length-1) {
-                    if(outStr.endsWith("\n")) {
-                        value+="\n";
-                    }
-                    return value;
                 }
                 if(lastPlugin.name.length()==0) {
                     int si=value.indexOf(" ");
@@ -407,18 +394,12 @@ public class RegRipperParser extends AbstractParser {
                         }
                         lastPlugin.name.append(value.substring(start,si));
                     }
-                    if(lastPlugin.name.toString().contains("timezone")) {
+                    if(lastPlugin.name.toString().startsWith("xplorer_cu")) {
                         System.out.println();
                     }
                     continue;
                 }
-                if(lastPlugin.description.length()==0 && i==buff.length-1) {
-                    if(outStr.endsWith("\n")) {
-                        value+="\n";
-                    }
-                    return value;
-                }
-                if(lastPlugin.description.length()==0 && i!=buff.length-1) {
+                if(lastPlugin.description.length()==0) {
                     if(value.equals("")) {
                         lastPlugin.description.append(" ");
                     }else {
@@ -427,12 +408,6 @@ public class RegRipperParser extends AbstractParser {
                     continue;
                 }
                 String msofficeapp = isMSOfficePlugin(value, lastPlugin);
-                if(msofficeapp!=null && i==buff.length-1) {
-                    if(outStr.endsWith("\n")) {
-                        value+="\n";
-                    }
-                    return value;
-                }
                 if(msofficeapp!=null) {
                     lastPlugin.name.replace(0, lastPlugin.name.length(), "");
                     lastPlugin.description.replace(0, lastPlugin.description.length(), "");
@@ -466,18 +441,14 @@ public class RegRipperParser extends AbstractParser {
                         }
                     }
                 }
-                if(i>=buff.length-1) {
-                    if(outStr.endsWith("\n")) {
-                        value+="\n";
-                    }
-                    if(lastMatch!=-1) {
-                        return value.substring(lastMatch);
-                    }else {
-                        return value;
-                    }
+            }
+            if(buff.length>0) {
+                value = buff[buff.length-1];
+                if(outStr.endsWith("\n")) {
+                    value+="\n";
                 }
             }
-            return "";
+            return value;
         }catch (Exception e) {
             e.printStackTrace();
         }
@@ -510,9 +481,6 @@ public class RegRipperParser extends AbstractParser {
         String fieldName="";
 
         if(lastPlugin.name.toString().startsWith("msoffice")) {
-            if(lastPlugin.name.toString().equals("msoffice")) {
-                System.out.println("teste");
-            }
             return "EntryModified";
         }else if(lastPlugin.name.toString().equals("cached")) {
             return "ShellExtensionFirstLoad";
@@ -706,6 +674,7 @@ public class RegRipperParser extends AbstractParser {
                 }
                 if(!remain.equals("\n")) {//last line processing
                     remain+="\n\n";
+                    out = new byte[0];
                     remain = extractTimeMetadata(metadata, out, remain, handler, extractor,lastPlugin);
                 }
            }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
@@ -504,7 +504,7 @@ public class RegRipperParser extends AbstractParser {
                 int id = ++virtualId;
                 kmeta.set(ExtraProperties.ITEM_VIRTUAL_ID, Integer.toString(id));
                 kmeta.set(ExtraProperties.PARENT_VIRTUAL_ID, Integer.toString(parentId));
-                kmeta.set(StandardParser.INDEXER_CONTENT_TYPE, "application/x-windows-registry-report"); //$NON-NLS-1$
+                kmeta.set(StandardParser.INDEXER_CONTENT_TYPE, "application/x-windows-registry-report-timestamp"); //$NON-NLS-1$
                 
                 extractor.parseEmbedded(featureStream, handler, kmeta, false);
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/registry/RegRipperParser.java
@@ -246,7 +246,7 @@ public class RegRipperParser extends AbstractParser {
         OutputStream os = new FileOutputStream(outFile);
         try {
             ContainerVolatile msg = new ContainerVolatile();
-            Thread thread = readStream(p.getInputStream(), os, msg, metadata, handler, extractor, !extractTimestampViaTLNPlugins || !command.contains("-f"));
+            Thread thread = readStream(p.getInputStream(), os, msg, metadata, handler, extractor, !extractTimestampViaTLNPlugins && !command.contains("-f"));
             waitFor(p, handler, msg);
             thread.join();
 

--- a/iped-utils/src/main/java/iped/utils/DateUtil.java
+++ b/iped-utils/src/main/java/iped/utils/DateUtil.java
@@ -116,5 +116,17 @@ public class DateUtil {
     public static Date stringToDate(String date) throws ParseException {
         return threadLocal.get().parse(date);
     }
+    
+    static Pattern pattern = null;
+    
+    public static Pattern getDateStrPattern(){
+        if(pattern==null) {
+            String patternStr = "(\\d{4}-(0[1-9]|1[1-2])-(0[1-9]|[1-2][0-9]|3[0-1])(\\s|T)([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:([0-5][0-9])Z?)"
+                    + "|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s(0[1-9]|[1-2][0-9]|3[0-1])\\s([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:(([0-5][0-9])Z?)\\s\\d{4})";
+            pattern = Pattern.compile(patternStr);
+            //pattern = Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})[T\\s](\\d{2})\\:(\\d{2})\\:(\\d{2})[Z(\\+(\\d{2})\\:(\\d{2}))]");
+        }
+        return pattern;
+    }
 
 }

--- a/iped-utils/src/main/java/iped/utils/DateUtil.java
+++ b/iped-utils/src/main/java/iped/utils/DateUtil.java
@@ -116,13 +116,13 @@ public class DateUtil {
     public static Date stringToDate(String date) throws ParseException {
         return threadLocal.get().parse(date);
     }
-    
+
     static Pattern pattern = null;
-    
+
     public static Pattern getDateStrPattern(){
         if(pattern==null) {
-            String patternStr = "(\\d{4}-(0[1-9]|1[1-2])-(0[1-9]|[1-2][0-9]|3[0-1])(\\s|T)([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:([0-5][0-9])Z?)"
-                    + "|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s(0[1-9]|[1-2][0-9]|3[0-1])\\s([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:(([0-5][0-9])Z?)\\s\\d{4})";
+            String patternStr = "(\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])(\\s|T)([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:([0-5][0-9])Z?)"
+                    + "|((Mon|Tue|Wed|Thu|Fri|Sat|Sun)\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s(0[1-9]|[1-2][0-9]|3[0-1])\\s([0-1][0-9]|2[0-3])\\:([0-5][0-9])\\:(([0-5][0-9])Z?)\\s\\d{4})";
             pattern = Pattern.compile(patternStr);
             //pattern = Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})[T\\s](\\d{2})\\:(\\d{2})\\:(\\d{2})[Z(\\+(\\d{2})\\:(\\d{2}))]");
         }


### PR DESCRIPTION
Timestamp extraction from reg ripper reports. Timestamp event name is inferred from the plugin name used plus any significative string that appear in the start of the same line of the timestamp.