### PR TITLE
Map selection sync error

### DIFF
--- a/iped-geo/src/main/java/iped/geo/impl/AppMapPanel.java
+++ b/iped-geo/src/main/java/iped/geo/impl/AppMapPanel.java
@@ -316,15 +316,17 @@ public class AppMapPanel extends JPanel implements Consumer<Object[]> {
             int rowModel = resultsTable.convertRowIndexToModel(selected[i]);
             IItemId item = results.getItem(rowModel);
 
-            List<Integer> subitems = kmlResult.getGPSItems().get(item);
-            if (subitems == null) {
-                String gid = "marker_" + item.getSourceId() + "_" + item.getId(); //$NON-NLS-1$ //$NON-NLS-2$
-                selecoes.put(gid, true);
-            } else {
-                for (Integer subitem : subitems) {
-                    String gid = "marker_" + item.getSourceId() + "_" + item.getId() + "_" //$NON-NLS-1$ //$NON-NLS-2$
-                            + subitem;
+            if (kmlResult != null && kmlResult.getGPSItems().containsKey(item)) {
+                List<Integer> subitems = kmlResult.getGPSItems().get(item);
+                if (subitems == null) {
+                    String gid = "marker_" + item.getSourceId() + "_" + item.getId(); //$NON-NLS-1$ //$NON-NLS-2$
                     selecoes.put(gid, true);
+                } else {
+                    for (Integer subitem : subitems) {
+                        String gid = "marker_" + item.getSourceId() + "_" + item.getId() + "_" //$NON-NLS-1$ //$NON-NLS-2$
+                                + subitem;
+                        selecoes.put(gid, true);
+                    }
                 }
             }
         }

--- a/iped-geo/src/main/java/iped/geo/impl/AppMapPanel.java
+++ b/iped-geo/src/main/java/iped/geo/impl/AppMapPanel.java
@@ -315,25 +315,28 @@ public class AppMapPanel extends JPanel implements Consumer<Object[]> {
         for (int i = 0; i < selected.length; i++) {
             int rowModel = resultsTable.convertRowIndexToModel(selected[i]);
             IItemId item = results.getItem(rowModel);
-
-            if (kmlResult != null && kmlResult.getGPSItems().containsKey(item)) {
-                List<Integer> subitems = kmlResult.getGPSItems().get(item);
-                if (subitems == null) {
-                    String gid = "marker_" + item.getSourceId() + "_" + item.getId(); //$NON-NLS-1$ //$NON-NLS-2$
-                    selecoes.put(gid, true);
-                } else {
-                    for (Integer subitem : subitems) {
-                        String gid = "marker_" + item.getSourceId() + "_" + item.getId() + "_" //$NON-NLS-1$ //$NON-NLS-2$
-                                + subitem;
-                        selecoes.put(gid, true);
-                    }
-                }
-            }
+            addSelection(selecoes, item);
         }
 
         mapViewer.updateMapLeadCursor();
 
         browserCanvas.sendSelection(selecoes);
+    }
+
+    public void addSelection(HashMap<String, Boolean> selecoes, IItemId item) {
+        if (kmlResult != null && kmlResult.getGPSItems().containsKey(item)) {
+            List<Integer> subitems = kmlResult.getGPSItems().get(item);
+            if (subitems == null) {
+                String gid = "marker_" + item.getSourceId() + "_" + item.getId(); //$NON-NLS-1$ //$NON-NLS-2$
+                selecoes.put(gid, true);
+            } else {
+                for (Integer subitem : subitems) {
+                    String gid = "marker_" + item.getSourceId() + "_" + item.getId() + "_" //$NON-NLS-1$ //$NON-NLS-2$
+                            + subitem;
+                    selecoes.put(gid, true);
+                }
+            }
+        }
     }
 
     @Override

--- a/iped-geo/src/main/java/iped/geo/impl/MapViewer.java
+++ b/iped-geo/src/main/java/iped/geo/impl/MapViewer.java
@@ -2,7 +2,6 @@ package iped.geo.impl;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map.Entry;
 
 import javax.swing.JPanel;
@@ -218,20 +217,7 @@ public class MapViewer implements ResultSetViewer, TableModelListener, ListSelec
                             int rowModel = resultsTable.convertRowIndexToModel(i);
 
                             IItemId item = results.getItem(rowModel);
-
-                            if (mapaPanel.kmlResult != null && mapaPanel.kmlResult.getGPSItems().containsKey(item)) {
-                                List<Integer> subitems = mapaPanel.kmlResult.getGPSItems().get(item);
-                                if (subitems == null) {
-                                    String gid = "marker_" + item.getSourceId() + "_" + item.getId(); //$NON-NLS-1$ //$NON-NLS-2$
-                                    selecoes.put(gid, selected);
-                                } else {
-                                    for (Integer subitem : subitems) {
-                                        String gid = "marker_" + item.getSourceId() + "_" + item.getId() + "_" //$NON-NLS-1$ //$NON-NLS-2$
-                                                + subitem;
-                                        selecoes.put(gid, selected);
-                                    }
-                                }
-                            }
+                            mapaPanel.addSelection(selecoes, item);
                         } catch (Exception e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
closes #1973 

syncselection method, that sends selection made in results table when map was not visible, wasn't filtering out non georeferenced items leading to exceptions being printed in App Log. This PR reimplements the method to filter them out.