### PR TITLE
More robust audio detection in MOVCarver (#2110)

### DIFF
--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -1584,7 +1584,16 @@
         </magic>
         <glob pattern="*.lzfse"/>
     </mime-type>
-    
+
+    <mime-type type="audio/mp4">
+        <magic priority="60">
+            <match value="ftypmp42" type="string" offset="4">
+                <match value="M4A" type="string" offset="16"/>
+                <match value="m4a" type="string" offset="16"/>
+            </match>
+        </magic>
+        <glob pattern="*.mp4a"/>
+    </mime-type>
 
     <mime-type type="application/x-ofx-v1">
         <magic priority="50">

--- a/iped-app/resources/config/conf/CustomSignatures.xml
+++ b/iped-app/resources/config/conf/CustomSignatures.xml
@@ -1586,13 +1586,22 @@
     </mime-type>
 
     <mime-type type="audio/mp4">
+        <alias type="audio/x-m4a"/>
+        <alias type="audio/x-mp4a"/>
         <magic priority="60">
+            <match value="ftypM4A " type="string" offset="4"/>
+            <match value="ftypM4B " type="string" offset="4"/>
+            <match value="ftypF4A " type="string" offset="4"/>
+            <match value="ftypF4B " type="string" offset="4"/>
             <match value="ftypmp42" type="string" offset="4">
                 <match value="M4A" type="string" offset="16"/>
                 <match value="m4a" type="string" offset="16"/>
             </match>
         </magic>
         <glob pattern="*.mp4a"/>
+        <glob pattern="*.m4a"/>
+        <glob pattern="*.m4b"/>
+        <sub-class-of type="application/quicktime" />
     </mime-type>
 
     <mime-type type="application/x-ofx-v1">

--- a/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/custom/MOVCarver.java
+++ b/iped-carvers/iped-carvers-impl/src/main/java/iped/carvers/custom/MOVCarver.java
@@ -32,8 +32,6 @@ public class MOVCarver extends AbstractCarver {
 
         carverTypes[0] = new CarverType();
         carverTypes[0].addHeader("????ftypmp41");
-        carverTypes[0].addHeader("????ftypmp42????mp");
-        carverTypes[0].addHeader("????ftypmp42????MP");
         carverTypes[0].addHeader("????ftypmmp4");
         carverTypes[0].addHeader("????ftypMSNV");
         carverTypes[0].addHeader("????ftypFACE");
@@ -58,9 +56,7 @@ public class MOVCarver extends AbstractCarver {
         carverTypes[4].setMimeType(MediaType.parse("video/quicktime"));
 
         carverTypes[5] = new CarverType();
-        carverTypes[5].addHeader("????ftypmp42????M4A");
-        carverTypes[5].addHeader("????ftypmp42????m4a");
-        carverTypes[5].setMimeType(MediaType.parse("audio/mp4"));
+        carverTypes[5].addHeader("????ftypmp42");
 
         for (int i = 0; i < carverTypes.length; i++) {
             carverTypes[i].setMaxLength(defaultMaxLength);


### PR DESCRIPTION
@lfcnassif, not setting the mime type while carving "ftypmp42" as you suggested seems much better.
I had to add a custom signature for "audio/mp4", as the default behavior was detecting these audios as videos.
I tested with a synthetic case (with few videos and audios merged with random bytes in a large binary block) and a real case (no "audio/mp4" files in that case, but many videos), and it behaved as expected.
Sorry for overlooking this!