### PR TITLE
Postpone timeline chart load

### DIFF
--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -579,6 +579,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
             @Override
             public void changed(CDockableLocationEvent dockableEvent) {
                 if (!isUpdated && dockableEvent.isShowingChanged()) {
+                    ipedTimelineDatasetManager.startBackgroundCacheCreation();
                     self.refreshChart();
                 }
             }
@@ -728,7 +729,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         }
         if (!dataSetUpdated.getAndSet(true)) {
             new Thread(populateEventNames).start();
-            ipedTimelineDatasetManager.startBackgroundCacheCreation();
+            //ipedTimelineDatasetManager.startBackgroundCacheCreation();
         }
 
         if (internalUpdate) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -579,8 +579,18 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
             @Override
             public void changed(CDockableLocationEvent dockableEvent) {
                 if (!isUpdated && dockableEvent.isShowingChanged()) {
-                    ipedTimelineDatasetManager.startBackgroundCacheCreation();
-                    self.refreshChart();
+                    self.remove(splitPane);
+                    self.add(loadingLabel);
+                    self.repaint();
+                    Runnable r = new Runnable() {
+                        @Override
+                        public void run() {
+                            ipedTimelineDatasetManager.startBackgroundCacheCreation();
+                            self.refreshChart();
+                        }
+                        
+                    };
+                    new Thread(r).start();
                 }
             }
         };

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -588,7 +588,6 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
                             ipedTimelineDatasetManager.startBackgroundCacheCreation();
                             self.refreshChart();
                         }
-                        
                     };
                     new Thread(r).start();
                 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
@@ -32,6 +32,8 @@ public class IpedTimelineDatasetManager {
     IpedChartsPanel ipedChartsPanel;
 
     List<TimeStampCache> timeStampCaches = new ArrayList<>();
+    
+    boolean startDatasetCreationCalled = false;
 
     TimeStampCache selectedTimeStampCache;
 
@@ -65,25 +67,35 @@ public class IpedTimelineDatasetManager {
     /*
      * Start the creation of cache for timeline chart
      */
-    public void startBackgroundCacheCreation() {
+    public void startBackgroundCacheCreation(int delay) {
         try {
-            Thread.sleep(1000);
+            Thread.sleep(delay);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-        int poolSize = (int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / 2f);
-        ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);
-        boolean first = true;
-        for (TimeStampCache timeStampCache : timeStampCaches) {
-            Future<?> future = threadPool.submit(timeStampCache);
-            // first loads the Day cache alone to speed up it, then run others in parallel
-            if (first) {
-                try {
-                    future.get();
-                } catch (InterruptedException | ExecutionException e) {
-                    e.printStackTrace();
+        startBackgroundCacheCreation();
+    }
+    
+    /*
+     * Start the creation of cache for timeline chart
+     */
+    public void startBackgroundCacheCreation() {
+        if(!startDatasetCreationCalled) {
+            startDatasetCreationCalled = true;
+            int poolSize = (int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / 2f);
+            ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);
+            boolean first = true;
+            for (TimeStampCache timeStampCache : timeStampCaches) {
+                Future<?> future = threadPool.submit(timeStampCache);
+                // first loads the Day cache alone to speed up it, then run others in parallel
+                if (first) {
+                    try {
+                        future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        e.printStackTrace();
+                    }
+                    first = false;
                 }
-                first = false;
             }
         }
     }

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
@@ -32,7 +32,7 @@ public class IpedTimelineDatasetManager {
     IpedChartsPanel ipedChartsPanel;
 
     List<TimeStampCache> timeStampCaches = new ArrayList<>();
-    
+
     boolean startDatasetCreationCalled = false;
 
     TimeStampCache selectedTimeStampCache;
@@ -68,7 +68,7 @@ public class IpedTimelineDatasetManager {
      * Start the creation of cache for timeline chart
      */
     public void startBackgroundCacheCreation() {
-        if(!startDatasetCreationCalled) {
+        if (!startDatasetCreationCalled) {
             startDatasetCreationCalled = true;
             int poolSize = (int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / 2f);
             ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jfree.data.time.Day;
 import org.jfree.data.time.Hour;
@@ -33,7 +34,7 @@ public class IpedTimelineDatasetManager {
 
     List<TimeStampCache> timeStampCaches = new ArrayList<>();
 
-    boolean startDatasetCreationCalled = false;
+    private AtomicBoolean startDatasetCreationCalled = new AtomicBoolean(false);
 
     TimeStampCache selectedTimeStampCache;
 
@@ -68,8 +69,7 @@ public class IpedTimelineDatasetManager {
      * Start the creation of cache for timeline chart
      */
     public void startBackgroundCacheCreation() {
-        if (!startDatasetCreationCalled) {
-            startDatasetCreationCalled = true;
+        if (!startDatasetCreationCalled.getAndSet(true)) {
             int poolSize = (int) Math.ceil((float) Runtime.getRuntime().availableProcessors() / 2f);
             ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);
             boolean first = true;

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
@@ -67,18 +67,6 @@ public class IpedTimelineDatasetManager {
     /*
      * Start the creation of cache for timeline chart
      */
-    public void startBackgroundCacheCreation(int delay) {
-        try {
-            Thread.sleep(delay);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        startBackgroundCacheCreation();
-    }
-    
-    /*
-     * Start the creation of cache for timeline chart
-     */
     public void startBackgroundCacheCreation() {
         if(!startDatasetCreationCalled) {
             startDatasetCreationCalled = true;


### PR DESCRIPTION
Location of first call to load/create cache data was postponed to the first time the timeline tab is shown.