### PR TITLE
#1843 Better identification of deleted chats and messages

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ufed/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ufed/ReportGenerator.java
@@ -113,8 +113,6 @@ public class ReportGenerator {
                 name = Messages.getString("ReportGenerator.Unknown"); //$NON-NLS-1$
         }
 
-        if (chatDeleted || message.isDeleted())
-            out.println("🚫 "); //$NON-NLS-1$
 
         if (name != null)
             out.println(
@@ -192,17 +190,23 @@ public class ReportGenerator {
             out.print("<p><i>" + Messages.getString("WhatsAppReport.FoundInPedoHashDB") + " "
                     + format(message.getChildPornSets().toString()) + "</i></p>");
         }
-
         if (message.getTimeStamp() != null) {
             out.println("<span class=\"time\">"); //$NON-NLS-1$
             out.println(timeFormat.format(message.getTimeStamp())); // $NON-NLS-1$
             out.println("</span>"); //$NON-NLS-1$
         }
-
+        if (chatDeleted || message.isDeleted()) {
+            out.println("<br/><span class=\"recovered\">"); //$NON-NLS-1$
+            out.println("<i>" + Messages.getString("WhatsAppReport.MessageDeletedRecovered") + "</i>"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            out.println("<div class=\"deletedIcon\"></div>"); //$NON-NLS-1$
+            out.println("</span>"); //$NON-NLS-1$
+        }
         if (isTo)
             out.println("</div><div class=\"aw\"><div class=\"awr\"></div></div>"); 
         if (isFrom)
             out.println("</div>");
+
+
 
         out.println("</div></div>"); //$NON-NLS-1$
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ufed/UFEDChatParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/ufed/UFEDChatParser.java
@@ -198,6 +198,7 @@ public class UFEDChatParser extends AbstractParser {
     private UfedMessage createMessage(IItemReader msg, IItemReader attach) {
         UfedMessage m = new UfedMessage();
         m.setId(msg.getId());
+        m.setDeleted(msg.isDeleted());
         for (String body : msg.getMetadata().getValues(ExtraProperties.MESSAGE_BODY)) {
             if (!body.startsWith(ATTACHED_MEDIA_MSG))
                 m.setData(body);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
@@ -170,7 +170,7 @@ public class ExtractorIOS extends Extractor {
                             c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
                             c.setDeleted(rs.getInt("ZREMOVED") != 0);
                             remote.setAvatarPath(rs.getString("avatarPath")); //$NON-NLS-1$
-                            if (recoverDeletedRecords && !c.isDeleted()) {
+                            if (recoverDeletedRecords) {
                                 activeChats.add(c.getId());
                             }
                             list.add(c);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
@@ -168,8 +168,9 @@ public class ExtractorIOS extends Extractor {
                             c.setId(rs.getLong("id")); //$NON-NLS-1$
                             c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
                             c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                            c.setDeleted(rs.getInt("ZREMOVED") != 0);
                             remote.setAvatarPath(rs.getString("avatarPath")); //$NON-NLS-1$
-                            if (recoverDeletedRecords) {
+                            if (recoverDeletedRecords && !c.isDeleted()) {
                                 activeChats.add(c.getId());
                             }
                             list.add(c);
@@ -545,7 +546,7 @@ public class ExtractorIOS extends Extractor {
                     WAContact contact = contacts.getContact(contactId);
                     Chat c = new Chat(contact);
                     c.setId(row.getIntValue("Z_PK")); //$NON-NLS-1$
-                    c.setDeleted(row.isDeletedRow());
+                    c.setDeleted(row.getIntValue("ZREMOVED") != 0 || row.isDeletedRow());
                     c.setSubject(row.getTextValue("ZPARTNERNAME")); //$NON-NLS-1$
                     c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
                     result.add(c);
@@ -652,13 +653,13 @@ public class ExtractorIOS extends Extractor {
      * ** static strings ***
      */
     private static final String SELECT_CHAT_LIST = "SELECT ZWACHATSESSION.Z_PK as id, ZCONTACTJID AS contact, " //$NON-NLS-1$
-            + "ZPARTNERNAME as subject, ZLASTMESSAGEDATE, ZPATH as avatarPath " //$NON-NLS-1$
+            + "ZPARTNERNAME as subject, ZLASTMESSAGEDATE, ZPATH as avatarPath,ZREMOVED as ZREMOVED" //$NON-NLS-1$
             + "FROM ZWACHATSESSION " //$NON-NLS-1$
             + "LEFT JOIN ZWAPROFILEPICTUREITEM ON ZWAPROFILEPICTUREITEM.ZJID = ZWACHATSESSION.ZCONTACTJID " //$NON-NLS-1$
             + "ORDER BY ZLASTMESSAGEDATE DESC"; //$NON-NLS-1$
 
     private static final String SELECT_CHAT_LIST_NO_PPIC = "SELECT ZWACHATSESSION.Z_PK as id, ZCONTACTJID AS contact, " //$NON-NLS-1$
-            + "ZPARTNERNAME as subject, ZLASTMESSAGEDATE, NULL as avatarPath " //$NON-NLS-1$
+            + "ZPARTNERNAME as subject, ZLASTMESSAGEDATE, NULL as avatarPath , 0 as ZREMOVED" //$NON-NLS-1$
             + "FROM ZWACHATSESSION " //$NON-NLS-1$
             + "ORDER BY ZLASTMESSAGEDATE DESC"; //$NON-NLS-1$
     /*


### PR DESCRIPTION
There is a flag called ZREMOVED in the chatstorage database, if this flag is set to 1 the chat is deleted by the user. Another thing is that when importing messages from the UFED file they were not being exhibited as deleted in the chat HTML file. This fixes both cases. 