### PR TITLE
Always try DateFormats in the same order, to avoid timezone loss (#1879)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
@@ -435,19 +435,9 @@ public class UfedXmlReader extends DataSourceReader {
             out.setTimeZone(TimeZone.getTimeZone("GMT")); //$NON-NLS-1$
         }
 
-        private DateFormat lastDateFormat = null;
-
         private Date parseDate(String value) throws ParseException {
-            if (lastDateFormat != null) {
-                try {
-                    return lastDateFormat.parse(value);
-                } catch (ParseException e) {
-                    // ignore
-                }
-            }
             for (DateFormat df : dfs) {
                 try {
-                    lastDateFormat = df;
                     return df.parse(value);
                 } catch (ParseException e) {
                     // ignore


### PR DESCRIPTION
Fixes #1879.