### PR TITLE
Fix duplicated WhatsApp suffix (iOS)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
@@ -200,7 +200,7 @@ public class ExtractorAndroid extends Extractor {
 
                 for (Chat c : undeletedChats) {
                     String remoteId = c.getRemote().getId();
-                    remoteId += c.isGroupChat() ? "@g.us" : "@s.whatsapp.net"; //$NON-NLS-1$ //$NON-NLS-2$
+                    remoteId += c.isGroupChat() ? "@g.us" : WAContact.waSuffix;
                     if (!activeChats.contains(remoteId)) {
                         list.add(c);
                         if (firstTry && c.isDeleted()) {
@@ -337,7 +337,7 @@ public class ExtractorAndroid extends Extractor {
         boolean recoverDeleted = undeleteTable != null && !undeletedMessages.isEmpty();
 
         String id = remote.getId();
-        id += isGroupChat ? "@g.us" : "@s.whatsapp.net"; //$NON-NLS-1$ //$NON-NLS-2$
+        id += isGroupChat ? "@g.us" : WAContact.waSuffix;
         
         Set<MessageWrapperForDuplicateRemoval> activeMessages = new HashSet<>();
         Map<Long, Message> activeMessageIds = new HashMap<>();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
@@ -44,7 +44,6 @@ public class ReportGenerator {
     private static final String lockedIcon = "<img class=\"lock\"/>";
     private static final String locationIcon = "<img class=\"location\"/>";
     private static final String forwardedIcon = "<img class=\"fwd\"/>";
-    private static final String waSuffix = "@s.whatsapp.net";
 
     public ReportGenerator() {
     }
@@ -427,7 +426,7 @@ public class ReportGenerator {
                 if (!number.isEmpty()) {
                     if (name.isEmpty()) {
                         name = number;
-                    } else if (!number.equals(name) && !number.equals(name + waSuffix)) {
+                    } else if (!number.equals(name) && !number.equals(name + WAContact.waSuffix)) {
                         name += " (" + number + ")"; //$NON-NLS-1$ //$NON-NLS-2$
                     }
                 }
@@ -675,8 +674,8 @@ public class ReportGenerator {
                             if (contact != null) {
                                 name = contact.getName();
                             }
-                            if (number.endsWith(waSuffix)) {
-                                number = number.substring(0, number.length() - waSuffix.length());
+                            if (number.endsWith(WAContact.waSuffix)) {
+                                number = number.substring(0, number.length() - WAContact.waSuffix.length());
                             }
                         }
                     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAAccount.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAAccount.java
@@ -20,8 +20,6 @@ import com.dd.plist.PropertyListParser;
 
 public class WAAccount extends WAContact {
 
-    private static final String idSuffix = "@s.whatsapp.net"; //$NON-NLS-1$
-
     private boolean isUnknown = false;
 
     public WAAccount(String id) {
@@ -47,8 +45,8 @@ public class WAAccount extends WAContact {
                 if (value == null || value.isBlank())
                     return null;
             }
-            if (!value.endsWith(idSuffix))
-                value += idSuffix;
+            if (!value.endsWith(waSuffix))
+                value += waSuffix;
 
             WAAccount account = new WAAccount(value);
 
@@ -80,8 +78,8 @@ public class WAAccount extends WAContact {
                     return null;
             }
             String strVal = value.toString();
-            if (!strVal.endsWith(idSuffix))
-                strVal += idSuffix;
+            if (!strVal.endsWith(waSuffix))
+                strVal += waSuffix;
 
             WAAccount account = new WAAccount(strVal);
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
@@ -2,6 +2,8 @@ package iped.parsers.whatsapp;
 
 public class WAContact {
 
+    protected static final String waSuffix = "@s.whatsapp.net";
+    
     private final String id;
 
     private final String suffix;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
@@ -58,8 +58,8 @@ public class WAContactsExtractorIOS extends WAContactsExtractor {
 
             while (rs.next()) {
                 String id = getString(rs, "ZWHATSAPPID");
-                if (!id.endsWith("@s.whatsapp.net")) {
-                    id += "@s.whatsapp.net";
+                if (!id.endsWith(WAContact.waSuffix)) {
+                    id += WAContact.waSuffix;
                 }
                 WAContact c = directory.getContact(id);
                 c.setDisplayName(getString(rs, "ZHIGHLIGHTEDNAME")); //$NON-NLS-1$
@@ -82,8 +82,8 @@ public class WAContactsExtractorIOS extends WAContactsExtractor {
         if (undeletedContactsTable != null) {
             for (var row : undeletedContactsTable.getTableRows()) {
                 var id = row.getTextValue("ZWHATSAPPID");
-                if (!id.endsWith("@s.whatsapp.net")) {
-                    id += "@s.whatsapp.net";
+                if (!id.endsWith(WAContact.waSuffix)) {
+                    id += WAContact.waSuffix;
                 }
                 if (! directory.hasContact(id)) { // only recover contact if it does not exist already
                     WAContact c = directory.getContact(id);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
@@ -57,7 +57,11 @@ public class WAContactsExtractorIOS extends WAContactsExtractor {
             }
 
             while (rs.next()) {
-                WAContact c = directory.getContact(getString(rs, "ZWHATSAPPID") + "@s.whatsapp.net"); //$NON-NLS-1$ //$NON-NLS-2$
+                String id = getString(rs, "ZWHATSAPPID");
+                if (!id.endsWith("@s.whatsapp.net")) {
+                    id += "@s.whatsapp.net";
+                }
+                WAContact c = directory.getContact(id);
                 c.setDisplayName(getString(rs, "ZHIGHLIGHTEDNAME")); //$NON-NLS-1$
                 c.setWaName(getString(rs, "ZFULLNAME")); //$NON-NLS-1$
                 c.setNickName(getString(rs, "ZNICKNAME")); //$NON-NLS-1$
@@ -78,8 +82,11 @@ public class WAContactsExtractorIOS extends WAContactsExtractor {
         if (undeletedContactsTable != null) {
             for (var row : undeletedContactsTable.getTableRows()) {
                 var id = row.getTextValue("ZWHATSAPPID");
+                if (!id.endsWith("@s.whatsapp.net")) {
+                    id += "@s.whatsapp.net";
+                }
                 if (! directory.hasContact(id)) { // only recover contact if it does not exist already
-                    WAContact c = directory.getContact(id + "@s.whatsapp.net"); //$NON-NLS-1$
+                    WAContact c = directory.getContact(id);
                     c.setDisplayName(nullToEmpty(row.getTextValue("ZHIGHLIGHTEDNAME"))); //$NON-NLS-1$
                     c.setWaName(nullToEmpty(row.getTextValue("ZFULLNAME"))); //$NON-NLS-1$
                     c.setNickName(nullToEmpty(row.getTextValue("ZNICKNAME"))); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContactsExtractorIOS.java
@@ -85,7 +85,7 @@ public class WAContactsExtractorIOS extends WAContactsExtractor {
                 if (!id.endsWith(WAContact.waSuffix)) {
                     id += WAContact.waSuffix;
                 }
-                if (! directory.hasContact(id)) { // only recover contact if it does not exist already
+                if (! directory.hasContact(Util.getNameFromId(id))) { // only recover contact if it does not exist already
                     WAContact c = directory.getContact(id);
                     c.setDisplayName(nullToEmpty(row.getTextValue("ZHIGHLIGHTEDNAME"))); //$NON-NLS-1$
                     c.setWaName(nullToEmpty(row.getTextValue("ZFULLNAME"))); //$NON-NLS-1$


### PR DESCRIPTION
This fixes a side effect of #1880.
Contacts read from iOS database already have "@s.whatsapp.net" suffix (at least in more recent databases).
In `WAContactsExtractorIOS`, the suffix was append again, resulting in IDs like `5511998877666@s.whatsapp.net@s.whatsapp.net`.
Before PR #1881, the `split("@")` removed the second "@s.whatsapp.net", but it shouldn't be added in the first place, if already present.
