### PR TITLE
#2011: Use group identifier as Communication:To in group messages

### DIFF
--- a/iped-api/src/main/java/iped/properties/ExtraProperties.java
+++ b/iped-api/src/main/java/iped/properties/ExtraProperties.java
@@ -53,6 +53,8 @@ public class ExtraProperties {
 
     public static final String GROUP_ID = "GroupID";
 
+    public static final String IS_GROUP_MESSAGE = "isGroupMessage";
+
     public static final String MESSAGE_BODY = MESSAGE_PREFIX + "Body"; //$NON-NLS-1$
 
     public static final String MESSAGE_IS_ATTACHMENT = Message.MESSAGE_PREFIX + "IsEmailAttachment"; //$NON-NLS-1$

--- a/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/UfedXmlReader.java
@@ -27,7 +27,6 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Random;
@@ -1164,43 +1163,36 @@ public class UfedXmlReader extends DataSourceReader {
             }
         }
 
-        private HashMap<String, String[]> toCache = new LinkedHashMap<String, String[]>(16, 0.75f, true) {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            protected boolean removeEldestEntry(Entry<String, String[]> eldest) {
-                return this.size() > 1000;
-            }
-        };
-
         private Property toProperty = Property.internalText(ExtraProperties.COMMUNICATION_TO);
 
         private void fillMissingInfo(Item item) {
             String from = item.getMetadata().get(ExtraProperties.COMMUNICATION_FROM);
-            String to = item.getMetadata().get(ExtraProperties.COMMUNICATION_TO);
+            String[] to = item.getMetadata().getValues(ExtraProperties.COMMUNICATION_TO);
             boolean fromOwner = Boolean.valueOf(item.getMetadata().get(ExtraProperties.UFED_META_PREFIX + "fromOwner"));
-            if (to == null) {
+            if (to == null || to.length != 1) {
                 if (item.getMediaType() != null
                         && MediaTypes.isInstanceOf(item.getMediaType(), MediaTypes.UFED_MESSAGE_MIME)) {
                     // we have seen ufed messages without parent chat
                     if (itemSeq.size() == 0)
                         return;
                     IItem parentChat = itemSeq.get(itemSeq.size() - 1);
-                    String[] parties = parentChat.getMetadata()
-                            .getValues(ExtraProperties.UFED_META_PREFIX + "Participants");
-                    ArrayList<String> toList = new ArrayList<>();
-                    for (String party : parties) {
-                        if ((from != null && !party.equals(from)) || (fromOwner && !ownerParties.contains(party)))
-                            toList.add(party);
+                    List<String> toList = new ArrayList<>();
+                    if (to != null && to.length > 0) {
+                        toList = Arrays.asList(to);
+                    } else {
+                        String[] parties = parentChat.getMetadata().getValues(ExtraProperties.UFED_META_PREFIX + "Participants");
+                        for (String party : parties) {
+                            if ((from != null && !party.equals(from)) || (fromOwner && !ownerParties.contains(party)))
+                                toList.add(party);
+                        }
                     }
-                    String key = toList.toString();
-                    String[] val = toCache.get(key);
-                    if (val == null) {
-                        val = toList.toArray(new String[toList.size()]);
-                        toCache.put(key, val);
+                    if (toList.size() == 1) {
+                        item.getMetadata().set(toProperty, toList.get(0));
+                    } else if (toList.size() > 1) {
+                        item.getMetadata().set(toProperty, parentChat.getName());
+                        item.getMetadata().set(ExtraProperties.IS_GROUP_MESSAGE, "true");
                     }
-                    item.getMetadata().set(toProperty, val);
+
                 }
             }
             if (!msisdns.isEmpty() && (MediaTypes.UFED_CALL_MIME.equals(item.getMediaType())

--- a/iped-engine/src/main/java/iped/engine/graph/GraphTask.java
+++ b/iped-engine/src/main/java/iped/engine/graph/GraphTask.java
@@ -354,6 +354,10 @@ public class GraphTask extends AbstractTask {
         return null;
     }
 
+    private NodeValues getGroupNodeValues(String value) {
+        return new NodeValues(DynLabel.label(GraphConfiguration.CONTACT_GROUP_LABEL), BasicProps.NAME, value.trim().toLowerCase());
+    }
+
     private NodeValues getGenericNodeValues(String value) {
         return new NodeValues(DynLabel.label("GENERIC"), "entity", value.trim().toLowerCase());
     }
@@ -469,7 +473,12 @@ public class GraphTask extends AbstractTask {
         recipients.addAll(Arrays.asList(metadata.getValues(Message.MESSAGE_BCC)));
 
         for (String recipient : recipients) {
-            NodeValues nv2 = getNodeValues(recipient, evidence.getMetadata(), detectPhones);
+            NodeValues nv2;
+            if (Boolean.valueOf(metadata.get(ExtraProperties.IS_GROUP_MESSAGE))) {
+                nv2 = getGroupNodeValues(recipient);
+            } else {
+                nv2 = getNodeValues(recipient, metadata, detectPhones);
+            }
             graphFileWriter.writeNode(nv2.label, nv2.propertyName, nv2.propertyValue, nv2.props);
             graphFileWriter.writeRelationship(nv1.label, nv1.propertyName, nv1.propertyValue, nv2.label,
                     nv2.propertyName, nv2.propertyValue, relationshipType, relProps);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/discord/DiscordParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/discord/DiscordParser.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import iped.data.IItemReader;
 import iped.parsers.browsers.chrome.CacheIndexParser;
-import iped.parsers.discord.cache.CacheAddr.InputStreamNotAvailable;
 import iped.parsers.discord.cache.Index;
 import iped.parsers.discord.json.DiscordAttachment;
 import iped.parsers.discord.json.DiscordAuthor;
@@ -324,15 +323,18 @@ public class DiscordParser extends AbstractParser {
             meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, d.getAuthor().getFullUsername());
             meta.set(ExtraProperties.DECODED_DATA, Boolean.TRUE.toString());
 
-            // Add "Message-TO" field
-            for (String participant : participants) {
-                if (participant.length() <= 1) {
-                    // In cases where only one participant sends messages, it is not possible to
-                    // determine the participants as only the participant list of the calls are
-                    // cached.
-                } else if (!participant.equals(d.getAuthor().getFullUsername())) {
-                    meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, participant);
+            // Add "Message-TO" field.
+            // In cases where only one participant sends messages, it is not possible to
+            // determine the participants as only the participant list of the calls are cached.
+            if (participants.size() <= 2) {
+                for (String participant : participants) {
+                    if (!participant.equals(d.getAuthor().getFullUsername())) {
+                        meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, participant);
+                    }
                 }
+            } else {
+                meta.set(org.apache.tika.metadata.Message.MESSAGE_TO, chatName);
+                meta.set(ExtraProperties.IS_GROUP_MESSAGE, "true");
             }
 
             for (DiscordAttachment da : d.getAttachments()) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/skype/SkypeParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/skype/SkypeParser.java
@@ -7,7 +7,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -253,13 +252,8 @@ public class SkypeParser extends AbstractParser {
                     tMetadata.set(ExtraProperties.MESSAGE_DATE, t.getStart());
                     tMetadata.set(ExtraProperties.MESSAGE_BODY, name);
                     tMetadata.set(Metadata.MESSAGE_FROM, formatSkypeName(contactMap, t.getFrom()));
-                    if (t.getType() == 3 && t.getConversation().getParticipantes() != null) {
-                        for (Iterator<String> iterator = t.getConversation().getParticipantes().iterator(); iterator
-                                .hasNext();) {
-                            String recip = formatSkypeName(contactMap, iterator.next());
-                            if (recip != null)
-                                tMetadata.add(Metadata.MESSAGE_TO, recip);
-                        }
+                    if (t.getType() == 3 && t.getConversation().getParticipantes() != null && t.getConversation().getParticipantes().size() > 1) {
+                        tMetadata.set(Metadata.MESSAGE_TO, t.getConversation().getTitle());
                     } else {
                         tMetadata.set(Metadata.MESSAGE_TO, formatSkypeName(contactMap, t.getTo()));
                     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/telegram/TelegramParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/telegram/TelegramParser.java
@@ -266,10 +266,10 @@ public class TelegramParser extends SQLite3DBParser {
             meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, m.getFrom().toString());
             if (m.getChat().isGroupOrChannel()) {
                 ChatGroup groupChat = (ChatGroup) m.getChat();
-                for (Long id : groupChat.getMembers()) {
-                    if (id != m.getFrom().getId())
-                        meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, e.getContact(id).toString());
-                }
+                String to = groupChat.isGroup() ? "Group " : "Channel ";
+                to += groupChat.getName() + " (id:" + groupChat.getId() + ")";
+                meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, to);
+                meta.set(ExtraProperties.IS_GROUP_MESSAGE, "true");
             }
             if (meta.get(org.apache.tika.metadata.Message.MESSAGE_TO) == null) {
                 if (m.getToId() != 0) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/threema/ThreemaParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/threema/ThreemaParser.java
@@ -331,13 +331,14 @@ public class ThreemaParser extends SQLite3DBParser {
         return account;
     }
 
-    private void fillGroupRecipients(Metadata meta, Chat c, String from) {
-        for (ThreemaContact member : c.getParticipants()) {
-            String gmb = member.getFullId();
-            if (!gmb.equals(from)) {
-                meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, gmb);
-            }
+    private void fillGroupRecipients(Metadata meta, Chat c) {
+        String to = "Group";
+        if (c.getSubject() != null) {
+            to += " " + c.getSubject().strip();
         }
+        to += " (id:" + c.getId() + ")";
+        meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, to);
+        meta.set(ExtraProperties.IS_GROUP_MESSAGE, "true");
     }
 
     private void extractMessages(String chatName, Chat c, List<Message> messages, ThreemaAccount account, int parentVirtualId, ContentHandler handler, EmbeddedDocumentExtractor extractor) throws SAXException, IOException {
@@ -360,14 +361,14 @@ public class ThreemaParser extends SQLite3DBParser {
             if (m.isFromMe()) {
                 meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, local);
                 if (c.isGroupChat()) {
-                    fillGroupRecipients(meta, c, local);
+                    fillGroupRecipients(meta, c);
                 } else {
                     meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, remote);
                 }
             } else {
                 meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, remote);
                 if (c.isGroupChat()) {
-                    fillGroupRecipients(meta, c, remote);
+                    fillGroupRecipients(meta, c);
                 } else {
                     meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, local);
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
@@ -889,13 +889,14 @@ public class WhatsAppParser extends SQLite3DBParser {
         return result;
     }
 
-    private void fillGroupRecipients(Metadata meta, Chat c, String from, Map<String, String> cache) {
-        for (WAContact member : c.getGroupMembers()) {
-            String gmb = formatContact(member, cache);
-            if (!gmb.equals(from)) {
-                meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, gmb);
-            }
+    private void fillGroupRecipients(Metadata meta, Chat c) {
+        String to = c.isChannelChat() ? "Channel " : "Group ";
+        if (c.getSubject() != null) {
+            to += c.getSubject().strip();
         }
+        to += " (id:" + c.getId() + ")";
+        meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, to);
+        meta.set(ExtraProperties.IS_GROUP_MESSAGE, "true");
     }
 
     private void extractMessages(String chatName, Chat c, List<Message> messages, WAAccount account,
@@ -926,15 +927,15 @@ public class WhatsAppParser extends SQLite3DBParser {
                 }
                 if (m.isFromMe()) {
                     meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, local);
-                    if (c.isGroupChat()) {
-                        fillGroupRecipients(meta, c, local, cache);
+                    if (c.isGroupOrChannelChat()) {
+                        fillGroupRecipients(meta, c);
                     } else {
                         meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, remote);
                     }
                 } else {
                     meta.set(org.apache.tika.metadata.Message.MESSAGE_FROM, remote);
-                    if (c.isGroupChat()) {
-                        fillGroupRecipients(meta, c, remote, cache);
+                    if (c.isGroupOrChannelChat()) {
+                        fillGroupRecipients(meta, c);
                     } else {
                         meta.add(org.apache.tika.metadata.Message.MESSAGE_TO, local);
                     }

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/telegram/TelegramParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/telegram/TelegramParserTest.java
@@ -77,7 +77,7 @@ public class TelegramParserTest extends AbstractPkgTest {
 
             assertEquals("Telegram (phone: 42777)", telegramtracker.messageto.get(0));
             assertEquals("Nickerida (phone: 5561983125151)", telegramtracker.messageto.get(1));
-            assertEquals("Guilherme Andreúce (phone: 5561986143035)", telegramtracker.messageto.get(150));
+            assertEquals("Group mixirica e noronhe-se (id:-136232058)", telegramtracker.messageto.get(150));
 
             assertTrue(telegramtracker.messagebody.get(0).contains(
                     "Código de login: 73632. Não envie esse código para ninguém, nem mesmo que eles digam que são do Telegram!"));


### PR DESCRIPTION
Closes #2011. This can have a big impact in case disk size and processing time when groups with many members and messages are decoded from IM applications.

I would like someone else to review this, since it will change the output of some chat decoders (Telegram, WhatsApp, Threema, Discord, Skype, UFDR imported chats).

@hauck-jvsh could you take a look after you return from vacation?

@aberenguel, could you test this with the UFDR you mentioned on #2011?