### PR TITLE
Uses default windows SO certification store when on windows.

### DIFF
--- a/iped-app/src/main/java/iped/app/bootstrap/Bootstrap.java
+++ b/iped-app/src/main/java/iped/app/bootstrap/Bootstrap.java
@@ -169,6 +169,9 @@ public class Bootstrap {
             cmd.addAll(getCurrentJVMArgs());
             cmd.addAll(getCustomJVMArgs());
             cmd.addAll(getSystemProperties());
+            if (SystemUtils.IS_OS_WINDOWS) {
+                cmd.add("-Djavax.net.ssl.trustStoreType=WINDOWS-ROOT"); // fix for #1719
+            }
             cmd.add("-Djava.net.useSystemProxies=true"); // fix for #1446
             cmd.add(getMainClassName());
             cmd.addAll(finalArgs);


### PR DESCRIPTION
Uses default windows SO certification store (that one that can be viewed on "Manage User Certificates" in Control Panel)  when executing on Windows.