### PR TITLE
closes #1990: upgrade telegram decoder plugin, use jitpack artifacts

### DIFF
--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -472,9 +472,9 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>dpf.ap</groupId>
+                                    <groupId>com.github.sepinf-inc.telegram-decoder</groupId>
     								<artifactId>telegram-decoder-impl</artifactId>
-    								<version>${telegram.impl.version}</version>
+    								<version>${telegram.version}</version>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${plugin.dir}</outputDirectory>

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -179,14 +179,14 @@
             <version>1.10.0</version>
         </dependency>
         <dependency>
-            <groupId>dpf.ap</groupId>
+            <groupId>com.github.sepinf-inc.telegram-decoder</groupId>
             <artifactId>telegram-decoder-api</artifactId>
-            <version>1.0.4-SNAPSHOT</version>
+            <version>${telegram.version}</version>
         </dependency>
         <dependency>
-            <groupId>dpf.ap</groupId>
+            <groupId>com.github.sepinf-inc.telegram-decoder</groupId>
             <artifactId>telegram-decoder-impl</artifactId>
-            <version>${telegram.impl.version}</version>
+            <version>${telegram.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <java.dbx.version>1.1-p6</java.dbx.version>
         <xerial.sqlite.version>3.34.0</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>
-        <telegram.impl.version>1.0.9-SNAPSHOT</telegram.impl.version>
+        <telegram.version>1.0.10</telegram.version>
         <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
     </properties>
 


### PR DESCRIPTION
Closes #1990.

Much more contacts are being decoded and search hits for common words on chats and instant messages increased.