### PR TITLE
Fix metadata error (#2110)

### DIFF
--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/custom/MOVCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/custom/MOVCarver.java
@@ -28,50 +28,44 @@ public class MOVCarver extends AbstractCarver {
     private int defaultMaxLength = 500000000;
 
     public MOVCarver() throws DecoderException {
-        carverTypes = new CarverType[5];
+        carverTypes = new CarverType[6];
 
         carverTypes[0] = new CarverType();
         carverTypes[0].addHeader("????ftypmp41");
-        carverTypes[0].addHeader("????ftypmp42");
+        carverTypes[0].addHeader("????ftypmp42????mp");
+        carverTypes[0].addHeader("????ftypmp42????MP");
         carverTypes[0].addHeader("????ftypmmp4");
         carverTypes[0].addHeader("????ftypMSNV");
         carverTypes[0].addHeader("????ftypFACE");
         carverTypes[0].addHeader("????ftypdash");
         carverTypes[0].addHeader("????ftypisom");
         carverTypes[0].setMimeType(MediaType.parse("video/mp4"));
-        carverTypes[0].setMaxLength(defaultMaxLength);
-        carverTypes[0].setMinLength(defaultMinLength);
-        carverTypes[0].setName("MOV");
 
         carverTypes[1] = new CarverType();
         carverTypes[1].addHeader("????ftypmjp2");
         carverTypes[1].setMimeType(MediaType.parse("video/mj2"));
-        carverTypes[1].setMaxLength(defaultMaxLength);
-        carverTypes[1].setMinLength(defaultMinLength);
-        carverTypes[1].setName("MOV");
 
         carverTypes[2] = new CarverType();
         carverTypes[2].addHeader("????ftypM4V");
         carverTypes[2].setMimeType(MediaType.parse("video/x-m4v"));
-        carverTypes[2].setMaxLength(defaultMaxLength);
-        carverTypes[2].setMinLength(defaultMinLength);
-        carverTypes[2].setName("MOV");
 
         carverTypes[3] = new CarverType();
         carverTypes[3].addHeader("????ftyp3g");
         carverTypes[3].setMimeType(MediaType.parse("video/3gpp"));
-        carverTypes[3].setMaxLength(defaultMaxLength);
-        carverTypes[3].setMinLength(defaultMinLength);
-        carverTypes[3].setName("MOV");
 
         carverTypes[4] = new CarverType();
         carverTypes[4].addHeader("????ftypqt\\20\\20");
         carverTypes[4].setMimeType(MediaType.parse("video/quicktime"));
-        carverTypes[4].setMaxLength(defaultMaxLength);
-        carverTypes[4].setMinLength(defaultMinLength);
-        carverTypes[4].setName("MOV");
+
+        carverTypes[5] = new CarverType();
+        carverTypes[5].addHeader("????ftypmp42????M4A");
+        carverTypes[5].addHeader("????ftypmp42????m4a");
+        carverTypes[5].setMimeType(MediaType.parse("audio/mp4"));
 
         for (int i = 0; i < carverTypes.length; i++) {
+            carverTypes[i].setMaxLength(defaultMaxLength);
+            carverTypes[i].setMinLength(defaultMinLength);
+            carverTypes[i].setName("MOV");
             carverTypes[i].setCarverClass(this.getClass().getName());
         }
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/MetadataUtil.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/MetadataUtil.java
@@ -392,10 +392,13 @@ public class MetadataUtil {
         normalizeGPSMeta(metadata);
         normalizeCase(metadata);
         prefixCommonMetadata(metadata);
-        prefixAudioMetadata(metadata);
-        prefixImageMetadata(metadata);
-        prefixVideoMetadata(metadata);
-        prefixPDFMetadata(metadata);
+        if (!prefixVideoMetadata(metadata)) {
+            if (!prefixAudioMetadata(metadata)) {
+                if (!prefixImageMetadata(metadata)) {
+                    prefixPDFMetadata(metadata);
+                }
+            }
+        }
         prefixDocMetadata(metadata);
         prefixBasicMetadata(metadata);
         removeDuplicateValues(metadata);
@@ -654,14 +657,20 @@ public class MetadataUtil {
         }
     }
 
-    private static void prefixAudioMetadata(Metadata metadata) {
-        if (metadata.get(Metadata.CONTENT_TYPE).startsWith("audio")) //$NON-NLS-1$
+    private static boolean prefixAudioMetadata(Metadata metadata) {
+        if (metadata.get(Metadata.CONTENT_TYPE).startsWith("audio")) {
             includePrefix(metadata, ExtraProperties.AUDIO_META_PREFIX);
+            return true;
+        }
+        return false;
     }
 
-    private static void prefixImageMetadata(Metadata metadata) {
-        if (metadata.get(Metadata.CONTENT_TYPE).startsWith("image")) //$NON-NLS-1$
+    private static boolean prefixImageMetadata(Metadata metadata) {
+        if (metadata.get(Metadata.CONTENT_TYPE).startsWith("image")) {
             includePrefix(metadata, ExtraProperties.IMAGE_META_PREFIX);
+            return true;
+        }
+        return false;
     }
 
     public static boolean isVideoType(MediaType mediaType) {
@@ -669,15 +678,21 @@ public class MetadataUtil {
                 || mediaType.getBaseType().toString().equals("application/vnd.rn-realmedia"); //$NON-NLS-1$
     }
 
-    private static void prefixVideoMetadata(Metadata metadata) {
+    private static boolean prefixVideoMetadata(Metadata metadata) {
         if (isVideoType(MediaType.parse(metadata.get(Metadata.CONTENT_TYPE)))
-                || isVideoType(MediaType.parse(metadata.get(StandardParser.INDEXER_CONTENT_TYPE))))
+                || isVideoType(MediaType.parse(metadata.get(StandardParser.INDEXER_CONTENT_TYPE)))) {
             includePrefix(metadata, ExtraProperties.VIDEO_META_PREFIX);
+            return true;
+        }
+        return false;
     }
 
-    private static void prefixPDFMetadata(Metadata metadata) {
-        if (metadata.get(Metadata.CONTENT_TYPE).equals("application/pdf")) //$NON-NLS-1$
+    private static boolean prefixPDFMetadata(Metadata metadata) {
+        if (metadata.get(Metadata.CONTENT_TYPE).equals("application/pdf")) {
             includePrefix(metadata, ExtraProperties.PDF_META_PREFIX);
+            return true;
+        }
+        return false;
     }
 
     private static void prefixDocMetadata(Metadata metadata) {


### PR DESCRIPTION
Fixes #2110.

This was a tricky issue.
First, the provided file was carved as a video, but it was actually an audio file.
In `MetadataUtil`, it received both "audio:" and "video:" prefix because "Indexer-Content-Type" = "video/mp4" and
"Content-Type" = "audio/mp4".
In the code, checking if it's a video uses both properties ("Indexer-Content-Type" and "Content-Type"). If at least one of them starts with "video" it receives the "video:" prefix. Audio checks only the second property.

I kept this behavior (video check both properties), but changed the code to accept just a single prefix (among "video:", "audio:", "image:" and "pdf:"). This was enough to solve the issue.

I also refined the header signatures used by `MOVCarver`, so it handles "audio/mp4", so files like the provided one would be carved as audios.