### PR TITLE
Minor memory optimizations (#1960)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/chrome/ChromeSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/chrome/ChromeSqliteParser.java
@@ -9,7 +9,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -498,7 +498,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<ResumedVisit> getResumedHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<ResumedVisit> resumedHistory = new LinkedList<ResumedVisit>();
+        List<ResumedVisit> resumedHistory = new ArrayList<ResumedVisit>();
 
         Statement st = null;
         try {
@@ -524,7 +524,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<Visit> getHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<Visit> history = new LinkedList<Visit>();
+        List<Visit> history = new ArrayList<Visit>();
 
         Statement st = null;
         try {
@@ -549,7 +549,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<Download> getDownloads(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<Download> downloads = new LinkedList<Download>();
+        List<Download> downloads = new ArrayList<Download>();
 
         Statement st = null;
         try {
@@ -582,7 +582,7 @@ public class ChromeSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<Search> getSearchTerms(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<Search> searches = new LinkedList<Search>();
+        List<Search> searches = new ArrayList<Search>();
 
         Statement st = null;
         try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/edge/EdgeWebCacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/edge/EdgeWebCacheParser.java
@@ -7,9 +7,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -287,7 +287,7 @@ public class EdgeWebCacheParser extends AbstractParser {
 
     protected List<EdgeContainer> getHistory(String filePath, PointerByReference filePointerReference, ItemInfo itemInfo)
             throws EdgeWebCacheException {
-        List<EdgeContainer> history = new LinkedList<EdgeContainer>();
+        List<EdgeContainer> history = new ArrayList<EdgeContainer>();
 
         try {
             /*

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/firefox/FirefoxSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/firefox/FirefoxSqliteParser.java
@@ -9,7 +9,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -504,7 +504,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<ResumedVisit> getResumedHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<ResumedVisit> resumedHistory = new LinkedList<ResumedVisit>();
+        List<ResumedVisit> resumedHistory = new ArrayList<ResumedVisit>();
 
         Statement st = null;
         try {
@@ -531,7 +531,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<Visit> getHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<Visit> history = new LinkedList<Visit>();
+        List<Visit> history = new ArrayList<Visit>();
 
         Statement st = null;
         try {
@@ -555,7 +555,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<FirefoxMozBookmark> getBookmarks(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<FirefoxMozBookmark> bookmarks = new LinkedList<FirefoxMozBookmark>();
+        List<FirefoxMozBookmark> bookmarks = new ArrayList<FirefoxMozBookmark>();
 
         Statement st = null;
         try {
@@ -580,7 +580,7 @@ public class FirefoxSqliteParser extends AbstractSqliteBrowserParser {
 
     private List<Download> getDownloads(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException, JsonParseException, JsonMappingException, IOException {
-        List<Download> downloads = new LinkedList<Download>();
+        List<Download> downloads = new ArrayList<Download>();
 
         Statement st = null;
         try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/safari/SafariPlistParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/safari/SafariPlistParser.java
@@ -5,7 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -342,7 +342,7 @@ public class SafariPlistParser extends AbstractParser {
     }
 
     protected List<SafariResumedVisit> getResumedHistory(InputStream is) throws Exception {
-        List<SafariResumedVisit> resumedHistory = new LinkedList<SafariResumedVisit>();
+        List<SafariResumedVisit> resumedHistory = new ArrayList<SafariResumedVisit>();
 
         NSDictionary rootDict = (NSDictionary) PropertyListParser.parse(is);
         NSObject[] parameters = ((NSArray) rootDict.objectForKey("WebHistoryDates")).getArray();
@@ -371,7 +371,7 @@ public class SafariPlistParser extends AbstractParser {
     }
 
     // protected List<SafariVisit> getHistory(InputStream is) throws Exception {
-    // List<SafariVisit> history = new LinkedList<SafariVisit>();
+    // List<SafariVisit> history = new ArrayList<SafariVisit>();
     //
     // NSDictionary rootDict = (NSDictionary) PropertyListParser.parse(is);
     // NSObject[] parameters = ((NSArray)
@@ -400,7 +400,7 @@ public class SafariPlistParser extends AbstractParser {
     // }
 
     private List<Download> getDownloads(InputStream is) throws Exception {
-        List<Download> downloads = new LinkedList<>();
+        List<Download> downloads = new ArrayList<>();
 
         NSDictionary rootDict = (NSDictionary) PropertyListParser.parse(is);
         NSObject[] parameters = ((NSArray) rootDict.objectForKey("DownloadHistory")).getArray();
@@ -555,7 +555,7 @@ public class SafariPlistParser extends AbstractParser {
     }
 
     private List<SafariBookmark> getBookmarks(InputStream is) throws Exception {
-        List<SafariBookmark> bookmarks = new LinkedList<SafariBookmark>();
+        List<SafariBookmark> bookmarks = new ArrayList<SafariBookmark>();
 
         NSDictionary rootDict = (NSDictionary) PropertyListParser.parse(is);
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/safari/SafariSqliteParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/browsers/safari/SafariSqliteParser.java
@@ -9,7 +9,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -229,7 +229,7 @@ public class SafariSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<SafariResumedVisit> getResumedHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<SafariResumedVisit> resumedHistory = new LinkedList<SafariResumedVisit>();
+        List<SafariResumedVisit> resumedHistory = new ArrayList<SafariResumedVisit>();
 
         Statement st = null;
         try {
@@ -273,7 +273,7 @@ public class SafariSqliteParser extends AbstractSqliteBrowserParser {
 
     protected List<SafariVisit> getHistory(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<SafariVisit> history = new LinkedList<SafariVisit>();
+        List<SafariVisit> history = new ArrayList<SafariVisit>();
 
         Statement st = null;
         try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/discord/json/DiscordAttachment.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/discord/json/DiscordAttachment.java
@@ -1,7 +1,7 @@
 package iped.parsers.discord.json;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -42,7 +42,7 @@ public class DiscordAttachment {
 
     private String mediaHash;
 
-    private Set<String> childPornSets = new HashSet<>();
+    private List<String> childPornSets;
 
     public String getId() {
         return id;
@@ -122,15 +122,11 @@ public class DiscordAttachment {
 
     public void setMediaHash(String mediaHash) {
         this.mediaHash = mediaHash;
-        childPornSets.addAll(ChildPornHashLookup.lookupHash(mediaHash));
+        childPornSets = ChildPornHashLookup.lookupHashAndMerge(mediaHash, childPornSets);
     }
 
-    public Set<String> getChildPornSets() {
-        return childPornSets;
-    }
-
-    public void setChildPornSets(Set<String> childPornSets) {
-        this.childPornSets = childPornSets;
+    public List<String> getChildPornSets() {
+        return childPornSets == null ? Collections.emptyList() : childPornSets;
     }
 
     @Override

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/emule/KnownMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/emule/KnownMetParser.java
@@ -28,7 +28,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -199,13 +198,12 @@ public class KnownMetParser extends AbstractParser {
                 cells.add(e.getName());
                 String hash = e.getHash();
                 metadata.add(ExtraProperties.SHARED_HASHES, hash);
-                HashSet<String> hashSets = new HashSet<>();
-                hashSets.addAll(ChildPornHashLookup.lookupHash(EDONKEY, hash));
+                List<String> hashSets = ChildPornHashLookup.lookupHash(EDONKEY, hash);
                 item = searchItemInCase(searcher, EDONKEY, e.getHash());
                 if(item != null) {
-                    hashSets.addAll(ChildPornHashLookup.lookupHash(item.getHash()));
+                    hashSets = ChildPornHashLookup.lookupHashAndMerge(EDONKEY, hash, hashSets);
                 }
-                if (!hashSets.isEmpty()) {
+                if (hashSets != null && !hashSets.isEmpty()) {
                     hashDBHits++;
                     trClass = "rr"; //$NON-NLS-1$
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/emule/PartMetParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/emule/PartMetParser.java
@@ -8,7 +8,7 @@ import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -115,12 +115,11 @@ public class PartMetParser extends AbstractParser {
         xhtml.startElement("table", "class", "d");
 
         int hashDBHits = 0;
-        HashSet<String> hashSets = new HashSet<String>();
-        hashSets.addAll(ChildPornHashLookup.lookupHash(KnownMetParser.EDONKEY, e.getHash()));
+        List<String> hashSets = ChildPornHashLookup.lookupHash(KnownMetParser.EDONKEY, e.getHash());
         IItemReader item = KnownMetParser.searchItemInCase(searcher, KnownMetParser.EDONKEY, e.getHash());
         if (item != null)
-            hashSets.addAll(ChildPornHashLookup.lookupHash(item.getHash()));
-        if (!hashSets.isEmpty())
+            hashSets = ChildPornHashLookup.lookupHashAndMerge(item.getHash(), hashSets);
+        if (hashSets != null && !hashSets.isEmpty())
             hashDBHits++;
 
         AttributesImpl attributes = new AttributesImpl();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/JDBCTableReader.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/jdbc/JDBCTableReader.java
@@ -27,7 +27,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.text.html.HTMLEditorKit.Parser;
@@ -159,7 +159,7 @@ public class JDBCTableReader {
     }
 
     public List<String> getHeaders() throws IOException {
-        List<String> headers = new LinkedList<String>();
+        List<String> headers = new ArrayList<String>();
         // lazy initialization
         if (results == null) {
             results = getTableData();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/shareaza/LibraryFile.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/shareaza/LibraryFile.java
@@ -20,7 +20,7 @@ package iped.parsers.shareaza;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +65,7 @@ public class LibraryFile extends ShareazaEntity {
     private boolean cachedPreview;
     private boolean bogus;
     private final LibraryFolder parentFolder;
-    private HashSet<String> hashSetHits = new HashSet<>();
+    private List<String> hashSetHits;
 
     public LibraryFile(LibraryFolder parentFolder) {
         super("LIBRARY FILE"); //$NON-NLS-1$
@@ -208,14 +208,14 @@ public class LibraryFile extends ShareazaEntity {
 
     public void printTableRow(XHTMLContentHandler html, String path, IItemSearcher searcher, Map<Integer, List<String>> albunsForFiles) throws SAXException {
 
-        hashSetHits.addAll(ChildPornHashLookup.lookupHash(md5));
-        hashSetHits.addAll(ChildPornHashLookup.lookupHash(sha1));
+        hashSetHits = ChildPornHashLookup.lookupHashAndMerge(md5, hashSetHits);
+        hashSetHits = ChildPornHashLookup.lookupHashAndMerge(sha1, hashSetHits);
 
         AttributesImpl attributes = new AttributesImpl();
         if (md5 != null && !md5.isEmpty()) {
             attributes.addAttribute("", "name", "name", "CDATA", md5.toUpperCase());
         }
-        if (!hashSetHits.isEmpty()) {
+        if (hashSetHits != null && !hashSetHits.isEmpty()) {
             attributes.addAttribute("", "class", "class", "CDATA", "r");
         }
         html.startElement("tr", attributes);
@@ -260,7 +260,7 @@ public class LibraryFile extends ShareazaEntity {
             col++;
         }
         html.startElement("td"); //$NON-NLS-1$
-        if (!hashSetHits.isEmpty()) {
+        if (hashSetHits != null && !hashSetHits.isEmpty()) {
             html.characters(hashSetHits.toString());
         }
         html.endElement("td"); //$NON-NLS-1$
@@ -270,7 +270,7 @@ public class LibraryFile extends ShareazaEntity {
     }
 
     public boolean isHashDBHit() {
-        return !hashSetHits.isEmpty();
+        return hashSetHits != null && !hashSetHits.isEmpty();
     }
 
     public long getSize() {
@@ -377,8 +377,8 @@ public class LibraryFile extends ShareazaEntity {
         return parentFolder;
     }
 
-    public HashSet<String> getHashSetHits() {
-        return hashSetHits;
+    public List<String> getHashSetHits() {
+        return hashSetHits == null ? Collections.emptyList() : hashSetHits;
     }
 
     public void setIndex(int index) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3DBParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/sqlite/SQLite3DBParser.java
@@ -26,7 +26,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -189,7 +189,7 @@ public class SQLite3DBParser extends AbstractDBParser {
     @Override
     protected List<String> getTableNames(Connection connection, Metadata metadata, ParseContext context)
             throws SQLException {
-        List<String> tableNames = new LinkedList<String>();
+        List<String> tableNames = new ArrayList<String>();
 
         Statement st = null;
         try {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/telegram/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/telegram/Message.java
@@ -19,10 +19,9 @@
 package iped.parsers.telegram;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import dpf.ap.gpinf.interfacetelegram.MessageInterface;
 import dpf.ap.gpinf.interfacetelegram.PhotoData;
@@ -52,7 +51,7 @@ public class Message implements MessageInterface {
     private long toId = 0;
     private Double latitude = null;
     private Double longitude = null;
-    private Set<String> childPornSets = new HashSet<>();
+    private List<String> childPornSets;
 
     public long getId() {
         return id;
@@ -68,7 +67,7 @@ public class Message implements MessageInterface {
 
     public void setMediaHash(String mediaHash) {
         this.mediaHash = mediaHash;
-        childPornSets.addAll(ChildPornHashLookup.lookupHash(mediaHash));
+        childPornSets = ChildPornHashLookup.lookupHashAndMerge(mediaHash, childPornSets);
     }
 
     public String getMediaFile() {
@@ -248,8 +247,8 @@ public class Message implements MessageInterface {
         this.longitude = longitude;
     }
 
-    public Set<String> getChildPornSets() {
-        return this.childPornSets;
+    public List<String> getChildPornSets() {
+        return childPornSets == null ? Collections.emptyList() : childPornSets;
     }
 
     public void addChildPornSets(Collection<String> sets) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/ChildPornHashLookup.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/ChildPornHashLookup.java
@@ -19,8 +19,17 @@ public class ChildPornHashLookup {
     }
 
     public static List<String> lookupHash(String mediaHash) {
+        return lookupHashAndMerge(mediaHash, null);
+    }
+
+    /**
+     * Lookup a hash in the database and merge the result with a optionally provided
+     * list (returned from a previous call to hash lookup). The hash algorithm (md5,
+     * sha-1 or sha-256) is guessed from the hash length.
+     */
+    public static List<String> lookupHashAndMerge(String mediaHash, List<String> prev) {
         if (mediaHash == null || mediaHash.isEmpty() || lookupProviders.isEmpty())
-            return Collections.EMPTY_LIST;
+            return prev != null ? prev : Collections.emptyList();
         String guessedAlgo = "";
         if (mediaHash.length() == 32)
             guessedAlgo = "md5";
@@ -29,18 +38,36 @@ public class ChildPornHashLookup {
         else if (mediaHash.length() == 64)
             guessedAlgo = "sha-256";
 
-        return lookupHash(guessedAlgo, mediaHash);
+        return lookupHashAndMerge(guessedAlgo, mediaHash, prev);
     }
 
     public static List<String> lookupHash(String algorithm, String hash) {
-        Set<String> hashsets = new HashSet<String>();
+        return lookupHashAndMerge(algorithm, hash, null);
+    }
+
+    /**
+     * Lookup a hash in the database and merge the result with a optionally provided
+     * list (returned from a previous call to hash lookup), using a defined
+     * algorithm.
+     */
+    public static List<String> lookupHashAndMerge(String algorithm, String hash, List<String> prev) {
+        Set<String> hashsets = null;
         if (hash != null) {
             for (LookupProvider provider : lookupProviders) {
                 List<String> sets = provider.lookupHash(algorithm, hash);
                 if (sets != null) {
+                    if (hashsets == null) {
+                        hashsets = new HashSet<String>();
+                    }
                     hashsets.addAll(sets);
                 }
             }
+        }
+        if (hashsets == null || hashsets.isEmpty()) {
+            return prev != null ? prev : Collections.emptyList();
+        }
+        if (prev != null) {
+            hashsets.addAll(prev);
         }
         List<String> l = new ArrayList<String>(hashsets);
         Collections.sort(l);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -262,7 +261,7 @@ public class ExtractorAndroid extends Extractor {
 
     private List<Chat> undeleteChats(SQLiteUndeleteTable undeleteChatListTable,
             SQLiteUndeleteTable undeleteChatTable, SQLiteUndeleteTable undeleteJIDTable, WAContactsDirectory contacts) {
-        List<Chat> result = new LinkedList<>();
+        List<Chat> result = new ArrayList<>();
         
         if (undeleteChatListTable != null && undeleteChatListTable.getTableRows() != null && !undeleteChatListTable.getTableRows().isEmpty()) {
             // this is the case of a database with the table "chat_list"

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -554,7 +553,7 @@ public class ExtractorIOS extends Extractor {
     }
 
     private List<Chat> undeleteChats(SQLiteUndeleteTable undeleteChatsSessions, WAContactsDirectory contacts) {
-        List<Chat> result = new LinkedList<>();
+        List<Chat> result = new ArrayList<>();
 
         if (undeleteChatsSessions != null && !undeleteChatsSessions.getTableRows().isEmpty()) {
             for (SqliteRow row : undeleteChatsSessions.getTableRows()) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -8,11 +8,9 @@ import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -63,10 +61,10 @@ public class Message {
     private int mediaDuration;
     private MessageStatus messageStatus;
     private String recoveredFrom = null;
-    private Set<String> childPornSets = new HashSet<>();
+    private List<String> childPornSets;
     private IItemReader mediaItem = null;
     private String mediaQuery = null;
-    private List<MessageAddOn> addOns = new ArrayList<>();
+    private List<MessageAddOn> addOns;
 
     static {
         try {
@@ -99,7 +97,6 @@ public class Message {
 
     public Message() {
         messageType = MessageType.TEXT_MESSAGE;
-        vcards = new ArrayList<>();
     }
 
     public long getId() {
@@ -219,7 +216,7 @@ public class Message {
         } else {
             this.mediaHash = mediaHash;
         }
-        childPornSets.addAll(ChildPornHashLookup.lookupHash(this.mediaHash));
+        childPornSets = ChildPornHashLookup.lookupHashAndMerge(this.mediaHash, childPornSets);
     }
 
     public byte[] getThumbData() {
@@ -320,7 +317,7 @@ public class Message {
     }
 
     public List<String> getVcards() {
-        return vcards;
+        return vcards == null ? Collections.emptyList() : vcards;
     }
 
     public void setVcards(List<String> vcards) {
@@ -424,12 +421,12 @@ public class Message {
         this.recoveredFrom = recoveredFrom;
     }
 
-    public Set<String> getChildPornSets() {
-        return childPornSets;
+    public List<String> getChildPornSets() {
+        return childPornSets == null ? Collections.emptyList() : childPornSets;
     }
 
-    public void addChildPornSets(Collection<String> sets) {
-        this.childPornSets.addAll(sets);
+    public void lookupAndAddChildPornSets(String hash) {
+        childPornSets = ChildPornHashLookup.lookupHashAndMerge(hash, childPornSets);
     }
     
     public IItemReader getMediaItem() {
@@ -449,11 +446,14 @@ public class Message {
     }
 
     public boolean addMessageAddOn(MessageAddOn m) {
+        if (addOns == null) {
+            addOns = new ArrayList<MessageAddOn>(1);
+        }
         return addOns.add(m);
     }
 
     public List<MessageAddOn> getAddOns() {
-        return addOns;
+        return addOns == null ? Collections.emptyList() : addOns;
     }
 
     public String getCallId() {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
@@ -17,7 +17,6 @@ import org.apache.commons.text.lookup.StringLookup;
 import org.apache.commons.text.lookup.StringLookupFactory;
 
 import iped.data.IItemReader;
-import iped.parsers.util.ChildPornHashLookup;
 import iped.parsers.util.Messages;
 import iped.parsers.vcard.VCardParser;
 import iped.parsers.whatsapp.Message.MessageType;
@@ -641,7 +640,7 @@ public class ReportGenerator {
                         break;
                 }
                 if (mediaItem != null) {
-                    message.addChildPornSets(ChildPornHashLookup.lookupHash(mediaItem.getHash()));
+                    message.lookupAndAddChildPornSets(mediaItem.getHash());
                 }
                 break;
         }


### PR DESCRIPTION
Closes #1960.
Just minor memory optimizations and code enhancements describe in the issue.

EDIT: In some parsers, the memory usage is very low, so these changes don't make any practical difference. However, as parsers' code are sometimes used as references for future parsers, I changed all of them to use a similar logic regarding HashDB lookup related code.