### PR TITLE
Locale config loaded sooner

### DIFF
--- a/iped-engine/src/main/java/iped/engine/config/Configuration.java
+++ b/iped-engine/src/main/java/iped/engine/config/Configuration.java
@@ -182,7 +182,9 @@ public class Configuration {
         }
 
         ConfigurationManager configManager = ConfigurationManager.createInstance(configDirectory);
-        configManager.addObject(new LocaleConfig());
+        LocaleConfig lc = new LocaleConfig();
+        configManager.addObject(lc);
+        configManager.loadConfig(lc);
 
         PluginConfig pluginConfig = new PluginConfig();
         configManager.addObject(pluginConfig);


### PR DESCRIPTION
Closes #1979 
Load config soon after object creation to avoid dependent code execution before it.