### PR TITLE
Detect and avoid a loop when the extracted item is equal its parent archive (#1814)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
@@ -298,7 +298,7 @@ public class SevenZipParser extends AbstractParser {
 
                 boolean isLoop = false;
                 if (extractedLen == parentFile.length()) {
-                    try (BufferedInputStream isp = new BufferedInputStream(new FileInputStream(parentFile))) {
+                    try (InputStream isp = new BufferedInputStream(new FileInputStream(parentFile))) {
                         byte[] buf1 = new byte[4096];
                         byte[] buf2 = new byte[4096];
                         boolean dif = false;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
@@ -1,5 +1,6 @@
 package iped.parsers.compress;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -258,7 +259,7 @@ public class SevenZipParser extends AbstractParser {
                 if (tmpFile == null) {
                     parseSubitem(new ByteArrayInputStream(tmpBuf, 0, bufPos));
                 } else {
-                    try (InputStream is = new FileInputStream(tmpFile)) {
+                    try (InputStream is = new BufferedInputStream(new FileInputStream(tmpFile))) {
                         parseSubitem(is);
                     }
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/compress/SevenZipParser.java
@@ -296,11 +296,14 @@ public class SevenZipParser extends AbstractParser {
                 if (item.isFolder())
                     entrydata.set(ExtraProperties.EMBEDDED_FOLDER, "true"); //$NON-NLS-1$
 
+                // Check if this subitem is equal to its parentFile. This should avoid an
+                // infinite recursion loop observed in a corrupted ISO file (see issue #1814).
                 boolean isLoop = false;
-                if (extractedLen == parentFile.length()) {
+                if (extractedLen > 0 && extractedLen == parentFile.length()) {
+                    // If both length are exactly the same, compare each byte.
                     try (InputStream isp = new BufferedInputStream(new FileInputStream(parentFile))) {
                         byte[] buf1 = new byte[4096];
-                        byte[] buf2 = new byte[4096];
+                        byte[] buf2 = new byte[buf1.length];
                         boolean dif = false;
                         OUT: while (true) {
                             int r1 = isp.read(buf1);


### PR DESCRIPTION
Closes #1814.

@lfcnassif, in the code I used an auxiliary stream to check if the subitem content is equal to its parent. Maybe that could be done in a more concise way (using the same InputStream), but I was concerned about possible side effects, so I kept it the way it is.
 