### PR TITLE
Do not overwrite the mediaType if new parsed type is null (#1947)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -478,7 +478,10 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
         String prevMediaType = evidence.getMediaType().toString();
         String parsedMediaType = metadata.get(StandardParser.INDEXER_CONTENT_TYPE);
         if (!prevMediaType.equals(parsedMediaType)) {
-            evidence.setMediaType(MediaType.parse(parsedMediaType));
+            MediaType mediaType = MediaType.parse(parsedMediaType);
+            if (mediaType != null) {
+                evidence.setMediaType(mediaType);
+            }
         }
 
         if (Boolean.valueOf(metadata.get(BasicProps.HASCHILD))) {


### PR DESCRIPTION
Fixes #1947.

I could not find where the parsed media type became only "application/".
Not sure if it is even possible, but maybe a external (TIKA) parser.