### PR TITLE
Review openIfExists (#1840) and some formatting enhancements (#1842)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/Util.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/Util.java
@@ -279,12 +279,6 @@ public class Util {
         return sb.toString();
     }
 
-    public static String getReportHref(String hash, String ext, String originalPath) {
-        String exportPath = getExportPath(hash, ext);
-        String path = getSourceFileIfExists(originalPath);
-        return "javascript:openIfExists('" + exportPath + "','" + path + "')";
-    }
-
     public static String getReportHref(IItemReader item) {
         String exportPath = getExportPath(item);
         String originalPath = getSourceFileIfExists(item).orElse("");

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/Util.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/Util.java
@@ -288,7 +288,24 @@ public class Util {
     public static String getReportHref(IItemReader item) {
         String exportPath = getExportPath(item);
         String originalPath = getSourceFileIfExists(item).orElse("");
-        return "javascript:openIfExists('" + exportPath + "','" + originalPath + "')";
+        StringBuilder sb = new StringBuilder();
+        sb.append("javascript:open");
+        String type = item.getMediaType().getType();
+        if (type.equals("image")) {
+            sb.append("Image");
+        } else if (type.equals("audio")) {
+            sb.append("Audio");
+        } else if (type.equals("video")) {
+            sb.append("Video");
+        } else {
+            sb.append("Other");
+        }
+        sb.append("('");
+        sb.append(exportPath);
+        sb.append("','");
+        sb.append(originalPath);
+        sb.append("')");
+        return sb.toString();
     }
 
     public static String getSourceFileIfExists(String originalPath) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
@@ -539,14 +539,14 @@ public class ReportGenerator {
                                 String source = iped.parsers.util.Util.getSourceFileIfExists(mediaItem)
                                         .orElse("");
                                 if (message.getMessageType() == MessageType.AUDIO_MESSAGE) {
-                                    out.println(Messages.getString("WhatsAppReport.AudioMessageTitle")); //$NON-NLS-1$
+                                    out.println(Messages.getString("WhatsAppReport.AudioMessageTitle") + "<br>"); //$NON-NLS-1$
                                     out.println("<div class=\"audioImg iped-audio\" " //$NON-NLS-1$
                                             + " title=\"Audio\" " + "data-src1=\"" + format(exportPath) + "\" "
                                             + "data-src2=\"" //$NON-NLS-1$
                                             + format(source) + "\" ></div>");
                                     out.println("</a><br>"); //$NON-NLS-1$
                                 } else {
-                                    out.println(Messages.getString("WhatsAppReport.VideoMessageTitle")); //$NON-NLS-1$
+                                    out.println(Messages.getString("WhatsAppReport.VideoMessageTitle") + "<br>"); //$NON-NLS-1$
                                     if (thumb != null) {
                                         out.print("<img class=\"thumb iped-video\" src=\""); //$NON-NLS-1$
                                         out.print("data:image/jpg;base64," + Util.encodeBase64(thumb) + "\""); //$NON-NLS-1$ //$NON-NLS-2$

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -10,6 +10,11 @@ video {
 	max-height:400px;
 }
 
+audio {
+	max-width:100%;
+	width:550px;
+}
+
 div.audioImg {
     width: 100px;
     height: 102px;

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -5,6 +5,11 @@ body {
     margin: 0 auto;
 }
 
+video {
+	max-width:400px;
+	max-height:400px;
+}
+
 div.audioImg {
     width: 100px;
     height: 102px;

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
@@ -1,9 +1,37 @@
-function openIfExists(url2, url1){
+function openImage(url2, url1){
     if (navigator.userAgent.search("JavaFX") >= 0) return;
-    const img1 = new Image();
-    img1.onload = () => window.location = url1;
-    img1.onerror = () => window.location = url2;
-    img1.src = url1;
+    const aux = new Image();
+    aux.onload = () => window.location = url1;
+    aux.onerror = () => window.location = url2;
+    aux.src = url1;
+}
+
+function openAudio(url2, url1){
+    openAV(url2, url1, 'audio');
+}
+
+function openVideo(url2, url1){
+    openAV(url2, url1, 'video');
+}
+
+function openAV(url2, url1, type){
+    if (navigator.userAgent.search("JavaFX") >= 0) return;
+    const aux = document.createElement(type);
+    aux.style.display = 'none';
+    aux.addEventListener('loadedmetadata', () => {
+        aux.remove();
+        window.location = url1;
+    });
+    aux.addEventListener('error', () => {
+        aux.remove();
+        window.location = url2;
+    });
+    aux.src = url1;
+    document.body.append(aux);
+}
+
+function openOther(url2, url1){
+    window.location = url2;
 }
 
 function createMediaElement(elementType, el) {

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
@@ -31,6 +31,7 @@ function openAV(url2, url1, type){
 }
 
 function openOther(url2, url1){
+    if (navigator.userAgent.search("JavaFX") >= 0) return;
     window.location = url2;
 }
 

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
@@ -39,11 +39,6 @@ function createMediaElement(elementType, el) {
     const mediaElement = document.createElement(elementType);
     const controls = document.createAttribute("controls");
     mediaElement.setAttributeNode(controls);
-    if (elementType == 'video') {
-        const st = document.createAttribute("style");
-        st.value = 'max-width:400px; max-height:400px;';	
-        mediaElement.setAttributeNode(st);
-    }    
     const src1 = el.getAttribute("data-src1");
     if (src1) {
         const sourceElement = document.createElement("source");

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/js/whatsapp.js
@@ -38,6 +38,11 @@ function createMediaElement(elementType, el) {
     const mediaElement = document.createElement(elementType);
     const controls = document.createAttribute("controls");
     mediaElement.setAttributeNode(controls);
+    if (elementType == 'video') {
+        const st = document.createAttribute("style");
+        st.value = 'max-width:400px; max-height:400px;';	
+        mediaElement.setAttributeNode(st);
+    }    
     const src1 = el.getAttribute("data-src1");
     if (src1) {
         const sourceElement = document.createElement("source");


### PR DESCRIPTION
Closes #1840.
Closes #1842.

This should fix the link issue for audios and videos.

For other files types (like PDFs), there is a new JavaScript function named `openOther()`, but for now it only opens the file in the exported location (not in its original one). This will keep the current behavior for such files, and can be improved in the future.

Commits [d6fec93](https://github.com/sepinf-inc/IPED/commit/d6fec938c8ed4a7422095e5809a0154618a19cdc) and [8a7604f](https://github.com/sepinf-inc/IPED/commit/8a7604fe140b1cb21ac4f224593a4589b1683d12) are just minor formatting improvements.