### PR TITLE
Avoid concurrency problems that may cause items not being included in their bookmarks when generating multicases reports (#1940)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/IPEDReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/IPEDReader.java
@@ -253,7 +253,7 @@ public class IPEDReader extends DataSourceReader {
                     newIds.add(oldToNewIdMap[oldId]);
             reportState.addBookmark(newIds, newLabelId);
         }
-        reportState.saveState();
+        reportState.saveState(true);
     }
 
     private void insertParentTreeNodes(LuceneSearchResult result) throws Exception {


### PR DESCRIPTION
Fixes #1940.

The first commit (that makes `saveState()` synchronous) was enough to solve this particular issue.
However, I kept the changes I made in `SaveStateThread` class to handle asynchronous save calls in the correct order, as processing the save requests not in their original order may lead to other hard-to-trace issues.