### PR TITLE
Overcome path with trailing spaces 2

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/FolderTreeReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/FolderTreeReader.java
@@ -30,6 +30,9 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import iped.data.ICaseData;
 import iped.data.IItem;
 import iped.engine.CmdLineArgs;
@@ -44,6 +47,8 @@ import iped.utils.FileInputStreamFactory;
 public class FolderTreeReader extends DataSourceReader {
 
     public static final String FS_OWNER = "fileSystemOwner"; //$NON-NLS-1$
+
+    private static final Logger logger = LoggerFactory.getLogger(FolderTreeReader.class);
 
     private FileInputStreamFactory inputStreamFactory;
 
@@ -227,9 +232,7 @@ public class FolderTreeReader extends DataSourceReader {
             parents.pollLast();
 
             if (exception != null) {
-                System.err.println(
-                        new Date() + "\t[WARN]\t" + "Directory ignored: " + path.toFile().getAbsolutePath() + " " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                                + exception.toString());
+                logger.error("Directory ignored: " + path.toFile().getAbsolutePath() + ": " + exception.toString());
             }
 
             return FileVisitResult.CONTINUE;
@@ -239,8 +242,7 @@ public class FolderTreeReader extends DataSourceReader {
         public FileVisitResult visitFileFailed(Path path, IOException exception) throws IOException {
 
             if (exception != null) {
-                System.err.println(new Date() + "\t[WARN]\t" + "File ignored: " + path.toFile().getAbsolutePath() + " " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                        + exception.toString());
+                logger.error("File ignored: " + path.toFile().getAbsolutePath() + ": " + exception.toString());
             }
 
             return FileVisitResult.CONTINUE;

--- a/iped-engine/src/main/java/iped/engine/datasource/FolderTreeReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/FolderTreeReader.java
@@ -242,7 +242,7 @@ public class FolderTreeReader extends DataSourceReader {
         public FileVisitResult visitFileFailed(Path path, IOException exception) throws IOException {
 
             if (exception != null) {
-                logger.error("File ignored: " + path.toFile().getAbsolutePath() + ": " + exception.toString());
+                logger.error("File/Folder ignored: " + path.toFile().getAbsolutePath() + ": " + exception.toString());
             }
 
             return FileVisitResult.CONTINUE;

--- a/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
+++ b/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
@@ -20,10 +20,10 @@ public class FileInputStreamFactory extends SeekableInputStreamFactory {
         super(dataSource.toUri());
     }
 
-    public File getFile(String subPath) {
+    public Path getPath(String subPath) {
         Path source = Paths.get(this.dataSource);
         try {
-            return source.resolve(subPath).toFile();
+            return source.resolve(subPath);
 
         } catch (InvalidPathException e) {
             File file = new File(subPath);
@@ -42,13 +42,13 @@ public class FileInputStreamFactory extends SeekableInputStreamFactory {
                     throw new RuntimeException(e1);
                 }
             }
-            return file;
+            return file.toPath();
         }
     }
 
     @Override
     public SeekableInputStream getSeekableInputStream(String subPath) throws IOException {
-        File file = getFile(subPath);
+        File file = getPath(subPath).toFile();
         if (file.isFile())
             return new SeekableFileInputStream(file);
         else

--- a/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
+++ b/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
@@ -3,7 +3,6 @@ package iped.utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import iped.io.SeekableInputStream;
 
@@ -13,14 +12,18 @@ public class FileInputStreamFactory extends SeekableInputStreamFactory {
         super(dataSource.toUri());
     }
 
-    public Path getPath(String subPath) {
-        Path source = Paths.get(this.dataSource);
-        return source.resolve(subPath);
+    public File getFile(String subPath) {
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            //this is a workaround to support cases where there are folders with trailing spaces on the name
+            return new File("\\\\?\\" + new File(subPath).getAbsolutePath());
+        } else {
+            return new File(subPath);
+        }
     }
 
     @Override
     public SeekableInputStream getSeekableInputStream(String subPath) throws IOException {
-        File file = getPath(subPath).toFile();
+        File file = getFile(subPath);
         if (file.isFile())
             return new SeekableFileInputStream(file);
         else

--- a/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
+++ b/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
@@ -32,14 +32,22 @@ public class FileInputStreamFactory extends SeekableInputStreamFactory {
             }
             if (IS_WINDOWS) {
                 // workaround for https://github.com/sepinf-inc/IPED/issues/1861
-                File f =  new File("\\\\?\\" + file.getAbsolutePath());
-                try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(f))) {
-                    file = File.createTempFile("iped", ".tmp");
-                    file.deleteOnExit();
-                    Files.copy(bis, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    
-                } catch (IOException e1) {
-                    throw new RuntimeException(e1);
+                if (file.isDirectory()) {
+                    try {
+                        file = Files.createTempDirectory("iped").toFile();
+                        file.deleteOnExit();
+                    } catch (IOException e1) {
+                        throw new RuntimeException(e1);
+                    }
+                } else {
+                    File f = new File("\\\\?\\" + file.getAbsolutePath());
+                    try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(f))) {
+                        file = File.createTempFile("iped", ".tmp");
+                        file.deleteOnExit();
+                        Files.copy(bis, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e1) {
+                        throw new RuntimeException(e1);
+                    }
                 }
             }
             return file.toPath();

--- a/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
+++ b/iped-utils/src/main/java/iped/utils/FileInputStreamFactory.java
@@ -2,22 +2,36 @@ package iped.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import iped.io.SeekableInputStream;
 
 public class FileInputStreamFactory extends SeekableInputStreamFactory {
+
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().startsWith("windows");
 
     public FileInputStreamFactory(Path dataSource) {
         super(dataSource.toUri());
     }
 
     public File getFile(String subPath) {
-        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-            //this is a workaround to support cases where there are folders with trailing spaces on the name
-            return new File("\\\\?\\" + new File(subPath).getAbsolutePath());
-        } else {
-            return new File(subPath);
+        Path source = Paths.get(this.dataSource);
+        try {
+            return source.resolve(subPath).toFile();
+
+        } catch (InvalidPathException e) {
+            File file = new File(subPath);
+            if (!file.isAbsolute()) {
+                file = new File(source.toFile(), subPath);
+            }
+            if (IS_WINDOWS) {
+                //this is a workaround to support cases where there are folders with trailing spaces on the name
+                return new File("\\\\?\\" + file.getAbsolutePath());
+            } else {
+                return file;
+            }
         }
     }
 

--- a/iped-utils/src/main/java/iped/utils/IOUtil.java
+++ b/iped-utils/src/main/java/iped/utils/IOUtil.java
@@ -413,7 +413,7 @@ public class IOUtil {
     public static File getFile(IItemReader item) {
         if (hasFile(item)) {
             FileInputStreamFactory fisf = ((FileInputStreamFactory) item.getInputStreamFactory());
-            return fisf.getFile(item.getIdInDataSource());
+            return fisf.getPath(item.getIdInDataSource()).toFile();
         }
         return null;
     }

--- a/iped-utils/src/main/java/iped/utils/IOUtil.java
+++ b/iped-utils/src/main/java/iped/utils/IOUtil.java
@@ -413,7 +413,7 @@ public class IOUtil {
     public static File getFile(IItemReader item) {
         if (hasFile(item)) {
             FileInputStreamFactory fisf = ((FileInputStreamFactory) item.getInputStreamFactory());
-            return fisf.getPath(item.getIdInDataSource()).toFile();
+            return fisf.getFile(item.getIdInDataSource());
         }
         return null;
     }


### PR DESCRIPTION
Fix #1861 using a simple approach to skip problematic files and folders, warning users on the Console.