### PR TITLE
Does not caches the union of bitmaps in a resulting bitmap

### DIFF
--- a/iped-app/src/main/java/iped/app/ui/CaseSearcherFilter.java
+++ b/iped-app/src/main/java/iped/app/ui/CaseSearcherFilter.java
@@ -57,7 +57,7 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
     ArrayList<CaseSearchFilterListener> listeners = new ArrayList<CaseSearchFilterListener>();
     RoaringBitmap[] unionsArray;
     RoaringBitmap[] excludeUnionsArray;
-    
+
     public static SoftReference<MultiSearchResult> allItemsCache;
     private static IPEDSource ipedCase;
 
@@ -216,7 +216,7 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
                         result.setIPEDSource(ipedCase);
                     }
                 }
-                
+
             } catch (Throwable e) {
                 if (!(e instanceof CancellationException)) {
                     e.printStackTrace();
@@ -240,11 +240,11 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
 
             if (rsFilter != null) {
                 if (rsFilter instanceof IBitmapFilter) {// if the filter exposes a internal bitmap
-                	applyBitmapFilter((IBitmapFilter)rsFilter);
+                    applyBitmapFilter((IBitmapFilter) rsFilter);
                 } else {
                     RoaringBitmap[] cachedBitmaps = filterManager.getCachedBitmaps((IResultSetFilter) rsFilter);
                     if (cachedBitmaps != null) { // if filtermanager returned a cached bitmap
-                    	applyBitmapFilter(cachedBitmaps);
+                        applyBitmapFilter(cachedBitmaps);
                     } else {
                         MultiSearchResult newresult = filterManager.applyFilter((IResultSetFilter) rsFilter, result);
                         if (newresult != result) {
@@ -256,10 +256,10 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
                 }
             }
         }
-	}
+    }
 
-	private void applyBitmapFilter(RoaringBitmap[] cachedBitmaps) {
-		RoaringBitmap[] lunionsArray = result.getCasesBitSets((IPEDMultiSource) ipedCase);
+    private void applyBitmapFilter(RoaringBitmap[] cachedBitmaps) {
+        RoaringBitmap[] lunionsArray = result.getCasesBitSets((IPEDMultiSource) ipedCase);
         for (int i = 0; i < unionsArray.length; i++) {
             lunionsArray[i].and(cachedBitmaps[i]);
         }
@@ -270,10 +270,10 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
             result = newresult;
             result.setIPEDSource(ipedCase);
         }
-	}
+    }
 
-	private void applyBitmapFilter(IBitmapFilter rsFilter) {
-		RoaringBitmap[] lunionsArray = result.getCasesBitSets((IPEDMultiSource) ipedCase);
+    private void applyBitmapFilter(IBitmapFilter rsFilter) {
+        RoaringBitmap[] lunionsArray = result.getCasesBitSets((IPEDMultiSource) ipedCase);
         for (int i = 0; i < lunionsArray.length; i++) {
             if (rsFilter.isToFilterOut()) {
                 lunionsArray[i].andNot(((IBitmapFilter) rsFilter).getBitmap()[i]);
@@ -288,9 +288,9 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
             result = newresult;
             result.setIPEDSource(ipedCase);
         }
-	}
+    }
 
-	@Override
+    @Override
     public void done() {
         for (CaseSearchFilterListener caseSearchFilterListener : listeners) {
             if (isCancelled()) {
@@ -376,6 +376,6 @@ public class CaseSearcherFilter extends CancelableWorker<MultiSearchResult, Obje
             } else {
                 unionsArray[i].and(lunionsArray[i]);
             }
-        }	
+        }
     }
 }

--- a/iped-engine/src/main/java/iped/engine/search/MultiSearchResult.java
+++ b/iped-engine/src/main/java/iped/engine/search/MultiSearchResult.java
@@ -232,7 +232,18 @@ public class MultiSearchResult implements IMultiSearchResult {
                 }
                 bitset.add(ids[i].getId());
             }
-        }
-        return casesBitSet;
+
+        } 
+        return clone(casesBitSet);
     }
+
+	private RoaringBitmap[] clone(RoaringBitmap[] casesBitSet2) {
+    	RoaringBitmap[] lcasesBitSet = new RoaringBitmap[casesBitSet.length];
+    	for(int i=0; i<casesBitSet.length;i++) {
+            lcasesBitSet[i] = new RoaringBitmap();
+    		lcasesBitSet[i].or(casesBitSet[i]);
+    	}
+    	return lcasesBitSet;
+	}
+    
 }

--- a/iped-engine/src/main/java/iped/engine/search/MultiSearchResult.java
+++ b/iped-engine/src/main/java/iped/engine/search/MultiSearchResult.java
@@ -233,17 +233,17 @@ public class MultiSearchResult implements IMultiSearchResult {
                 bitset.add(ids[i].getId());
             }
 
-        } 
+        }
         return clone(casesBitSet);
     }
 
-	private RoaringBitmap[] clone(RoaringBitmap[] casesBitSet2) {
-    	RoaringBitmap[] lcasesBitSet = new RoaringBitmap[casesBitSet.length];
-    	for(int i=0; i<casesBitSet.length;i++) {
+    private RoaringBitmap[] clone(RoaringBitmap[] casesBitSet2) {
+        RoaringBitmap[] lcasesBitSet = new RoaringBitmap[casesBitSet.length];
+        for (int i = 0; i < casesBitSet.length; i++) {
             lcasesBitSet[i] = new RoaringBitmap();
-    		lcasesBitSet[i].or(casesBitSet[i]);
-    	}
-    	return lcasesBitSet;
-	}
-    
+            lcasesBitSet[i].or(casesBitSet[i]);
+        }
+        return lcasesBitSet;
+    }
+
 }


### PR DESCRIPTION
Does not caches the union of bitmaps in a resulting bitmap, as the order of the filters applied in cache may not follow the order that is enforced by the filterer registration in filter manager.

This PR closes '#2251 and '#2252