### PR TITLE
Carver and file signature for Shareaza Download (SD) files (#1816)

### DIFF
--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -240,7 +240,7 @@
         <carverType>
             <name>SD</name>
             <signatures>
-                <headerSignature>\53\44\4C?\00\00\00\FF</headerSignature>
+                <headerSignature>SDL?\00\00\00\FF</headerSignature>
             </signatures>
             <minLength>128</minLength>
             <maxLength>65536</maxLength>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -246,6 +246,7 @@
             <maxLength>32768</maxLength>
             <mediaType>application/x-shareaza-download</mediaType>
             <trimTrailingZeros>true</trimTrailingZeros>
+            <stopOnNextHeader>true</stopOnNextHeader>
         </carverType>
         
         <!--carverType>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -242,7 +242,7 @@
             <signatures>
                 <headerSignature>\53\44\4C?\00\00\00\FF</headerSignature>
             </signatures>
-            <minLength>256</minLength>
+            <minLength>128</minLength>
             <maxLength>32768</maxLength>
             <mediaType>application/x-shareaza-download</mediaType>
             <trimTrailingZeros>true</trimTrailingZeros>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -245,6 +245,7 @@
             <minLength>256</minLength>
             <maxLength>32768</maxLength>
             <mediaType>application/x-shareaza-download</mediaType>
+            <trimTrailingZeros>true</trimTrailingZeros>
         </carverType>
         
         <!--carverType>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -243,7 +243,7 @@
                 <headerSignature>\53\44\4C?\00\00\00\FF</headerSignature>
             </signatures>
             <minLength>128</minLength>
-            <maxLength>32768</maxLength>
+            <maxLength>65536</maxLength>
             <mediaType>application/x-shareaza-download</mediaType>
             <stopOnNextHeader>true</stopOnNextHeader>
         </carverType>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -237,6 +237,16 @@
             <mediaType>application/x-ares-galaxy</mediaType>
         </carverType>
 
+        <carverType>
+            <name>SD</name>
+            <signatures>
+                <headerSignature>\53\44\4C?\00\00\00\FF</headerSignature>
+            </signatures>
+            <minLength>256</minLength>
+            <maxLength>32768</maxLength>
+            <mediaType>application/x-shareaza-download</mediaType>
+        </carverType>
+        
         <!--carverType>
             <name>PLIST</name>
             <signatures>

--- a/iped-app/resources/config/conf/CarverConfig.xml
+++ b/iped-app/resources/config/conf/CarverConfig.xml
@@ -245,7 +245,6 @@
             <minLength>128</minLength>
             <maxLength>32768</maxLength>
             <mediaType>application/x-shareaza-download</mediaType>
-            <trimTrailingZeros>true</trimTrailingZeros>
             <stopOnNextHeader>true</stopOnNextHeader>
         </carverType>
         

--- a/iped-app/resources/config/conf/CategoriesConfig.json
+++ b/iped-app/resources/config/conf/CategoriesConfig.json
@@ -101,7 +101,7 @@
     {"name": "Peer-to-peer", "categories":[
       {"name": "Ares Galaxy", "mimes": ["application/x-ares-galaxy","application/x-ares-galaxy-entry"]},
       {"name": "E-Mule", "mimes": ["application/x-emule", "application/x-emule-part-met", "application/x-emule-searches", "application/x-emule-preferences-ini", "application/x-emule-preferences-dat", "application/x-emule-known-met-entry", "application/x-emule-part-met-entry"]},
-      {"name": "Shareaza", "mimes": ["application/x-shareaza-searches-dat", "application/x-shareaza-library-dat", "application/x-shareaza-library-dat-entry"]},
+      {"name": "Shareaza", "mimes": ["application/x-shareaza-searches-dat", "application/x-shareaza-library-dat", "application/x-shareaza-library-dat-entry", "application/x-shareaza-download"]},
       {"name": "Torrent", "mimes": ["application/x-bittorrent-resume-dat", "application/x-bittorrent"]},
       {"name": "Other Peer-to-peer", "mimes": ["application/x-p2p"]}
     ]},

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -413,7 +413,16 @@
     <mime-type type="application/x-shareaza-library-dat-entry">
         <sub-class-of type="application/x-metadata-entry"/>
     </mime-type>
-    
+
+    <mime-type type="application/x-shareaza-download">
+        <_comment>Shareaza download control file (.sd)</_comment>
+        <sub-class-of type="application/x-p2p"/>
+    	<magic priority="60">
+            <match value="0x53444C00000000FF" type="string" offset="0" mask="0xFFFFFF00FFFFFFFF"/>
+     	</magic>
+        <glob pattern="*.sd"/>
+    </mime-type>
+
     <mime-type type="application/x-bittorrent-resume-dat">
         <_comment>BitTorrent Client Resume.dat file</_comment>
         <sub-class-of type="application/x-p2p"/>

--- a/iped-app/resources/config/conf/metadataTypes.txt
+++ b/iped-app/resources/config/conf/metadataTypes.txt
@@ -4359,3 +4359,4 @@ Hardware-Wallet-VendorName = java.lang.String
 Hardware-Wallet-DeviceName = java.lang.String
 WinEvtx:recordCount = java.lang.Integer
 WinEvtx:eventRecordID = java.lang.Integer
+CarvedOffset = java.lang.Long

--- a/iped-app/src/main/java/iped/app/ui/IconManager.java
+++ b/iped-app/src/main/java/iped/app/ui/IconManager.java
@@ -191,6 +191,7 @@ public class IconManager {
         if (icon != null) {
             mimeIconMap.put("application/x-shareaza-searches-dat", icon);
             mimeIconMap.put("application/x-shareaza-library-dat", icon);
+            mimeIconMap.put("application/x-shareaza-download", icon);
         }
 
         icon = availableIconsMap.get("torrent");

--- a/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
+++ b/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
@@ -24,6 +24,7 @@ public class CarverType implements Serializable {
     int sizePos = -1, sizeBytes;
     ArrayList<Signature> signatures = new ArrayList<Signature>();
     private Long minLength = null, maxLength = null;
+    boolean trimTrailingZeros = false;
     boolean hasFooter = false;
     boolean hasLengthRef = false;
 
@@ -140,6 +141,14 @@ public class CarverType implements Serializable {
 
     public void setMaxLength(long maxLength) {
         this.maxLength = maxLength;
+    }
+
+    public boolean isTrimTrailingZeros() {
+        return trimTrailingZeros;
+    }
+
+    public void setTrimTrailingZeros(boolean trimTrailingZeros) {
+        this.trimTrailingZeros = trimTrailingZeros;
     }
 
     public String getName() {

--- a/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
+++ b/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
@@ -25,6 +25,7 @@ public class CarverType implements Serializable {
     ArrayList<Signature> signatures = new ArrayList<Signature>();
     private Long minLength = null, maxLength = null;
     boolean trimTrailingZeros = false;
+    boolean stopOnNextHeader = false;
     boolean hasFooter = false;
     boolean hasLengthRef = false;
 
@@ -149,6 +150,14 @@ public class CarverType implements Serializable {
 
     public void setTrimTrailingZeros(boolean trimTrailingZeros) {
         this.trimTrailingZeros = trimTrailingZeros;
+    }
+
+    public boolean isStopOnNextHeader() {
+        return stopOnNextHeader;
+    }
+
+    public void setStopOnNextHeader(boolean stopOnNextHeader) {
+        this.stopOnNextHeader = stopOnNextHeader;
     }
 
     public String getName() {

--- a/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
+++ b/iped-carvers/iped-carvers-api/src/main/java/iped/carvers/api/CarverType.java
@@ -24,7 +24,6 @@ public class CarverType implements Serializable {
     int sizePos = -1, sizeBytes;
     ArrayList<Signature> signatures = new ArrayList<Signature>();
     private Long minLength = null, maxLength = null;
-    boolean trimTrailingZeros = false;
     boolean stopOnNextHeader = false;
     boolean hasFooter = false;
     boolean hasLengthRef = false;
@@ -142,14 +141,6 @@ public class CarverType implements Serializable {
 
     public void setMaxLength(long maxLength) {
         this.maxLength = maxLength;
-    }
-
-    public boolean isTrimTrailingZeros() {
-        return trimTrailingZeros;
-    }
-
-    public void setTrimTrailingZeros(boolean trimTrailingZeros) {
-        this.trimTrailingZeros = trimTrailingZeros;
     }
 
     public boolean isStopOnNextHeader() {

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -80,27 +80,6 @@ public abstract class AbstractCarver implements Carver {
                 && !MediaTypes.UNALLOCATED.equals(parentEvidence.getMediaType())) {
             len = parentEvidence.getLength() - header.getOffset();
         }
-        
-        // Discard trailing zeros, if enabled for this carver type
-        CarverType typeCarved = header.getSignature().getCarverType();
-        if (typeCarved.isTrimTrailingZeros()) {
-            long end = Math.min(header.getOffset() + len, parentEvidence.getLength());
-            long minEnd = header.getOffset();
-            if (typeCarved.getMinLength() != null) {
-                minEnd += typeCarved.getMinLength();
-            }
-            // Read bytes in reverse order from the end, until a non-zero is found
-            try (SeekableInputStream is = parentEvidence.getSeekableInputStream()) {
-                while (end > minEnd) {
-                    is.seek(end - 1);
-                    if (is.read() != 0) {
-                        break;
-                    }
-                    end--;
-                }
-            }
-            len = end - header.getOffset();
-        }
 
         // Workaround for https://github.com/sepinf-inc/IPED/issues/1327
         if (len <= 0) {

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -96,11 +96,6 @@ public abstract class AbstractCarver implements Carver {
                     end--;
                 }
             }
-            System.err.println("\n>>>>parentEvidence.getFileOffset()="+parentEvidence.getFileOffset()+"\n"+
-                    "minEnd="+minEnd+"\n"+
-                    "end="+end+"\n"+
-                    "len="+len+"\n"+
-                    "header.getOffset()="+header.getOffset()+"\n");
             len = end - header.getOffset();
         }
 

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -253,7 +253,7 @@ public abstract class AbstractCarver implements Carver {
                 ready = true;
             } else if (!hit.equals(last) && type.equals(last.getSignature().getCarverType())) {
                 ready = true;
-                len = Math.min(len, last.getOffset());
+                len = Math.min(len, last.getOffset() - hit.getOffset());
             } else if (headersWithStopOnNext.size() > maxWaitingHeaders) {
                 ready = true;
             }

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -13,7 +13,6 @@ import iped.carvers.api.Hit;
 import iped.carvers.api.InvalidCarvedObjectException;
 import iped.carvers.api.Signature.SignatureType;
 import iped.data.IItem;
-import iped.io.SeekableInputStream;
 import iped.properties.ExtraProperties;
 import iped.properties.MediaTypes;
 

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -22,6 +22,17 @@ public abstract class AbstractCarver implements Carver {
 
     protected ArrayDeque<Hit> headersWaitingFooters = new ArrayDeque<>();
 
+    /**
+     * This list stores headers with "stop on next header" option enabled. These
+     * types of carved items do not have a footer nor a length defined in its
+     * content, so the end of the item is taken from the defined maxLength
+     * configuration. Instead of processing them as soon as they are found (in
+     * notifyHit()), they are added to this list. Whenever a new hit is notified,
+     * items in this list will be processed if the new hit is of the same type (in
+     * this case, the end of the processed hit will be limited to the start of the
+     * new hit), or when the offset of the new hit exceeds the maximum offset of the
+     * hit in the list. (See #1816 discussion)
+     */
     protected LinkedList<Hit> headersWithStopOnNext = new LinkedList<>();
 
     protected int maxWaitingHeaders = 1000;

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/standard/AbstractCarver.java
@@ -238,11 +238,13 @@ public abstract class AbstractCarver implements Carver {
             CarverType type = hit.getSignature().getCarverType();
             long len = Math.min(parentEvidence.getLength() - hit.getOffset(), type.getMaxLength());
             boolean ready = false;
-            if (hit.getOffset() + len <= currOffset || headersWithStopOnNext.size() > maxWaitingHeaders) {
+            if (hit.getOffset() + len <= currOffset) {
                 ready = true;
             } else if (!hit.equals(last) && type.equals(last.getSignature().getCarverType())) {
                 ready = true;
                 len = Math.min(len, last.getOffset());
+            } else if (headersWithStopOnNext.size() > maxWaitingHeaders) {
+                ready = true;
             }
             if (ready) {
                 it.remove();

--- a/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
+++ b/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
@@ -164,6 +164,7 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         Element lengthBigEndian = XMLUtil.getFirstElement(carverTypeEl, "lengthBigEndian");
         Element minLength = XMLUtil.getFirstElement(carverTypeEl, "minLength");
         Element maxLength = XMLUtil.getFirstElement(carverTypeEl, "maxLength");
+        Element trimTrailingZeros = XMLUtil.getFirstElement(carverTypeEl, "trimTrailingZeros");
         Element carverScriptFile = XMLUtil.getFirstElement(carverTypeEl, "carverScriptFile");
 
         if (name != null) {
@@ -188,6 +189,9 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         }
         if (maxLength != null) {
             ct.setMaxLength(Long.parseLong(maxLength.getTextContent().trim()));
+        }
+        if (trimTrailingZeros != null) {
+            ct.setTrimTrailingZeros(Boolean.parseBoolean(trimTrailingZeros.getTextContent().trim()));
         }
         if (carverClass != null) {
             ct.setCarverClass(carverClass.getTextContent().trim());

--- a/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
+++ b/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
@@ -165,6 +165,7 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         Element minLength = XMLUtil.getFirstElement(carverTypeEl, "minLength");
         Element maxLength = XMLUtil.getFirstElement(carverTypeEl, "maxLength");
         Element carverScriptFile = XMLUtil.getFirstElement(carverTypeEl, "carverScriptFile");
+        Element stopOnNextHeader = XMLUtil.getFirstElement(carverTypeEl, "stopOnNextHeader");
 
         if (name != null) {
             ct.setName(name.getTextContent());
@@ -188,6 +189,9 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         }
         if (maxLength != null) {
             ct.setMaxLength(Long.parseLong(maxLength.getTextContent().trim()));
+        }
+        if (stopOnNextHeader != null) {
+            ct.setStopOnNextHeader(Boolean.parseBoolean(stopOnNextHeader.getTextContent().trim()));
         }
         if (carverClass != null) {
             ct.setCarverClass(carverClass.getTextContent().trim());

--- a/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
+++ b/iped-engine/src/main/java/iped/engine/task/carver/XMLCarverConfiguration.java
@@ -164,7 +164,6 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         Element lengthBigEndian = XMLUtil.getFirstElement(carverTypeEl, "lengthBigEndian");
         Element minLength = XMLUtil.getFirstElement(carverTypeEl, "minLength");
         Element maxLength = XMLUtil.getFirstElement(carverTypeEl, "maxLength");
-        Element trimTrailingZeros = XMLUtil.getFirstElement(carverTypeEl, "trimTrailingZeros");
         Element carverScriptFile = XMLUtil.getFirstElement(carverTypeEl, "carverScriptFile");
 
         if (name != null) {
@@ -189,9 +188,6 @@ public class XMLCarverConfiguration implements CarverConfiguration, Serializable
         }
         if (maxLength != null) {
             ct.setMaxLength(Long.parseLong(maxLength.getTextContent().trim()));
-        }
-        if (trimTrailingZeros != null) {
-            ct.setTrimTrailingZeros(Boolean.parseBoolean(trimTrailingZeros.getTextContent().trim()));
         }
         if (carverClass != null) {
             ct.setCarverClass(carverClass.getTextContent().trim());


### PR DESCRIPTION
Closes #1816.

As discussed in https://github.com/sepinf-inc/IPED/issues/1816#issuecomment-1683029912, a new carving option (`stopOnNext header`) was added, to be used for SD files fo now, but possibly for other types in the future.

@lfcnassif, the new carving option is not essential, although I think it may be useful in some cases. As the carving process implementation is a critical part of the project, I tried to make the minimum amount of changes. If you think this may introduce some problem in the "regular" carving, we can remove this option. I ran two large tests, reprocessing two cases with many evidence files that I am currently working on. Compared with the previous processing, results matched as expected.