### PR TITLE
Minor Fix in DIETask initialization to avoid multiple log messages when generating a report

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
+++ b/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import iped.configuration.Configurable;
 import iped.data.IItem;
-import iped.engine.CmdLineArgs;
 import iped.engine.config.Configuration;
 import iped.engine.config.ConfigurationManager;
 import iped.engine.config.EnableTaskProperty;

--- a/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
+++ b/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
@@ -141,6 +141,7 @@ public class DIETask extends AbstractTask {
                     if (hasIpedDatasource()) {
                         logger.warn(msg);
                         taskEnabled = false;
+                        init.set(true);
                         return;
                     }
                     throw new IPEDException(msg);

--- a/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
+++ b/iped-engine/src/main/java/iped/engine/task/die/DIETask.java
@@ -138,13 +138,10 @@ public class DIETask extends AbstractTask {
                 File dieDat = new File(Configuration.getInstance().appRoot, DIE_MODEL_PATH);
                 if (!dieDat.exists() || !dieDat.canRead()) {
                     String msg = "Invalid DIE database file: " + dieDat.getAbsolutePath(); //$NON-NLS-1$
-                    CmdLineArgs args = (CmdLineArgs) caseData.getCaseObject(CmdLineArgs.class.getName());
-                    for (File source : args.getDatasources()) {
-                        if (source.getName().endsWith(".iped")) {
-                            logger.warn(msg);
-                            taskEnabled = false;
-                            return;
-                        }
+                    if (hasIpedDatasource()) {
+                        logger.warn(msg);
+                        taskEnabled = false;
+                        return;
                     }
                     throw new IPEDException(msg);
                 }


### PR DESCRIPTION
Currently, several messages (one per working thread) like below appear in the processing log when a report is generated (model file is not present).

```text
2023-05-29 19:22:02	[WARN]	[task.die.DIETask]			Invalid DIE database file: D:\XXXX\iped\models\rfdie.dat
2023-05-29 19:22:02	[WARN]	[task.die.DIETask]			Invalid DIE database file: D:\XXXX\iped\models\rfdie.dat
2023-05-29 19:22:02	[WARN]	[task.die.DIETask]			Invalid DIE database file: D:\XXXX\iped\models\rfdie.dat
2023-05-29 19:22:02	[WARN]	[task.die.DIETask]			Invalid DIE database file: D:\XXXX\iped\models\rfdie.dat
(...)
```