### PR TITLE
Metadata time zone flush to enforce timezone info

### DIFF
--- a/iped-engine/src/main/java/iped/engine/tika/SyncMetadata.java
+++ b/iped-engine/src/main/java/iped/engine/tika/SyncMetadata.java
@@ -174,6 +174,7 @@ public class SyncMetadata extends Metadata {
     @Override
     public synchronized void set(Property property, Calendar date) {
         checkReadOnly();
+        date.get(Calendar.HOUR_OF_DAY);
         super.set(property, date);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <plugin.rsc>${basedir}/resources/plugins</plugin.rsc>
         
         <!--dependencies-->
-        <tika.version>2.4.0</tika.version><!-- SyncMetadata change done in commit 7811b9a can be reverted when version is upgraded to include solution of https://issues.apache.org/jira/browse/TIKA-4126 -->
+        <tika.version>2.4.0</tika.version><!-- SyncMetadata change done in commit b673cf4 can be reverted when version is upgraded to include solution of https://issues.apache.org/jira/browse/TIKA-4126 -->
         <tika.core.version>2.4.0-p1</tika.core.version>
         <pdfbox.version>2.0.27</pdfbox.version>
         <lucene.version>9.2.0</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <plugin.rsc>${basedir}/resources/plugins</plugin.rsc>
         
         <!--dependencies-->
-        <tika.version>2.4.0</tika.version>
+        <tika.version>2.4.0</tika.version><!-- SyncMetadata change done in commit 7811b9a can be reverted when version is upgraded to include solution of https://issues.apache.org/jira/browse/TIKA-4126 -->
         <tika.core.version>2.4.0-p1</tika.core.version>
         <pdfbox.version>2.0.27</pdfbox.version>
         <lucene.version>9.2.0</lucene.version>


### PR DESCRIPTION
Some parsers load dates as Calendar objects,  but, although with correct timezone info loaded, doesn't have the other fields recomputed after this correct timezone is set. As the TIKA Metadata class implementation subsequently set the timezone to UTC to normalize all timezones, when the computeFields of calendar is called later, the original timezone info was lost, resulting in not applying the correct timezone offset correction.

This PR forces the computation of the fields before any subsequente Calendar operation.