### PR TITLE
Timeline event grouping

### DIFF
--- a/iped-app/resources/localization/iped-desktop-messages.properties
+++ b/iped-app/resources/localization/iped-desktop-messages.properties
@@ -395,3 +395,6 @@ IntervalDefinitionDialog.Title=Time line chart defined ranges
 IntervalDefinitionDialog.dateFormat=MM/dd/yyyy
 IntervalDefinitionDialog.hourFormat=HH:mm:ss
 IntervalDefinitionDialog.Exit=Exit
+TimeEventGroup.BasicProperties=Basic Properties
+IndexTimeStampCache.loadingMessage=Starting to load time cache of [{}] to {} event type group.
+IndexTimeStampCache.buildingMessage=Starting to build time cache of [{}] to {} event type group.

--- a/iped-app/resources/localization/iped-desktop-messages_de_DE.properties
+++ b/iped-app/resources/localization/iped-desktop-messages_de_DE.properties
@@ -395,3 +395,6 @@ IntervalDefinitionDialog.Title=Zeitlininechart festgelegte Bereiche
 IntervalDefinitionDialog.dateFormat=MM/dd/yyyy
 IntervalDefinitionDialog.hourFormat=HH:mm:ss
 IntervalDefinitionDialog.Exit=Beenden
+TimeEventGroup.BasicProperties=Basic Properties(TBT)
+IndexTimeStampCache.loadingMessage=Starting to load time cache of [{}] to {} event type group.(TBT)
+IndexTimeStampCache.buildingMessage=Starting to build time cache of [{}] to {} event type group.(TBT)

--- a/iped-app/resources/localization/iped-desktop-messages_es_AR.properties
+++ b/iped-app/resources/localization/iped-desktop-messages_es_AR.properties
@@ -395,3 +395,6 @@ IntervalDefinitionDialog.Title=Rangos definidos en el gráfico de tiempo
 IntervalDefinitionDialog.dateFormat=MM/dd/yyyy
 IntervalDefinitionDialog.hourFormat=HH:mm:ss
 IntervalDefinitionDialog.Exit=Salir
+TimeEventGroup.BasicProperties=Basic Properties(TBT)
+IndexTimeStampCache.loadingMessage=Starting to load time cache of [{}] to {} event type group.(TBT)
+IndexTimeStampCache.buildingMessage=Starting to build time cache of [{}] to {} event type group.(TBT)

--- a/iped-app/resources/localization/iped-desktop-messages_it_IT.properties
+++ b/iped-app/resources/localization/iped-desktop-messages_it_IT.properties
@@ -395,3 +395,6 @@ IntervalDefinitionDialog.Title=Grafico sequenza temporale con intervalli definit
 IntervalDefinitionDialog.dateFormat=dd/MM/yyyy
 IntervalDefinitionDialog.hourFormat=HH:mm:ss
 IntervalDefinitionDialog.Exit=Esci
+TimeEventGroup.BasicProperties=Basic Properties(TBT)
+IndexTimeStampCache.loadingMessage=Starting to load time cache of [{}] to {} event type group.(TBT)
+IndexTimeStampCache.buildingMessage=Starting to build time cache of [{}] to {} event type group.(TBT)

--- a/iped-app/resources/localization/iped-desktop-messages_pt_BR.properties
+++ b/iped-app/resources/localization/iped-desktop-messages_pt_BR.properties
@@ -395,3 +395,6 @@ IntervalDefinitionDialog.Title=Intervalos definidos no gráfico
 IntervalDefinitionDialog.dateFormat=MM/dd/yyyy
 IntervalDefinitionDialog.hourFormat=HH:mm:ss
 IntervalDefinitionDialog.Exit=Sair
+TimeEventGroup.BasicProperties=Propriedades básicas
+IndexTimeStampCache.loadingMessage=Carregando índice de [{}] para o grupo de eventos {}.
+IndexTimeStampCache.buildingMessage=Construindo índice de [{}] para o grupo de eventos {}.

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -1141,7 +1141,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         refreshChart(false);
     }
 
-    public void info(String info) {
-        loadingLabelText.setText(info);
+    public void info(String info, String period, String groupname) {
+        loadingLabelText.setText(info.replaceFirst("\\{\\}", period).replaceFirst("\\{\\}", groupname));
     }
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -1,5 +1,6 @@
 package iped.app.timelinegraph;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -154,6 +155,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
     IpedChartPanel chartPanel = null;
     JList legendList = new JList();
     JScrollPane listScroller = new JScrollPane(legendList);
+    JPanel legendPane = new JPanel();
     JComboBox<TimeEventGroup> tegCombo = new JComboBox<>();
 
     IpedStackedXYBarRenderer renderer = null;
@@ -309,8 +311,8 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
                     }
                 });
         tegCombo.setRenderer(cblcRenderer);
-        chartPanel.add(tegCombo);
         tegCombo.addActionListener(this);
+        tegCombo.setMaximumSize(new Dimension(100, 0));
 
         legendListModel = new DefaultListModel<LegendItemBlockContainer>();
         legendList.setModel(legendListModel);
@@ -362,7 +364,12 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         ttm.setEnabled(true);
 
         splitPane.setTopComponent(chartPanel);
-        splitPane.setBottomComponent(listScroller);
+
+        legendPane.setPreferredSize(new Dimension(Integer.MAX_VALUE, 80));
+        legendPane.setLayout(new BorderLayout());
+        legendPane.add(tegCombo, BorderLayout.NORTH);
+        legendPane.add(listScroller, BorderLayout.CENTER);
+        splitPane.setBottomComponent(legendPane);
         splitPane.setVisible(false);
 
         chartPanel.setPopupMenu(null);
@@ -544,7 +551,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
                                 self.remove(splitPane);
                                 self.add(splitPane);
                                 splitPane.setTopComponent(chartPanel);
-                                splitPane.setBottomComponent(listScroller);
+                                splitPane.setBottomComponent(legendPane);
                                 splitPane.setVisible(true);
 
                                 // hide hidden events

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -1135,6 +1135,9 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         } else {
             selectedTeGroups.add(teGroup);
         }
+        if (selectedTeGroups.isEmpty()) {
+            selectedTeGroups.add(TimeEventGroup.BASIC_EVENTS);
+        }
         refreshChart(false);
     }
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -193,6 +193,8 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         }
         combinedPlot.setDomainPannable(true);
 
+        selectedTeGroups.add(TimeEventGroup.BASIC_EVENTS);
+
         toolTipGenerator = new XYToolTipGenerator() {
             @Override
             public String generateToolTip(XYDataset dataset, int series, int item) {
@@ -311,7 +313,6 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
                     }
                 });
         tegCombo.setRenderer(cblcRenderer);
-        tegCombo.addActionListener(this);
         tegCombo.setMaximumSize(new Dimension(100, 0));
 
         legendListModel = new DefaultListModel<LegendItemBlockContainer>();
@@ -618,15 +619,6 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
             public void changed(CDockableLocationEvent dockableEvent) {
                 if (!isUpdated && dockableEvent.isShowingChanged()) {
                     refreshChart();
-                    if (!loadingCacheStarted.getAndSet(true)) {
-                        Runnable r = new Runnable() {
-                            @Override
-                            public void run() {
-                                ipedTimelineDatasetManager.startCacheCreation();
-                            }
-                        };
-                        new Thread(r).start();
-                    }
                 }
             }
         };
@@ -1102,11 +1094,14 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         populateEventNames.run();
         this.ipedTimelineDatasetManager = new IpedTimelineDatasetManager(this);
 
+        // updates tegCombo with updated time event groups of the case
+        tegCombo.removeActionListener(this);
         tegCombo.removeAllItems();
         tegCombo.addItem(TimeEventGroup.BASIC_EVENTS);
         for (TimeEventGroup teGroup : ipedTimelineDatasetManager.getTimeEventGroupsFromMetadataPrefix()) {
             tegCombo.addItem(teGroup);
         }
+        tegCombo.addActionListener(this);
 
         this.dataSetUpdated.set(false);
     }

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
+import javax.swing.BoxLayout;
 import javax.swing.DefaultListModel;
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
@@ -164,7 +165,9 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
 
     String metadataToBreakChart = null;
     ImageIcon loading = null;
-    JLabel loadingLabel;
+    JPanel loadingPanel = new JPanel();
+    JLabel loadingLabelImage;
+    JLabel loadingLabelText;
 
     IpedSplitPane splitPane;
 
@@ -377,8 +380,15 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
         this.addComponentListener(this);
 
         loading = (ImageIcon) new ImageIcon(IconUtil.class.getResource(resPath + "loading.gif"));
-        loadingLabel = new JLabel("", loading, JLabel.CENTER);
-        this.add(loadingLabel);
+        loadingLabelImage = new JLabel("", loading, JLabel.CENTER);
+        loadingLabelText = new JLabel("", JLabel.CENTER);
+        loadingPanel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        loadingPanel.setLayout(new BoxLayout(loadingPanel, BoxLayout.Y_AXIS));
+        loadingLabelImage.setAlignmentX(Component.CENTER_ALIGNMENT);
+        loadingLabelText.setAlignmentX(Component.CENTER_ALIGNMENT);
+        loadingPanel.add(loadingLabelImage, BorderLayout.CENTER);
+        loadingPanel.add(loadingLabelText, BorderLayout.CENTER);
+        this.add(loadingPanel);
 
         domainAxis.setTickMarkPosition(DateTickMarkPosition.START);
         domainAxis.setLowerMargin(0.01);
@@ -420,6 +430,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
     }
 
     public HashMap<String, AbstractIntervalXYDataset> createDataSets() {
+
         HashMap<String, AbstractIntervalXYDataset> result = new HashMap<String, AbstractIntervalXYDataset>();
         try {
             Set<String> selectedBookmarks = guiProvider.getSelectedBookmarks();
@@ -482,8 +493,8 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
             IpedChartsPanel self = this;
 
             self.remove(splitPane);
-            self.remove(loadingLabel);
-            self.add(loadingLabel);
+            self.remove(loadingPanel);
+            self.add(loadingPanel);
             self.repaint();
 
             if (swRefresh != null) {
@@ -548,7 +559,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
                             }
 
                             if (chart != null && !isCancelled()) {
-                                self.remove(loadingLabel);
+                                self.remove(loadingPanel);
                                 self.remove(splitPane);
                                 self.add(splitPane);
                                 splitPane.setTopComponent(chartPanel);
@@ -1060,7 +1071,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
 
     @Override
     public void componentResized(ComponentEvent e) {
-        this.remove(loadingLabel);
+        this.remove(loadingPanel);
         this.remove(splitPane);
         this.add(splitPane);
     }
@@ -1125,5 +1136,9 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
             selectedTeGroups.add(teGroup);
         }
         refreshChart(false);
+    }
+
+    public void info(String info) {
+        loadingLabelText.setText(info);
     }
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/IpedChartsPanel.java
@@ -42,6 +42,7 @@ import java.util.function.Predicate;
 
 import javax.swing.DefaultListModel;
 import javax.swing.ImageIcon;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
@@ -99,7 +100,6 @@ import iped.app.ui.App;
 import iped.app.ui.ClearFilterListener;
 import iped.app.ui.ColumnsManager;
 import iped.app.ui.controls.CheckboxListCellRenderer;
-import iped.app.ui.controls.JComboCheckBox;
 import iped.app.ui.themes.ThemeManager;
 import iped.data.IItemId;
 import iped.engine.search.QueryBuilder;
@@ -154,7 +154,7 @@ public class IpedChartsPanel extends JPanel implements ResultSetViewer, TableMod
     IpedChartPanel chartPanel = null;
     JList legendList = new JList();
     JScrollPane listScroller = new JScrollPane(legendList);
-    JComboCheckBox<TimeEventGroup> tegCombo = new JComboCheckBox<>();
+    JComboBox<TimeEventGroup> tegCombo = new JComboBox<>();
 
     IpedStackedXYBarRenderer renderer = null;
     XYLineAndShapeRenderer highlightsRenderer = new XYLineAndShapeRenderer();

--- a/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
@@ -1,6 +1,9 @@
 package iped.app.timelinegraph;
 
+import java.util.Collection;
 import java.util.HashSet;
+
+import org.roaringbitmap.RoaringBitmap;
 
 /**
  * Class that represents a collection of event to use as a filter to graph
@@ -14,6 +17,7 @@ public class TimeEventGroup {
     public static final TimeEventGroup BASIC_EVENTS = new TimeEventGroup("BasicProperties");
 
     HashSet eventNames = new HashSet<String>();
+    RoaringBitmap eventOrds = new RoaringBitmap();
 
     String name;
 
@@ -50,12 +54,21 @@ public class TimeEventGroup {
         return name;
     }
 
-    public void addEvent(String eventName) {
+    public void addEvent(String eventName, int ord) {
         eventNames.add(eventName);
+        eventOrds.add(ord);
     }
 
     @Override
     public String toString() {
         return name;
+    }
+
+    public Collection<? extends String> getEventNames() {
+        return eventNames;
+    }
+
+    public RoaringBitmap getEventOrds() {
+        return eventOrds;
     }
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 
 import org.roaringbitmap.RoaringBitmap;
 
+import iped.app.ui.Messages;
+
 /**
  * Class that represents a collection of event to use as a filter to graph
  * events viewing. Also, the cache will be managed/persisted based on this event
@@ -14,7 +16,8 @@ import org.roaringbitmap.RoaringBitmap;
  */
 public class TimeEventGroup {
     public static final TimeEventGroup ALL_EVENTS = new TimeEventGroup();
-    public static final TimeEventGroup BASIC_EVENTS = new TimeEventGroup("BasicProperties");
+    public static final TimeEventGroup BASIC_EVENTS = new TimeEventGroup(
+            Messages.get("TimeEventGroup.BasicProperties"));
 
     HashSet eventNames = new HashSet<String>();
     RoaringBitmap eventOrds = new RoaringBitmap();

--- a/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/TimeEventGroup.java
@@ -1,0 +1,61 @@
+package iped.app.timelinegraph;
+
+import java.util.HashSet;
+
+/**
+ * Class that represents a collection of event to use as a filter to graph
+ * events viewing. Also, the cache will be managed/persisted based on this event
+ * groups
+ * 
+ * @author Patrick Dalla Bernardina patrick.dalla@gmail.com
+ */
+public class TimeEventGroup {
+    public static final TimeEventGroup ALL_EVENTS = new TimeEventGroup();
+    public static final TimeEventGroup BASIC_EVENTS = new TimeEventGroup("BasicProperties");
+
+    HashSet eventNames = new HashSet<String>();
+
+    String name;
+
+    private TimeEventGroup() {
+        this.name = "ALL";
+    }
+
+    public TimeEventGroup(String name) {
+        this.name = name;
+    }
+
+    public boolean hasEvent(String eventType) {
+        if (this == ALL_EVENTS) {
+            return true;
+        }
+        return eventNames.contains(eventType);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof TimeEventGroup) {
+            return name.equals(((TimeEventGroup) obj).name);
+        } else {
+            return true;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void addEvent(String eventName) {
+        eventNames.add(eventName);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
@@ -21,6 +21,7 @@ import org.jfree.data.time.TimePeriod;
 import org.roaringbitmap.RoaringBitmap;
 
 import iped.app.timelinegraph.IpedChartsPanel;
+import iped.app.timelinegraph.TimeEventGroup;
 import iped.app.timelinegraph.cache.persistance.CachePersistance;
 import iped.engine.core.Manager;
 import iped.viewers.api.IMultiSearchResultProvider;
@@ -36,6 +37,7 @@ public class IndexTimeStampCache implements TimeStampCache {
     IMultiSearchResultProvider resultsProvider;
     IpedChartsPanel ipedChartsPanel;
     TimeZone timezone;
+    TimeEventGroup teGroup = TimeEventGroup.ALL_EVENTS;//default TimeEventGroup
 
     TimeIndexedMap newCache = new TimeIndexedMap();
 
@@ -91,7 +93,7 @@ public class IndexTimeStampCache implements TimeStampCache {
                 int ord = 0;
                 while (ord < cachedEventNames.length) {
                     String eventType = cachedEventNames[ord];
-                    if (eventType != null && !eventType.isEmpty()) {
+                    if (eventType != null && !eventType.isEmpty() && teGroup.hasEvent(eventType)) {
                         cacheLoaders.add(new EventTimestampCache(ipedChartsPanel, resultsProvider, this, cachedEventNames[ord], ord));
                     }
                     ord++;
@@ -118,7 +120,7 @@ public class IndexTimeStampCache implements TimeStampCache {
 
                         newCache = new TimeIndexedMap();
                         for (Class periodClasses : periodClassesToCache) {
-                            newCache.setIndexFile(periodClasses.getSimpleName(), cp.getBaseDir());
+                            newCache.setIndexFile(teGroup, periodClasses.getSimpleName(), cp.getBaseDir());
                             LinkedHashSet<CacheTimePeriodEntry> times = new LinkedHashSet<CacheTimePeriodEntry>();
                             newCache.put(periodClasses.getSimpleName(), times);
                         }
@@ -299,6 +301,21 @@ public class IndexTimeStampCache implements TimeStampCache {
         }
 
         selectedCt.addEventEntry(eventInternalOrd, doc);
+    }
+
+    @Override
+    public boolean isFromEventGroup(TimeEventGroup teGroup) {
+        return this.teGroup.equals(teGroup);
+    }
+
+    @Override
+    public void setTimeEventGroup(TimeEventGroup teGroup) {
+        this.teGroup = teGroup;
+    }
+
+    @Override
+    public TimeEventGroup getTimeEventGroup() {
+        return this.teGroup;
     }
 
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
@@ -89,6 +89,8 @@ public class IndexTimeStampCache implements TimeStampCache {
             if (!cacheExists) {
                 Date d1 = new Date();
                 logger.info("Starting to build time cache of [{}]...", periodClassesToCache.toString());
+                ipedChartsPanel.info("Starting to build time cache of [" + periodClassesToCache.toString() + "] to "
+                        + teGroup.getName() + " event type group");
 
                 ArrayList<EventTimestampCache> cacheLoaders = new ArrayList<EventTimestampCache>();
 
@@ -139,6 +141,9 @@ public class IndexTimeStampCache implements TimeStampCache {
                 }
 
             } else {
+                ipedChartsPanel.info("Starting to load time cache of [" + periodClassesToCache.toString() + "] to "
+                        + teGroup.getName() + " event type group");
+
                 CachePersistence cp = CachePersistence.getInstance();
                 for (Class periodClasses : periodClassesToCache) {
                     newCache.setIndexFile(teGroup, periodClasses.getSimpleName(), cp.getBaseDir());

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
@@ -22,7 +22,7 @@ import org.roaringbitmap.RoaringBitmap;
 
 import iped.app.timelinegraph.IpedChartsPanel;
 import iped.app.timelinegraph.TimeEventGroup;
-import iped.app.timelinegraph.cache.persistance.CachePersistance;
+import iped.app.timelinegraph.cache.persistance.CachePersistence;
 import iped.engine.core.Manager;
 import iped.viewers.api.IMultiSearchResultProvider;
 
@@ -71,7 +71,7 @@ public class IndexTimeStampCache implements TimeStampCache {
                 periodClassesToCache.add(ipedChartsPanel.getTimePeriodClass());
             }
             for (Class periodClasses : periodClassesToCache) {
-                CachePersistance cp = CachePersistance.getInstance();
+                CachePersistence cp = CachePersistence.getInstance();
                 try {
                     TimeIndexedMap c = cp.loadNewCache(teGroup, periodClasses);
                     if (c != null) {
@@ -111,7 +111,7 @@ public class IndexTimeStampCache implements TimeStampCache {
 
                         if (Manager.getInstance() != null && Manager.getInstance().isProcessingFinished()) {
                         }
-                        CachePersistance cp = CachePersistance.getInstance();
+                        CachePersistence cp = CachePersistence.getInstance();
                         cp.saveNewCache(this);
 
                         cacheLoaders.clear();
@@ -135,7 +135,7 @@ public class IndexTimeStampCache implements TimeStampCache {
                 }
 
             } else {
-                CachePersistance cp = CachePersistance.getInstance();
+                CachePersistence cp = CachePersistence.getInstance();
                 for (Class periodClasses : periodClassesToCache) {
                     newCache.setIndexFile(teGroup, periodClasses.getSimpleName(), cp.getBaseDir());
                 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
@@ -37,7 +37,7 @@ public class IndexTimeStampCache implements TimeStampCache {
     IMultiSearchResultProvider resultsProvider;
     IpedChartsPanel ipedChartsPanel;
     TimeZone timezone;
-    TimeEventGroup teGroup = TimeEventGroup.ALL_EVENTS;//default TimeEventGroup
+    TimeEventGroup teGroup;// default TimeEventGroup
 
     TimeIndexedMap newCache = new TimeIndexedMap();
 
@@ -73,7 +73,7 @@ public class IndexTimeStampCache implements TimeStampCache {
             for (Class periodClasses : periodClassesToCache) {
                 CachePersistance cp = CachePersistance.getInstance();
                 try {
-                    TimeIndexedMap c = cp.loadNewCache(periodClasses);
+                    TimeIndexedMap c = cp.loadNewCache(teGroup, periodClasses);
                     if (c != null) {
                         cacheExists = true;
                     }
@@ -137,7 +137,7 @@ public class IndexTimeStampCache implements TimeStampCache {
             } else {
                 CachePersistance cp = CachePersistance.getInstance();
                 for (Class periodClasses : periodClassesToCache) {
-                    newCache.setIndexFile(periodClasses.getSimpleName(), cp.getBaseDir());
+                    newCache.setIndexFile(teGroup, periodClasses.getSimpleName(), cp.getBaseDir());
                 }
                 newCache.createOrLoadUpperPeriodIndex(this);
             }
@@ -316,6 +316,16 @@ public class IndexTimeStampCache implements TimeStampCache {
     @Override
     public TimeEventGroup getTimeEventGroup() {
         return this.teGroup;
+    }
+
+    @Override
+    public boolean isFromEventGroup(ArrayList<TimeEventGroup> selectedTeGroups) {
+        for (TimeEventGroup teGroup : selectedTeGroups) {
+            if (isFromEventGroup(teGroup)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/IndexTimeStampCache.java
@@ -24,6 +24,7 @@ import org.roaringbitmap.RoaringBitmap;
 import iped.app.timelinegraph.IpedChartsPanel;
 import iped.app.timelinegraph.TimeEventGroup;
 import iped.app.timelinegraph.cache.persistance.CachePersistence;
+import iped.app.ui.Messages;
 import iped.engine.core.Manager;
 import iped.viewers.api.IMultiSearchResultProvider;
 
@@ -89,8 +90,8 @@ public class IndexTimeStampCache implements TimeStampCache {
             if (!cacheExists) {
                 Date d1 = new Date();
                 logger.info("Starting to build time cache of [{}]...", periodClassesToCache.toString());
-                ipedChartsPanel.info("Starting to build time cache of [" + periodClassesToCache.toString() + "] to "
-                        + teGroup.getName() + " event type group");
+                ipedChartsPanel.info(Messages.get("IndexTimeStampCache.buildingMessage"),
+                        periodClassesToCache.toString(), teGroup.toString());
 
                 ArrayList<EventTimestampCache> cacheLoaders = new ArrayList<EventTimestampCache>();
 
@@ -141,8 +142,8 @@ public class IndexTimeStampCache implements TimeStampCache {
                 }
 
             } else {
-                ipedChartsPanel.info("Starting to load time cache of [" + periodClassesToCache.toString() + "] to "
-                        + teGroup.getName() + " event type group");
+                ipedChartsPanel.info(Messages.get("IndexTimeStampCache.loadingMessage"),
+                        periodClassesToCache.toString(), teGroup.toString());
 
                 CachePersistence cp = CachePersistence.getInstance();
                 for (Class periodClasses : periodClassesToCache) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/PersistedArrayList.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/PersistedArrayList.java
@@ -16,8 +16,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jfree.data.time.TimePeriod;
 
-import iped.app.timelinegraph.cache.persistance.CachePersistance;
-import iped.app.timelinegraph.cache.persistance.CachePersistance.CacheFileIterator;
+import iped.app.timelinegraph.cache.persistance.CachePersistence;
+import iped.app.timelinegraph.cache.persistance.CachePersistence.CacheFileIterator;
 import iped.app.timelinegraph.datasets.IpedTimelineDatasetManager;
 
 public class PersistedArrayList implements Set<CacheTimePeriodEntry> {
@@ -176,7 +176,7 @@ public class PersistedArrayList implements Set<CacheTimePeriodEntry> {
 
         final int lflushCount = flushCount++;
 
-        CachePersistance cp = CachePersistance.getInstance();
+        CachePersistence cp = CachePersistence.getInstance();
         Future f = cp.cachePersistanceExecutor.submit(new Runnable() {
             @Override
             public void run() {
@@ -201,7 +201,7 @@ public class PersistedArrayList implements Set<CacheTimePeriodEntry> {
     }
 
     public void removeFlushes() {
-        CachePersistance.getInstance().cachePersistanceExecutor.execute(new Runnable() {
+        CachePersistence.getInstance().cachePersistanceExecutor.execute(new Runnable() {
             @Override
             public void run() {
                 for (File f : flushFiles) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
@@ -15,7 +15,7 @@ import java.util.TreeMap;
 import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
 
 import iped.app.timelinegraph.TimeEventGroup;
-import iped.app.timelinegraph.cache.persistance.CachePersistance;
+import iped.app.timelinegraph.cache.persistance.CachePersistence;
 
 /**
  * @author Patrick Dalla Bernardina
@@ -171,7 +171,7 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
         private String className;
         boolean useCache = false;
         private TimelineCache timelineCache;
-        CachePersistance cp = CachePersistance.getInstance();
+        CachePersistence cp = CachePersistence.getInstance();
         int countRead = 0;// counters to log number of cache reads
         int countCache = 0;// counters to log number of disk reads
         private Reference<CacheTimePeriodEntry>[] lsoftcache;// soft reference cache (a more complete cache but with SoftReferences)
@@ -271,7 +271,7 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
     };
 
     public void createOrLoadUpperPeriodIndex(IndexTimeStampCache indexTimeStampCache) {
-        CachePersistance cp = CachePersistance.getInstance();
+        CachePersistence cp = CachePersistence.getInstance();
         if (upperPeriodIndex.size() == 0) {
             TimelineCache timelineCache = TimelineCache.get(indexTimeStampCache.getTimeEventGroup());
             for (Iterator iterator = indexTimeStampCache.getPeriodClassesToCache().iterator(); iterator.hasNext();) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
@@ -75,9 +75,6 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
         }
     }
 
-    public void setIndexFile(String periodName, File f) throws IOException {
-    }
-
     Date lastStartDate = null;
     Date lastEndDate = null;
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeIndexedMap.java
@@ -14,14 +14,39 @@ import java.util.TreeMap;
 
 import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
 
+import iped.app.timelinegraph.TimeEventGroup;
 import iped.app.timelinegraph.cache.persistance.CachePersistance;
 
+/**
+ * @author Patrick Dalla Bernardina
+ */
 public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
-    HashMap<String, TreeMap<Long, Long>> upperPeriodIndex = new HashMap<String, TreeMap<Long, Long>>();
-    HashMap<String, File> cacheFiles = new HashMap<String, File>();
-    HashMap<String, File> monthIndexCacheFiles = new HashMap<String, File>();
+    /*
+     * Cache persistence will be done based on tuple of TimeEventGroup and Period name
+     */
+    public class Tuple {
+        TimeEventGroup teGroup;
+        String periodName;
 
-    TimelineCache timelineCache = TimelineCache.get();
+        public Tuple(TimeEventGroup teGroup, String periodName) {
+            this.periodName = periodName;
+            this.teGroup = teGroup;
+        }
+
+        @Override
+        public int hashCode() {
+            return periodName.hashCode() * teGroup.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return (obj instanceof Tuple) && obj.hashCode() == this.hashCode();
+        }
+    }
+
+    HashMap<Tuple, TreeMap<Long, Long>> upperPeriodIndex = new HashMap<Tuple, TreeMap<Long, Long>>();
+    HashMap<Tuple, File> cacheFiles = new HashMap<Tuple, File>();
+    HashMap<Tuple, File> monthIndexCacheFiles = new HashMap<Tuple, File>();
 
     @Override
     public Set<CacheTimePeriodEntry> put(String key, Set<CacheTimePeriodEntry> value) {
@@ -30,14 +55,15 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
         return result;
     }
 
-    public void setIndexFile(String string, File f) throws IOException {
-        File cacheFile = new File(new File(f, string), "0");
+    public void setIndexFile(TimeEventGroup teGroup, String periodName, File f) throws IOException {
+        File baseCacheDir = new File(new File(f, teGroup.getName()), periodName);
+        File cacheFile = new File(baseCacheDir, "0");
         if (!cacheFile.exists() || cacheFile.length() == 0) {
             throw new IOException("File content does not exists:" + f.getName());
         }
 
-        this.cacheFiles.put(string, cacheFile);
-        this.monthIndexCacheFiles.put(string, new File(new File(f, string), "1"));
+        this.cacheFiles.put(new Tuple(teGroup, periodName), cacheFile);
+        this.monthIndexCacheFiles.put(new Tuple(teGroup, periodName), new File(baseCacheDir, "1"));
 
         int committed = 0;
         try (RandomAccessBufferedFileInputStream lcacheSfis = new RandomAccessBufferedFileInputStream(cacheFile); DataInputStream lcacheDis = new DataInputStream(lcacheSfis)) {
@@ -49,11 +75,15 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
         }
     }
 
+    public void setIndexFile(String periodName, File f) throws IOException {
+    }
+
     Date lastStartDate = null;
     Date lastEndDate = null;
 
-    public RandomAccessBufferedFileInputStream getTmpCacheSfis(String className) throws IOException {
-        File f = cacheFiles.get(className);
+    public RandomAccessBufferedFileInputStream getTmpCacheSfis(TimeEventGroup teGroup, String className)
+            throws IOException {
+        File f = cacheFiles.get(new Tuple(teGroup, className));
         if (f != null) {
             return new RandomAccessBufferedFileInputStream(f);
         } else {
@@ -61,7 +91,8 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
         }
     }
 
-    public ResultIterator iterator(String className, RandomAccessBufferedFileInputStream lcacheSfis, Date startDate, Date endDate) {
+    public ResultIterator iterator(TimeEventGroup teGroup, String className,
+            RandomAccessBufferedFileInputStream lcacheSfis, Date startDate, Date endDate) {
         try {
             DataInputStream lcacheDis = new DataInputStream(lcacheSfis);
 
@@ -70,6 +101,7 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
             String timezoneID = lcacheDis.readUTF();
             int entries = lcacheDis.readInt();
 
+            TimelineCache timelineCache = TimelineCache.get(teGroup);
             CacheTimePeriodEntry[] cache = timelineCache.get(className, entries);
 
             long startpos = lcacheSfis.getPosition();// position of first entry in cache
@@ -78,7 +110,8 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
                 // throught month index
                 Long num = null;
                 try {
-                    Entry<Long, Long> entry = upperPeriodIndex.get(className).floorEntry(startDate.getTime());
+                    Entry<Long, Long> entry = upperPeriodIndex.get(new Tuple(teGroup, className))
+                            .floorEntry(startDate.getTime());
                     if (entry != null) {
                         num = entry.getValue();
                     } else {
@@ -151,7 +184,9 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
                                    // from position in file)
         private long startPos;// start position in file to iterate
 
-        public ResultIterator(long pos, Integer startIndex, TimelineCache timelineCache, RandomAccessBufferedFileInputStream lcacheSfis, DataInputStream lcacheDis, long endDate, String className) {
+        public ResultIterator(long pos, Integer startIndex, TimelineCache timelineCache,
+                RandomAccessBufferedFileInputStream lcacheSfis, DataInputStream lcacheDis, long endDate,
+                String className) {
             this.startPos = pos;
             this.startIndex = startIndex;
             this.lcache = timelineCache.caches.get(className);
@@ -241,18 +276,20 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
     public void createOrLoadUpperPeriodIndex(IndexTimeStampCache indexTimeStampCache) {
         CachePersistance cp = CachePersistance.getInstance();
         if (upperPeriodIndex.size() == 0) {
+            TimelineCache timelineCache = TimelineCache.get(indexTimeStampCache.getTimeEventGroup());
             for (Iterator iterator = indexTimeStampCache.getPeriodClassesToCache().iterator(); iterator.hasNext();) {
-                String ev = (String) ((Class) iterator.next()).getSimpleName();
-                File f = monthIndexCacheFiles.get(ev);
+                String periodName = (String) ((Class) iterator.next()).getSimpleName();
+                File f = monthIndexCacheFiles.get(new Tuple(indexTimeStampCache.getTimeEventGroup(), periodName));
                 TreeMap<Long, Long> datesPos = new TreeMap<Long, Long>();
-                Map<Long, Integer> positionsIndexes = timelineCache.getCachesIndexes(ev);
+                Map<Long, Integer> positionsIndexes = timelineCache.getCachesIndexes(periodName);
                 try {
                     if (f.exists()) {
-                        cp.loadUpperPeriodIndex(ev, datesPos, positionsIndexes);
-                        upperPeriodIndex.put(ev, datesPos);
+                        cp.loadUpperPeriodIndex(indexTimeStampCache.getTimeEventGroup(), periodName, datesPos,
+                                positionsIndexes);
+                        upperPeriodIndex.put(new Tuple(indexTimeStampCache.getTimeEventGroup(), periodName), datesPos);
                     }
                 } finally {
-                    timelineCache.liberateCachesIndexes(ev);
+                    timelineCache.liberateCachesIndexes(periodName);
                 }
 
             }
@@ -262,7 +299,7 @@ public class TimeIndexedMap extends HashMap<String, Set<CacheTimePeriodEntry>> {
     long cacheStartPos = 0;
     long cacheEndPos = 0;
 
-    public HashMap<String, TreeMap<Long, Long>> getMonthIndex() {
+    public HashMap<Tuple, TreeMap<Long, Long>> getMonthIndex() {
         return upperPeriodIndex;
     }
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
@@ -8,6 +8,9 @@ import java.util.TimeZone;
 
 import org.jfree.data.time.TimePeriod;
 
+import iped.app.timelinegraph.TimeEventGroup;
+
+
 public interface TimeStampCache extends Runnable {
     public void addTimePeriodClassToCache(Class<? extends TimePeriod> timePeriodClass);
 
@@ -20,4 +23,10 @@ public interface TimeStampCache extends Runnable {
     public Map<String, Set<CacheTimePeriodEntry>> getNewCache();
 
     public TimeZone getCacheTimeZone();
+
+    public boolean isFromEventGroup(TimeEventGroup teGroup);
+
+    public void setTimeEventGroup(TimeEventGroup teGroup);
+
+    public TimeEventGroup getTimeEventGroup();
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
@@ -31,4 +31,6 @@ public interface TimeStampCache extends Runnable {
     public TimeEventGroup getTimeEventGroup();
 
     public boolean isFromEventGroup(ArrayList<TimeEventGroup> selectedTeGroups);
+
+    public boolean isLoading();
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimeStampCache.java
@@ -29,4 +29,6 @@ public interface TimeStampCache extends Runnable {
     public void setTimeEventGroup(TimeEventGroup teGroup);
 
     public TimeEventGroup getTimeEventGroup();
+
+    public boolean isFromEventGroup(ArrayList<TimeEventGroup> selectedTeGroups);
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/TimelineCache.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/TimelineCache.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.Semaphore;
 
+import iped.app.timelinegraph.TimeEventGroup;
+
 public class TimelineCache {
     Date startDate;
     Date endDate;
@@ -25,11 +27,7 @@ public class TimelineCache {
         // neverUnloadCache.add("Day");
     }
 
-    static TimelineCache singleton = new TimelineCache();
-
-    static public TimelineCache get() {
-        return singleton;
-    }
+    static HashMap<TimeEventGroup, TimelineCache> singletonMap = new HashMap<TimeEventGroup, TimelineCache>();
 
     private TimelineCache() {
     }
@@ -159,5 +157,14 @@ public class TimelineCache {
 
     public HashMap<String, CacheTimePeriodEntry[]> getCaches() {
         return caches;
+    }
+
+    public static TimelineCache get(TimeEventGroup teGroup) {
+        TimelineCache result = singletonMap.get(teGroup);
+        if (result == null) {
+            result = new TimelineCache();
+            singletonMap.put(teGroup, result);
+        }
+        return result;
     }
 }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistance.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistance.java
@@ -62,6 +62,8 @@ public class CachePersistance {
 
     static CachePersistance singleton = new CachePersistance();
 
+    static final String TIMECACHE_BASE_FOLDER = "timecachegroups";
+
     public static CachePersistance getInstance() {
         return singleton;
     }
@@ -78,7 +80,7 @@ public class CachePersistance {
             startDir = new File(App.get().casesPathFile.getParentFile(), "iped-multicases");
         }
 
-        startDir = new File(startDir, "timecache");
+        startDir = new File(startDir, TIMECACHE_BASE_FOLDER);
         startDir.mkdirs();
 
         bitstreamSerializeFile = new File(startDir, "bitstreamSerialize");
@@ -101,7 +103,7 @@ public class CachePersistance {
             baseDir = new File(startDir, uuid);
             if (!baseDir.exists() && !baseDir.mkdirs()) {
                 // cache doesn't exist and folder is not writable, use user.home for caches
-                startDir = new File(System.getProperty("user.home"), ".iped/timecache");
+                startDir = new File(System.getProperty("user.home"), ".iped/" + TIMECACHE_BASE_FOLDER);
                 baseDir = new File(startDir, uuid);
                 baseDir.mkdirs();
             }

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistance.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistance.java
@@ -136,14 +136,25 @@ public class CachePersistance {
         }
     }
 
-    public TimeIndexedMap loadNewCache(Class<? extends TimePeriod> className) throws IOException {
+    public TimeIndexedMap loadNewCache(TimeEventGroup teGroup, Class<? extends TimePeriod> className)
+            throws IOException {
         TimeIndexedMap newCache = null;
 
-        for (File f : baseDir.listFiles()) {
-            if (f.getName().equals(className.getSimpleName())) {
-                newCache = new TimeIndexedMap();
-                newCache.setIndexFile(className.getSimpleName(), baseDir);
-                break;
+        File[] files = baseDir.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (f.getName().equals(teGroup.getName())) {
+                    File[] files2 = f.listFiles();
+                    if (files2 != null) {
+                        for (File f2 : files2) {
+                            if (f2.getName().equals(className.getSimpleName())) {
+                                newCache = new TimeIndexedMap();
+                                newCache.setIndexFile(teGroup, className.getSimpleName(), baseDir);
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistence.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/cache/persistance/CachePersistence.java
@@ -44,10 +44,10 @@ import iped.app.ui.App;
 import iped.utils.IOUtil;
 
 /*
- * Class implementing method for timeline chart cache persistance
+ * Class implementing method for timeline chart cache persistence
  */
 
-public class CachePersistance {
+public class CachePersistence {
     File baseDir;
 
     HashMap<String, String> pathsToCheck = new HashMap<String, String>();
@@ -60,17 +60,17 @@ public class CachePersistance {
 
     static private boolean bitstreamSerializeAsDefault = true;
 
-    static CachePersistance singleton = new CachePersistance();
+    static CachePersistence singleton = new CachePersistence();
 
     static final String TIMECACHE_BASE_FOLDER = "timecachegroups";
 
-    public static CachePersistance getInstance() {
+    public static CachePersistence getInstance() {
         return singleton;
     }
 
     static public ExecutorService cachePersistanceExecutor = Executors.newFixedThreadPool(1);
 
-    public CachePersistance() {
+    public CachePersistence() {
         File startDir;
         if (App.get().appCase.getAtomicSources().size() == 1) {
             // single case

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
@@ -65,6 +65,9 @@ import iped.search.IMultiSearchResult;
 import iped.viewers.api.IMultiSearchResultProvider;
 import iped.viewers.api.IQueryFilterer;
 
+/**
+ * @author Patrick Dalla Bernardina
+ */
 public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cloneable, PublicCloneable, IntervalXYDataset, DomainInfo, TimelineDataset, TableXYDataset, XYDomainInfo, AsynchronousDataset {
     private static final int CTITEMS_PER_THREAD = 500;
     IMultiSearchResultProvider resultsProvider;
@@ -385,9 +388,11 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
                     cacheWindowEndDate = new Date(ipedChartsPanel.getChartPanel().removeNextFromDatePart(endDate).getTime() - 1);
                 }
 
-                try (RandomAccessBufferedFileInputStream sfis = a.getTmpCacheSfis(className)) {
+                try (RandomAccessBufferedFileInputStream sfis = a.getTmpCacheSfis(cache.getTimeEventGroup(),
+                        className)) {
                     if (sfis != null) {
-                        Iterator<CacheTimePeriodEntry> it = a.iterator(className, sfis, startDate, endDate);
+                        Iterator<CacheTimePeriodEntry> it = a.iterator(cache.getTimeEventGroup(), className, sfis,
+                                startDate, endDate);
                         while (it != null && it.hasNext()) {
                             ipedChartsPanel.getIpedTimelineDatasetManager().waitMemory();// method to wait available mem to continue.
                             if (cancelled) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
@@ -52,7 +52,7 @@ import iped.app.timelinegraph.cache.CombinedIterators;
 import iped.app.timelinegraph.cache.EventTimestampCache;
 import iped.app.timelinegraph.cache.TimeIndexedMap;
 import iped.app.timelinegraph.cache.TimeStampCache;
-import iped.app.timelinegraph.cache.persistance.CachePersistance;
+import iped.app.timelinegraph.cache.persistance.CachePersistence;
 import iped.app.ui.App;
 import iped.app.ui.CaseSearcherFilter;
 import iped.app.ui.Messages;
@@ -1197,7 +1197,7 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
             t.start();
         }
 
-        CachePersistance cp = new CachePersistance();
+        CachePersistence cp = new CachePersistence();
 
         public void addValue(Count count, TimePeriod t, String eventType) {
             if (min == null || t.getStart().before(min.getStart())) {

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDataset.java
@@ -1,8 +1,10 @@
 package iped.app.timelinegraph.datasets;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,8 +12,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -45,8 +45,10 @@ import iped.app.timelinegraph.DateUtil;
 import iped.app.timelinegraph.IpedChartPanel;
 import iped.app.timelinegraph.IpedChartsPanel;
 import iped.app.timelinegraph.IpedDateAxis;
+import iped.app.timelinegraph.TimeEventGroup;
 import iped.app.timelinegraph.cache.CacheEventEntry;
 import iped.app.timelinegraph.cache.CacheTimePeriodEntry;
+import iped.app.timelinegraph.cache.CombinedIterators;
 import iped.app.timelinegraph.cache.EventTimestampCache;
 import iped.app.timelinegraph.cache.TimeIndexedMap;
 import iped.app.timelinegraph.cache.TimeStampCache;
@@ -95,8 +97,7 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
     SortedSetDocValues timeEventGroupValues;
     IpedChartsPanel ipedChartsPanel;
 
-    SortedSet<String> eventTypes = new TreeSet<String>();
-    String[] eventTypesArray;
+    RoaringBitmap eventOrds = new RoaringBitmap();
     LeafReader reader;
 
     static ThreadPoolExecutor queriesThreadPool = new ThreadPoolExecutor(5, 10, 20000, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());// pool of concurrent group of itens in a dataset beeing populated
@@ -222,6 +223,9 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
                 for (int i = 0; i < threadCtsEnd; i++) {
                     CacheTimePeriodEntry ct = threadLocalCts[i];
                     for (CacheEventEntry ce : ct.getEvents()) {
+                        if (!eventOrds.contains(ce.getEventOrd())) {
+                            continue;
+                        }
                         if (ce.docIds != null) {
                             Count count = new Count();
                             for (int docId : ce.docIds) {
@@ -349,8 +353,7 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
             result = csf.get();
 
             if (result.getLength() > 0) {
-                TimeStampCache cache = ipedChartsPanel.getIpedTimelineDatasetManager().getCache();
-                TimeIndexedMap a = (TimeIndexedMap) cache.getNewCache();
+                Collection<TimeStampCache> caches = ipedChartsPanel.getIpedTimelineDatasetManager().getCaches();
 
                 String className = ipedChartsPanel.getTimePeriodClass().getSimpleName();
 
@@ -388,62 +391,83 @@ public class IpedTimelineDataset extends AbstractIntervalXYDataset implements Cl
                     cacheWindowEndDate = new Date(ipedChartsPanel.getChartPanel().removeNextFromDatePart(endDate).getTime() - 1);
                 }
 
-                try (RandomAccessBufferedFileInputStream sfis = a.getTmpCacheSfis(cache.getTimeEventGroup(),
-                        className)) {
-                    if (sfis != null) {
-                        Iterator<CacheTimePeriodEntry> it = a.iterator(cache.getTimeEventGroup(), className, sfis,
-                                startDate, endDate);
-                        while (it != null && it.hasNext()) {
-                            ipedChartsPanel.getIpedTimelineDatasetManager().waitMemory();// method to wait available mem to continue.
-                            if (cancelled) {
-                                break;
-                            }
+                ArrayList<RandomAccessBufferedFileInputStream> toCloseAtEnd = new ArrayList<RandomAccessBufferedFileInputStream>();
+                try {
+                    Iterator<CacheTimePeriodEntry>[] iterators = new Iterator[caches.size()];
+                    int i = 0;
+                    eventOrds.clear();
+                    for (TimeStampCache cache : caches) {
+                        TimeIndexedMap cacheMap = (TimeIndexedMap) cache.getNewCache();
+                        TimeEventGroup teGroup = cache.getTimeEventGroup();
+                        RandomAccessBufferedFileInputStream sfis = cacheMap
+                                .getTmpCacheSfis(teGroup, className);
+                        if (sfis == null) {
+                            throw new IOException("Temporary timeline cache not found for " + cache.getTimeEventGroup()
+                                    + " group:" + className);
+                        }
+                        eventOrds.or(teGroup.getEventOrds());
+                        toCloseAtEnd.add(sfis);
+                        iterators[i] = cacheMap.iterator(teGroup, className, sfis, startDate,
+                                endDate);
+                        i++;
+                    }
+                    CombinedIterators it = new CombinedIterators(iterators);
+                    while (it != null && it.hasNext()) {
+                        ipedChartsPanel.getIpedTimelineDatasetManager().waitMemory();// method to wait available mem to continue.
+                        if (cancelled) {
+                            break;
+                        }
 
-                            CacheTimePeriodEntry ctpe = it.next();
+                        CacheTimePeriodEntry ctpe = it.next();
 
-                            boolean remove = false;
-                            if (!fullrange) {
-                                if (ctpe.getDate().before(startDate)) {
-                                    if (ctpe.getDate().getTime() > cacheWindowStartDate.getTime()) {
-                                        if (!memoryWindowCache.contains(ctpe)) {
-                                            beforecache.addFirst(ctpe);
-                                            memoryWindowCache.add(ctpe);
-                                        }
-                                        remove = false;
-                                    } else {
-                                        // remove from memoryCacheWindow
-                                        remove = true;
-                                    }
-                                } else if (ctpe.getDate().after(endDate)) {
-                                    if (ctpe.getDate().getTime() < cacheWindowEndDate.getTime()) {
-                                        if (!memoryWindowCache.contains(ctpe)) {
-                                            aftercache.add(ctpe);
-                                            memoryWindowCache.add(ctpe);
-                                        }
-                                        remove = false;
-                                    } else {
-                                        // remove from memoryCacheWindow
-                                        remove = true;
-                                    }
-                                } else {// inside visible window
+
+                        boolean remove = false;
+
+                        if (!fullrange) {
+                            if (ctpe.getDate().before(startDate)) {
+                                if (ctpe.getDate().getTime() > cacheWindowStartDate.getTime()) {
                                     if (!memoryWindowCache.contains(ctpe)) {
-                                        visibleIntervalCache.add(ctpe);
+                                        beforecache.addFirst(ctpe);
                                         memoryWindowCache.add(ctpe);
                                     }
                                     remove = false;
+                                } else {
+                                    // remove from memoryCacheWindow
+                                    remove = true;
                                 }
-                            } else {
+                            } else if (ctpe.getDate().after(endDate)) {
+                                if (ctpe.getDate().getTime() < cacheWindowEndDate.getTime()) {
+                                    if (!memoryWindowCache.contains(ctpe)) {
+                                        aftercache.add(ctpe);
+                                        memoryWindowCache.add(ctpe);
+                                    }
+                                    remove = false;
+                                } else {
+                                    // remove from memoryCacheWindow
+                                    remove = true;
+                                }
+                            } else {// inside visible window
                                 if (!memoryWindowCache.contains(ctpe)) {
                                     visibleIntervalCache.add(ctpe);
                                     memoryWindowCache.add(ctpe);
                                 }
+                                remove = false;
                             }
-                            if (remove) {
-                                TimePeriod t = ipedChartsPanel.getDomainAxis().getDateOnConfiguredTimePeriod(ipedChartsPanel.getTimePeriodClass(), ctpe.getDate());
-                                accumulator.remove(t);
-                                memoryWindowCache.remove(ctpe);
+                        } else {
+                            if (!memoryWindowCache.contains(ctpe)) {
+                                visibleIntervalCache.add(ctpe);
+                                memoryWindowCache.add(ctpe);
                             }
                         }
+                        if (remove) {
+                            TimePeriod t = ipedChartsPanel.getDomainAxis().getDateOnConfiguredTimePeriod(ipedChartsPanel.getTimePeriodClass(), ctpe.getDate());
+                            accumulator.remove(t);
+                            memoryWindowCache.remove(ctpe);
+                        }
+                    }
+                } finally {
+                    for (RandomAccessBufferedFileInputStream sfis : toCloseAtEnd) {
+                        sfis.close();
                     }
                 }
 

--- a/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
+++ b/iped-app/src/main/java/iped/app/timelinegraph/datasets/IpedTimelineDatasetManager.java
@@ -41,7 +41,7 @@ public class IpedTimelineDatasetManager {
 
     List<TimeStampCache> timeStampCaches = new ArrayList<>();
     volatile boolean isCacheLoaded = false;
-    TimeStampCache selectedTimeStampCache;
+    ArrayList<TimeStampCache> selectedTimeStampCaches = new ArrayList<TimeStampCache>();
 
     public IpedTimelineDatasetManager(IpedChartsPanel ipedChartsPanel) {
         this.ipedChartsPanel = ipedChartsPanel;
@@ -71,18 +71,20 @@ public class IpedTimelineDatasetManager {
 
     }
 
-    public AbstractIntervalXYDataset getBestDataset(Class<? extends TimePeriod> timePeriodClass, TimeEventGroup teGroup,
+    public AbstractIntervalXYDataset getBestDataset(Class<? extends TimePeriod> timePeriodClass,
+            ArrayList<TimeEventGroup> selectedTeGroups,
             String splitValue) {
+        selectedTimeStampCaches.clear();
         try {
             for (TimeStampCache timeStampCache : timeStampCaches) {
                 if (timeStampCache.hasTimePeriodClassToCache(timePeriodClass)
-                        && timeStampCache.isFromEventGroup(teGroup)) {
-                    selectedTimeStampCache = timeStampCache;
-                    IpedTimelineDataset result = new IpedTimelineDataset(this, ipedChartsPanel.getResultsProvider(), splitValue);
-                    return result; 
+                        && timeStampCache.isFromEventGroup(selectedTeGroups)) {
+                    selectedTimeStampCaches.add(timeStampCache);
                 }
             }
-            return null;
+            IpedTimelineDataset result = new IpedTimelineDataset(this, ipedChartsPanel.getResultsProvider(),
+                    splitValue);
+            return result; 
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -128,8 +130,8 @@ public class IpedTimelineDatasetManager {
         }
     }
 
-    public TimeStampCache getCache() {
-        return selectedTimeStampCache;
+    public Collection<TimeStampCache> getCaches() {
+        return selectedTimeStampCaches;
     }
 
     public IpedChartsPanel getIpedChartsPanel() {
@@ -171,6 +173,7 @@ public class IpedTimelineDatasetManager {
             groupNames = new HashMap<String, TimeEventGroup>();
             String[] cachedEventNames = ipedChartsPanel.getOrdToEventName();
 
+            int ord = 0;
             for (String eventName : cachedEventNames) {
                 String groupName;
                 TimeEventGroup teGroup = TimeEventGroup.BASIC_EVENTS;
@@ -188,9 +191,11 @@ public class IpedTimelineDatasetManager {
                 }
 
 
-                teGroup.addEvent(eventName);
+                teGroup.addEvent(eventName, ord);
+                ord++;
             }
         }
         return groupNames.values();
     }
+
 }

--- a/iped-app/src/main/java/iped/app/ui/UICaseDataLoader.java
+++ b/iped-app/src/main/java/iped/app/ui/UICaseDataLoader.java
@@ -114,9 +114,9 @@ public class UICaseDataLoader extends SwingWorker<Void, Integer> {
                 UICaseSearcherFilter pesquisa = new UICaseSearcherFilter(new MatchAllDocsQuery());
                 pesquisa.execute();
                 LOGGER.info("Listing all items Finished"); //$NON-NLS-1$
-            } else {
-                App.get().notifyCaseDataChanged();
             }
+
+            App.get().notifyCaseDataChanged();
 
             treeModel = new TreeViewModel();
 
@@ -185,6 +185,7 @@ public class UICaseDataLoader extends SwingWorker<Void, Integer> {
                 ColumnsManager.getInstance().dispose();
                 App.get().appletListener.updateFileListing();
             }
+
         } finally {
             App.get().dialogBar.setVisible(false);
         }

--- a/iped-app/src/main/java/iped/app/ui/controls/CheckboxListCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/controls/CheckboxListCellRenderer.java
@@ -7,12 +7,14 @@ import java.awt.event.ActionListener;
 import java.util.function.Predicate;
 
 import javax.swing.JCheckBox;
+import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 
 public class CheckboxListCellRenderer<E> extends JPanel implements ListCellRenderer<E> {
     JCheckBox enabledCheckBox = new JCheckBox();
+    JLabel selectedValues = new JLabel();
     Predicate isEnabled;
     int maxStringWidth = 0;
     boolean indexedPredicate = false;
@@ -32,6 +34,30 @@ public class CheckboxListCellRenderer<E> extends JPanel implements ListCellRende
     @Override
     public Component getListCellRendererComponent(JList<? extends E> list, E value, int index, boolean isSelected,
             boolean cellHasFocus) {
+        if (index == -1) {
+
+            StringBuffer sb = new StringBuffer();
+            sb.append(" ");
+            for (int i = 0; i < list.getModel().getSize(); i++) {
+                Object lvalue = list.getModel().getElementAt(i);
+                boolean include = false;
+                if (indexedPredicate) {
+                    if (isEnabled.test(i)) {
+                        include = true;
+                    }
+                } else {
+                    if (isEnabled.test(lvalue)) {
+                        include = true;
+                    }
+                }
+                if (include) {
+                    sb.append(lvalue);
+                    sb.append(",");
+                }
+            }
+            selectedValues.setText(sb.toString());
+            return selectedValues;
+        }
         if (indexedPredicate) {
             enabledCheckBox.setSelected(isEnabled.test(index));
         } else {

--- a/iped-app/src/main/java/iped/app/ui/controls/CheckboxListCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/controls/CheckboxListCellRenderer.java
@@ -1,0 +1,64 @@
+package iped.app.ui.controls;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.ActionListener;
+import java.util.function.Predicate;
+
+import javax.swing.JCheckBox;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
+
+public class CheckboxListCellRenderer<E> extends JPanel implements ListCellRenderer<E> {
+    JCheckBox enabledCheckBox = new JCheckBox();
+    Predicate isEnabled;
+    int maxStringWidth = 0;
+    boolean indexedPredicate = false;
+
+    public CheckboxListCellRenderer(Predicate isEnabled) {
+        this.setLayout(new BorderLayout());
+        this.isEnabled = isEnabled;
+        this.setBackground(Color.white);
+        add(enabledCheckBox, BorderLayout.CENTER);
+    }
+
+    public CheckboxListCellRenderer(Predicate isEnabled, boolean indexedPredicate) {
+        this(isEnabled);
+        this.indexedPredicate = indexedPredicate;
+    }
+
+    @Override
+    public Component getListCellRendererComponent(JList<? extends E> list, E value, int index, boolean isSelected,
+            boolean cellHasFocus) {
+        if (indexedPredicate) {
+            enabledCheckBox.setSelected(isEnabled.test(index));
+        } else {
+            enabledCheckBox.setSelected(isEnabled.test(value));
+        }
+        enabledCheckBox.setText(value.toString());
+
+        this.add(enabledCheckBox, BorderLayout.CENTER);
+        if (isSelected) {
+            this.setBackground(Color.BLUE);
+            enabledCheckBox.setForeground(Color.white);
+        } else {
+            this.setBackground(Color.white);
+            enabledCheckBox.setForeground(Color.black);
+        }
+
+        return this;
+    }
+
+    public int getMaxStringWidth() {
+        if (maxStringWidth < enabledCheckBox.getWidth()) {
+            maxStringWidth = enabledCheckBox.getWidth();
+        }
+        return maxStringWidth;
+    }
+
+    public void addCheckBoxActionListener(ActionListener l) {
+        enabledCheckBox.addActionListener(l);
+    }
+}


### PR DESCRIPTION
Timeline event grouping implementation.

It recognizes groups from metadata name first prefix. Not prefixed metadata are included in "BasicProperties" group (this name can be improved in localization files).

Cache creation and loading are on demand and per group, i. e., if a group is never checked to appear on timeline chart, no index/cache is created/loaded for this group.

First group to appear selected in chart is "BasicProperties". At least on group should be selected, so, if none is selected, "BasicProperties" is automatically selected.
