### PR TITLE
'#1929 Creates a clearFilter method on IpedChartsPanel with a parameter

### DIFF
--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartPanel.java
@@ -828,13 +828,19 @@ public class IpedChartPanel extends ChartPanel implements KeyListener {
     }
 
     public void removeAllFilters() {
+        removeAllFilters(true);
+    }
+
+    public void removeAllFilters(boolean updateResult) {
         for (Date[] removedDates : definedFilters) {
             HighlightWorker sw = new HighlightWorker(ipedChartsPanel.getDomainAxis(), ipedChartsPanel.resultsProvider, removedDates[0], removedDates[1], false, false);
         }
         definedFilters.clear();
         excludedEvents.clear();
         ipedChartsPanel.setApplyFilters(false);
-        filterSelection();
+        if (updateResult) {
+            filterSelection();
+        }
         IpedCombinedDomainXYPlot rootPlot = ((IpedCombinedDomainXYPlot) getChart().getPlot());
         List<XYPlot> xyPlots = rootPlot.getSubplots();
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -936,7 +936,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
 
     @Override
     public void clearFilter() {
-        chartPanel.removeAllFilters();
+        chartPanel.removeAllFilters(false);
     }
 
     @Override


### PR DESCRIPTION
to indicate if the filterSelection (and consequently app.getAppListener().updateFileListing()) should be called after filters remoaval. This should not be called on interface ClearFilterListener method clearFliter implementation.