### PR TITLE
Upgrade TwelveMonkeys library to version 3.10.1 (#1966)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <xerial.sqlite.version>3.34.0</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>
         <telegram.impl.version>1.0.9-SNAPSHOT</telegram.impl.version>
-        <twelvemonkeys.version>3.9.4</twelvemonkeys.version>
+        <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Closes #1966.
The issue detected with 3.10.0 is gone in 3.10.1.