### PR TITLE
#1224 Optimization for UFDR and small files

### DIFF
--- a/iped-engine/src/main/java/iped/engine/data/Item.java
+++ b/iped-engine/src/main/java/iped/engine/data/Item.java
@@ -1,10 +1,11 @@
 package iped.engine.data;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -193,6 +195,8 @@ public class Item implements IItem {
 
     private byte[] thumb;
 
+    private byte[] data;
+
     private ISeekableInputStreamFactory inputStreamFactory;
 
     static final int BUF_LEN = 8 * 1024 * 1024;
@@ -243,6 +247,7 @@ public class Item implements IItem {
         } catch (Exception e) {
             LOGGER.warn("Error closing resources of " + getPath(), e);
         }
+        data = null;
         tmpFile = null;
         tis = null;
         try {
@@ -279,6 +284,9 @@ public class Item implements IItem {
      * @throws IOException
      */
     public BufferedInputStream getBufferedInputStream() throws IOException {
+        if (data != null) {
+            return new BufferedInputStream(new ByteArrayInputStream(data));
+        }
         return new BufferedInputStream(getSeekableInputStream(), getBestBufferSize());
     }
 
@@ -528,6 +536,10 @@ public class Item implements IItem {
     @Override
     public SeekableInputStream getSeekableInputStream() throws IOException {
 
+        if (data != null) {
+            return new SeekableFileInputStream(new SeekableInMemoryByteChannel(data));
+        }
+
         // block 1 (referenciado abaixo)
         if (tmpFile == null && tis != null && tis.hasFile()) {
             tmpFile = tis.getFile();
@@ -575,7 +587,39 @@ public class Item implements IItem {
 
     @Override
     public SeekableByteChannel getSeekableByteChannel() throws IOException {
+        if (data != null) {
+            return new SeekableInMemoryByteChannel(data);
+        }
         return new SeekableByteChannelImpl(this.getSeekableInputStream());
+    }
+
+    /**
+     *  Cache data in memory for small items to avoid:
+     *  1. multiple decompression of data from compressed evidences
+     *  2. multiple reads from evidences in network shares
+     *  3. writing small temp files in temp dir, when possible
+     *  4. decrease heavy IO calls into kernel space 
+     *  
+     * @return true if data was cached on memory, false otherwise
+     */
+    public boolean cacheDataInMemory() {
+        if (length == null || length > BUF_LEN) {
+            return false;
+        }
+        if (data != null) {
+            return true;
+        }
+        try (InputStream is = this.getSeekableInputStream()) {
+            data = new byte[length.intValue()];
+            int i, offset = 0;
+            while (offset < data.length && (i = is.read(data, offset, data.length - offset)) != -1) {
+                offset += i;
+            }
+            return true;
+        } catch (IOException e) {
+            // ignore
+        }
+        return false;
     }
 
     /**
@@ -593,6 +637,16 @@ public class Item implements IItem {
         if (tmpFile == null) {
             if (tis != null && tis.hasFile()) {
                 tmpFile = tis.getFile();
+                return tmpFile;
+            }
+            String ext = ".tmp"; //$NON-NLS-1$
+            if (type != null && !type.toString().isEmpty()) {
+                ext = Util.getValidFilename("." + type.toString()); //$NON-NLS-1$
+            }
+            if (data != null) {
+                Path path = Files.createTempFile("iped", ext); //$NON-NLS-1$
+                Files.write(path, data);
+                tmpFile = path.toFile();
             } else {
                 try (SeekableInputStream sis = getSeekableInputStream()) {
                     if (sis instanceof SeekableFileInputStream) {
@@ -602,24 +656,18 @@ public class Item implements IItem {
                         }
                     }
                     if (tmpFile == null) {
-                        String ext = ".tmp"; //$NON-NLS-1$
-                        if (type != null && !type.toString().isEmpty()) {
-                            ext = Util.getValidFilename("." + type.toString()); //$NON-NLS-1$
-                        }
                         Path path = Files.createTempFile("iped", ext); //$NON-NLS-1$
                         Files.copy(new BufferedInputStream(sis, getBestBufferSize()), path, StandardCopyOption.REPLACE_EXISTING);
                         tmpFile = path.toFile();
                     }
-                    tmpResources.addResource(new Closeable() {
-                        public void close() {
-                            if (tmpFile != null) {
-                                tmpFile.delete();
-                            }
-                        }
-                    });
                 }
             }
-
+            final File finalFile = tmpFile;
+            tmpResources.addResource(new Closeable() {
+                public void close() {
+                    finalFile.delete();
+                }
+            });
         }
         return tmpFile;
     }
@@ -646,14 +694,20 @@ public class Item implements IItem {
             if (tmpFile == null && tis != null && tis.hasFile()) {
                 tmpFile = tis.getFile();
             }
+            // reset tis, it may have been set (and consumed) by a previous call of this
+            // method
+            tis = null;
             if (tmpFile != null) {
                 try {
                     tis = TikaInputStream.get(tmpFile.toPath());
-                } catch (FileNotFoundException fnfe) {
+                } catch (IOException fnfe) {
                     tmpFile = null;
                 }
             }
-            if (tmpFile == null) {
+            if (tis == null && data != null) {
+                tis = TikaInputStream.get(data);
+            }
+            if (tis == null) {
                 tis = TikaInputStream.get(getBufferedInputStream());
             }
         }

--- a/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
+++ b/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
@@ -158,9 +158,9 @@ public class ZIPInputStreamFactory extends SeekableInputStreamFactory implements
         }
         synchronized (filesCache) {
             tmp = filesCache.get(path);
-        }
-        if (tmp != null) {
-            return new SeekableFileInputStream(tmp.toFile());
+            if (tmp != null) {
+                return new SeekableFileInputStream(tmp.toFile());
+            }
         }
 
         ZipArchiveEntry zae;

--- a/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
+++ b/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
@@ -194,7 +194,7 @@ public class ZIPInputStreamFactory extends SeekableInputStreamFactory implements
                     if (zae.getSize() <= MAX_BYTES_CACHED) {
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
                         int read;
-                        byte[] buf = new byte[8192];
+                        byte[] buf = new byte[UFDR_BUF_SIZE];
                         while ((read = is.read(buf, 0, buf.length)) >= 0) {
                             if (canceled.get()) {
                                 return null;
@@ -212,7 +212,7 @@ public class ZIPInputStreamFactory extends SeekableInputStreamFactory implements
                         tmp = Files.createTempFile("zip-stream", null);
                         try (OutputStream out = Files.newOutputStream(tmp)) {
                             int read;
-                            byte[] buf = new byte[8192];
+                            byte[] buf = new byte[UFDR_BUF_SIZE];
                             while (!canceled.get() && (read = is.read(buf, 0, buf.length)) >= 0) {
                                 out.write(buf, 0, read);
                             }

--- a/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
+++ b/iped-engine/src/main/java/iped/engine/io/ZIPInputStreamFactory.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -159,7 +160,12 @@ public class ZIPInputStreamFactory extends SeekableInputStreamFactory implements
         synchronized (filesCache) {
             tmp = filesCache.get(path);
             if (tmp != null) {
-                return new SeekableFileInputStream(tmp.toFile());
+                try {
+                    return new SeekableFileInputStream(tmp.toFile());
+                } catch (NoSuchFileException e) {
+                    // Could have been deleted by Item.dispose()
+                    filesCache.remove(path);
+                }
             }
         }
 

--- a/iped-engine/src/main/java/iped/engine/task/TempFileTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/TempFileTask.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import iped.configuration.Configurable;
 import iped.data.IItem;
+import iped.engine.CmdLineArgs;
 import iped.engine.config.ConfigurationManager;
 import iped.engine.config.LocalConfig;
 import iped.engine.data.Item;
@@ -30,10 +31,11 @@ public class TempFileTask extends AbstractTask {
     private static Logger LOGGER = LoggerFactory.getLogger(TempFileTask.class);
     private static int MAX_TEMPFILE_LEN = 1024 * 1024 * 1024;
     private boolean indexTempOnSSD = false;
+    private boolean isEnabled = true;
 
     @Override
     public boolean isEnabled() {
-        return indexTempOnSSD;
+        return isEnabled;
     }
 
     @Override
@@ -45,7 +47,8 @@ public class TempFileTask extends AbstractTask {
     public void init(ConfigurationManager configurationManager) throws Exception {
         LocalConfig config = configurationManager.findObject(LocalConfig.class);
         indexTempOnSSD = config.isIndexTempOnSSD();
-
+        CmdLineArgs args = (CmdLineArgs) caseData.getCaseObject(CmdLineArgs.class.getName());
+        isEnabled = !"fastmode".equals(args.getProfile()) && !"triage".equals(args.getProfile());
     }
 
     @Override
@@ -56,14 +59,25 @@ public class TempFileTask extends AbstractTask {
     @Override
     protected void process(IItem evidence) throws Exception {
 
+
+        if (evidence instanceof Item) {
+            if (((Item) evidence).cacheDataInMemory()) {
+                return;
+            }
+        }
+
+        if (!indexTempOnSSD) {
+            return;
+        }
+
         Long len = evidence.getLength();
-        if (indexTempOnSSD && len != null
-                && len <= MAX_TEMPFILE_LEN /* && evidence.getPath().toLowerCase().contains(".e01/vol_vol") */) {
+        if (len != null && len <= MAX_TEMPFILE_LEN) {
             try {
-                if (!IOUtil.hasFile(evidence) && !evidence.isSubItem()
-                // skip carved items pointing to parent temp file
-                        && (!(evidence instanceof Item) || !((Item) evidence).hasParentTmpFile())) {
-                    evidence.getTempFile();
+                // skip items with File refs && carved items pointing to parent temp file
+                if (!IOUtil.hasFile(evidence) && (!(evidence instanceof Item) || !((Item) evidence).hasParentTmpFile())) {
+                    if (!evidence.isSubItem()) { // should we create temp files for large subitems?
+                        evidence.getTempFile();
+                    }
                 }
             } catch (IOException e) {
                 LOGGER.warn("{} Error creating temp file {} {}", Thread.currentThread().getName(), evidence.getPath(), //$NON-NLS-1$

--- a/iped-engine/src/main/java/iped/engine/task/TempFileTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/TempFileTask.java
@@ -75,7 +75,7 @@ public class TempFileTask extends AbstractTask {
             try {
                 // skip items with File refs && carved items pointing to parent temp file
                 if (!IOUtil.hasFile(evidence) && (!(evidence instanceof Item) || !((Item) evidence).hasParentTmpFile())) {
-                    if (!evidence.isSubItem()) { // should we create temp files for large subitems?
+                    if (!evidence.isSubItem()) { // should we create temp files for subitems compressed into the sqlite storages?
                         evidence.getTempFile();
                     }
                 }

--- a/iped-utils/src/main/java/iped/utils/SeekableFileInputStream.java
+++ b/iped-utils/src/main/java/iped/utils/SeekableFileInputStream.java
@@ -11,15 +11,21 @@ import iped.io.SeekableInputStream;
 
 public class SeekableFileInputStream extends SeekableInputStream {
 
+    private File file;
     private SeekableByteChannel sbc;
     private boolean closed = false;
 
     public SeekableFileInputStream(File file) throws IOException {
+        this.file = file;
         this.sbc = FileChannel.open(file.toPath(), StandardOpenOption.READ);
     }
 
     public SeekableFileInputStream(SeekableByteChannel channel) {
         this.sbc = channel;
+    }
+
+    public File getFile() {
+        return this.file;
     }
 
     @Override


### PR DESCRIPTION
Closes #1224, closes #1958 and fixes #1955.

Simply increasing buffers used to read files from UFDRs from 8K to 64K resulted in up to 3x speed up in TempFileTask and overall 10%-15% speed up in total processing time in a few UFDR evidences I tested.