### PR TITLE
Use folder containing UFED XML report as root. Fix #2089

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
@@ -125,7 +125,7 @@ public class UfedXmlReader extends DataSourceReader {
 
     private static HashMap<File, UFDRInputStreamFactory> uisfMap = new HashMap<>();
 
-    File root, ufdrFile;
+    File root, rootFolder, ufdrFile;
     UFDRInputStreamFactory uisf;
     FileInputStreamFactory fisf, previewFisf;
     IItem rootItem;
@@ -136,7 +136,7 @@ public class UfedXmlReader extends DataSourceReader {
     private final List<String[]> deviceInfoData = new ArrayList<String[]>();
     private HashSet<String> addedImUfedIds = new HashSet<>();
     private HashSet<String> addedTrackIds = new HashSet<>();
-    
+
     public UfedXmlReader(ICaseData caseData, File output, boolean listOnly) {
         super(caseData, output, listOnly);
     }
@@ -365,7 +365,7 @@ public class UfedXmlReader extends DataSourceReader {
         DateFormat out = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
         private final DecimalFormat currencyFormat = LocalizedFormat.getDecimalInstance("#,##0.00");
-        
+
         ArrayList<XmlNode> nodeSeq = new ArrayList<>();
         ArrayList<Item> itemSeq = new ArrayList<>();
 
@@ -1129,7 +1129,7 @@ public class UfedXmlReader extends DataSourceReader {
                     deviceInfoData.add(new String[] { nameAttr, value, extractiontName });
                 }
             }
-            
+
             chars = new StringBuilder();
             nameAttr = null;
 
@@ -1260,12 +1260,15 @@ public class UfedXmlReader extends DataSourceReader {
                 ufdrPathToUfedId.put(path, ufedId);
             }
             if (ufdrFile == null) {
+                if (rootFolder == null) {
+                    rootFolder = root.getParentFile();
+                }
                 if (fisf == null) {
-                    fisf = new FileInputStreamFactory(root.toPath());
+                    fisf = new FileInputStreamFactory(rootFolder.toPath());
                 }
                 item.setInputStreamFactory(fisf);
                 item.setIdInDataSource(path);
-                File file = new File(root, path);
+                File file = new File(rootFolder, path);
                 item.setLength(file.length());
             } else {
                 if (getUISF().entryExists(path)) {
@@ -1347,7 +1350,7 @@ public class UfedXmlReader extends DataSourceReader {
                             .filter(cat -> StringUtils.isNotBlank(cat.value)) //
                             .forEach(cat -> finalScorePerCat.put(cat.value, cat.score));
                 }
-                
+
                 // set scores
                 finalScorePerCat.entrySet().stream()
                         .forEach(e -> item.setExtraAttribute(MEDIA_CLASSES_SCORE_PREFIX + e.getKey(), e.getValue()));
@@ -1629,7 +1632,7 @@ public class UfedXmlReader extends DataSourceReader {
             deviceInfo.setHash(null);
             return file;
         }
-        
+
         @Override
         public void characters(char[] ch, int start, int length) throws SAXException {
             if (listOnly)

--- a/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
@@ -1261,7 +1261,7 @@ public class UfedXmlReader extends DataSourceReader {
             }
             if (ufdrFile == null) {
                 if (rootFolder == null) {
-                    rootFolder = root.getParentFile();
+                    rootFolder = root.isDirectory() ? root : root.getParentFile();
                 }
                 if (fisf == null) {
                     fisf = new FileInputStreamFactory(rootFolder.toPath());


### PR DESCRIPTION
When using a UFED XML report as DataSource, UfedXmlReader.java was trying to use the XML file itself as a root folder for files referenced inside de XML. It should use the folder containing the XML report instead.