### PR TITLE
Fix ALT bookmark removal key when CRTL and/or SHIFT are used (#1875)

### DIFF
--- a/iped-app/src/main/java/iped/app/ui/BookmarksManager.java
+++ b/iped-app/src/main/java/iped/app/ui/BookmarksManager.java
@@ -670,7 +670,7 @@ public class BookmarksManager implements ActionListener, ListSelectionListener, 
 
     // alt key remove from bookmark
     private KeyStroke getRemoveKey(KeyStroke k) {
-        return KeyStroke.getKeyStroke(k.getKeyCode(), KeyEvent.ALT_DOWN_MASK, true);
+        return KeyStroke.getKeyStroke(k.getKeyCode(), k.getModifiers() | KeyEvent.ALT_DOWN_MASK, true);
     }
 
     private void showMessage(String msg) {


### PR DESCRIPTION
Fix #1875.