### PR TITLE
Use a single source of info to estimate time to finish (#2064)

### DIFF
--- a/iped-app/src/main/java/iped/app/processing/ui/ProgressFrame.java
+++ b/iped-app/src/main/java/iped/app/processing/ui/ProgressFrame.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.text.NumberFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -80,11 +79,11 @@ public class ProgressFrame extends JFrame implements PropertyChangeListener, Act
     private JProgressBar progressBar;
     private JButton pause, openApp;
     private JLabel tasks, itens, stats, parsers;
-    int indexed = 0, discovered = 0;
-    long rate = 0, instantRate;
-    int volume, taskSize;
-    long secsToEnd;
-    private Date indexStart;
+    private int prevVolume;
+    private boolean discoverEnded;
+    private long rate, instantRate;
+    private long secsToEnd;
+    private long processingStart;
     private Worker[] workers;
     private String[] lastWorkerTaskItemId;
     private long[] lastWorkerTime;
@@ -193,51 +192,68 @@ public class ProgressFrame extends JFrame implements PropertyChangeListener, Act
         });
     }
 
-    private void updateString() {
-        String msg = progressBar.getString();
-        if (indexed > 0) {
-            msg = Messages.getString("ProgressFrame.Processing") + indexed + " / " + discovered; //$NON-NLS-1$ //$NON-NLS-2$
-        } else if (discovered > 0) {
-            msg = Messages.getString("ProgressFrame.Found") + discovered + Messages.getString("ProgressFrame.items"); //$NON-NLS-1$ //$NON-NLS-2$
+    private void update() {
+        Statistics s = Statistics.get();
+        if (s == null) {
+            return;
+        }
+        // Get volume/item processed/total 
+        int totalVolume = (int)(Statistics.get().getCaseData().getDiscoveredVolume() >>> 20); // Converted to MB
+        int totalItems = Statistics.get().getCaseData().getDiscoveredEvidences();
+        int processedVolume = (int)(Statistics.get().getVolume() >>> 20); // Converted to MB
+        int processedItems = Statistics.get().getProcessed();
+
+        progressBar.setMaximum(totalVolume);
+        
+        tasks.setText(getTaskTimes());
+        itens.setText(getItemList());
+        stats.setText(getStats());
+        parsers.setText(getParserTimes());
+        if (processedItems > 0)
+            openApp.setEnabled(true);
+
+        if (discoverEnded) {
+            progressBar.setValue(processedVolume);
         }
 
-        if (taskSize != 0 && indexStart != null) {
-            secsToEnd = ((long) taskSize - (long) volume) * ((new Date()).getTime() - indexStart.getTime())
-                    / (((long) volume + 1) * 1000);
-            msg += Messages.getString("ProgressFrame.FinishIn") + secsToEnd / 3600 + "h " + (secsToEnd / 60) % 60 + "m " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    + secsToEnd % 60 + "s"; //$NON-NLS-1$
+        long interval = (System.currentTimeMillis() - processingStart) / 1000 + 1;
+        rate = processedVolume * 3600L / ((1 << 10) * interval);
+        instantRate = (processedVolume - prevVolume) * 3600L / (1 << 10) + 1;
+
+        String msg = progressBar.getString();
+        if (processedItems > 0) {
+            msg = Messages.getString("ProgressFrame.Processing") + processedItems + " / " + totalItems;
+        } else if (totalItems > 0) {
+            msg = Messages.getString("ProgressFrame.Found") + totalItems + Messages.getString("ProgressFrame.items");
+        }
+
+        if (discoverEnded && processingStart != 0) {
+            secsToEnd = (totalVolume - processedVolume) * (System.currentTimeMillis() - processingStart)
+                    / ((processedVolume + 1) * 1000L);
+            msg += Messages.getString("ProgressFrame.FinishIn") + secsToEnd / 3600 + "h " + (secsToEnd / 60) % 60 + "m "
+                    + secsToEnd % 60 + "s";
         } else if (decodingDir != null) {
             msg += " - " + decodingDir;
         }
         progressBar.setString(msg);
-
+        updateTaskBar(totalVolume, processedVolume, discoverEnded);
+        prevVolume = processedVolume;
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (indexStart == null) {
-            indexStart = new Date();
+        if (processingStart == 0) {
+            processingStart = System.currentTimeMillis();
             physicalMemory = Util.getPhysicalMemorySize();
-            updateTaskBar();
+            updateTaskBar(0, 0, false);
         }
 
-        if ("processed".equals(evt.getPropertyName())) { //$NON-NLS-1$
-            indexed = (Integer) evt.getNewValue();
-            updateString();
-            tasks.setText(getTaskTimes());
-            itens.setText(getItemList());
-            stats.setText(getStats());
-            parsers.setText(getParserTimes());
-            if (indexed > 0)
-                openApp.setEnabled(true);
-
-        } else if ("taskSize".equals(evt.getPropertyName())) { //$NON-NLS-1$
-            taskSize = (Integer) evt.getNewValue();
-            progressBar.setMaximum(taskSize);
-
-        } else if ("discovered".equals(evt.getPropertyName())) { //$NON-NLS-1$
-            discovered = (Integer) evt.getNewValue();
-            updateString();
+        if ("discoverEnded".equals(evt.getPropertyName())) {
+            discoverEnded = true;
+            update();
+            
+        } else if ("update".equals(evt.getPropertyName())) {
+            update();
 
         } else if ("decodingDir".equals(evt.getPropertyName())) { //$NON-NLS-1$
             decodingDir = (String) evt.getNewValue();
@@ -249,27 +265,12 @@ public class ProgressFrame extends JFrame implements PropertyChangeListener, Act
             stats.setText(getStats());
             parsers.setText(getParserTimes());
 
-        } else if ("progresso".equals(evt.getPropertyName())) { //$NON-NLS-1$
-            long prevVolume = volume;
-            volume = (Integer) evt.getNewValue();
-            if (taskSize != 0) {
-                progressBar.setValue(volume);
-            }
-
-            Date now = new Date();
-            long interval = (now.getTime() - indexStart.getTime()) / 1000 + 1;
-            rate = (long) volume * 1000000L * 3600L / ((1 << 30) * interval);
-            instantRate = (long) (volume - prevVolume) * 1000000L * 3600L / (1 << 30) + 1;
-
-            updateTaskBar();
-
         } else if ("workers".equals(evt.getPropertyName())) { //$NON-NLS-1$
             workers = (Worker[]) evt.getNewValue();
             lastWorkerTaskItemId = new String[workers.length];
             lastWorkerTime = new long[workers.length];
             pause.setEnabled(true);
         }
-
     }
 
     private String getItemList() {
@@ -414,7 +415,7 @@ public class ProgressFrame extends JFrame implements PropertyChangeListener, Act
         startTable(msg);
         addTitle(msg, 2, Messages.getString("ProgressFrame.Statistics"));
 
-        long time = (System.currentTimeMillis() - indexStart.getTime()) / 1000;
+        long time = (System.currentTimeMillis() - processingStart) / 1000;
         startRow(msg, Messages.getString("ProgressFrame.ProcessingTime"));
         finishRow(msg, time / 3600 + "h " + (time / 60) % 60 + "m " + time % 60 + "s", Align.RIGHT);
 
@@ -676,14 +677,14 @@ public class ProgressFrame extends JFrame implements PropertyChangeListener, Act
     /**
      * Show the current progress and state in system task bar.
      */
-    private void updateTaskBar() {
+    private void updateTaskBar(int totalVolume, int processedVolume, boolean discoverEnded) {
         if (Taskbar.isTaskbarSupported()) {
             Taskbar taskbar = Taskbar.getTaskbar();
             taskbar.setWindowProgressState(this,
-                    paused ? State.PAUSED : taskSize == 0 ? State.INDETERMINATE : State.NORMAL);
-            if (taskSize != 0) {
+                    paused ? State.PAUSED : discoverEnded ? State.INDETERMINATE : State.NORMAL);
+            if (discoverEnded) {
                 // Start from 10%, otherwise "paused" in earlier stages would be hard to see
-                int pct = (int) Math.min(100, 10 + Math.round(90.0 * volume / taskSize));
+                int pct = (int) Math.min(100, 10 + Math.round(90.0 * processedVolume / totalVolume));
                 taskbar.setWindowProgressValue(this, pct);
             }
         }

--- a/iped-engine/src/main/java/iped/engine/core/Manager.java
+++ b/iped-engine/src/main/java/iped/engine/core/Manager.java
@@ -590,9 +590,7 @@ public class Manager {
                 UIPropertyListenerProvider.getInstance().firePropertyChange("decodingDir", 0, //$NON-NLS-1$
                         Messages.getString("Manager.Adding") + currentDir.trim() + "\""); //$NON-NLS-1$ //$NON-NLS-2$
             }
-            UIPropertyListenerProvider.getInstance().firePropertyChange("discovered", 0, caseData.getDiscoveredEvidences()); //$NON-NLS-1$
-            UIPropertyListenerProvider.getInstance().firePropertyChange("processed", -1, stats.getProcessed()); //$NON-NLS-1$
-            UIPropertyListenerProvider.getInstance().firePropertyChange("progresso", 0, (int) (stats.getVolume() / 1000000)); //$NON-NLS-1$
+            UIPropertyListenerProvider.getInstance().firePropertyChange("update", 0, 0);
 
             boolean changeToNextQueue = !producer.isAlive();
             for (int k = 0; k < workers.length; k++) {

--- a/iped-engine/src/main/java/iped/engine/datasource/ItemProducer.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/ItemProducer.java
@@ -145,8 +145,7 @@ public class ItemProducer extends Thread implements Closeable {
             } else {
                 LOGGER.info("Total items found: {}", caseData.getDiscoveredEvidences()); //$NON-NLS-1$
             }
-            UIPropertyListenerProvider.getInstance().firePropertyChange("taskSize", 0, //$NON-NLS-1$
-                    (int) (caseData.getDiscoveredVolume() / 1000000));
+            UIPropertyListenerProvider.getInstance().firePropertyChange("discoverEnded", 0, 0);
 
         } catch (Throwable e) {
             if (manager.exception == null) {


### PR DESCRIPTION
Fix #2064.

When calculating the estimated time to finish processing, it uses the "Total Volume", the "Processed Volume" and the "Elapsed Time".
The negative time happened in the final part of the processing, when the "Processed Volume" was greater than the "Total Volume".
It shouldn't happen (the "Processed Volume" should be always less than or equal to the "Total Volume"), but it was because the "Total Volume" used in the calculation may have an outdated value (present in the beginning of the processing, but later incremented). The "Total Volume" presented in GUI was correct (updated).

Information used came from two different sources:
- The ProgressFrame/Console query Statistics to get these values;
- The ProgressFrame/Console receives new values through property changed events.

I changed the code a bit to use a single source of information (Statistics), which made things a bit simpler and fixed the issue (as the "Total Volume" used is always updated).
I also renamed some variables, which I believe will make the code a bit easier to follow:
```text
indexStart -> processingStart 
taskSize   -> totalVolume
volume     -> processedVolume
discovered -> totalItems
indexed    -> processedItems
```

