### PR TITLE
Lnk metadata extraction

### DIFF
--- a/iped-engine/src/main/java/iped/engine/core/QueuesProcessingOrder.java
+++ b/iped-engine/src/main/java/iped/engine/core/QueuesProcessingOrder.java
@@ -17,6 +17,7 @@ import iped.parsers.browsers.chrome.CacheIndexParser;
 import iped.parsers.discord.DiscordParser;
 import iped.parsers.emule.KnownMetParser;
 import iped.parsers.emule.PartMetParser;
+import iped.parsers.lnk.LNKShortcutParser;
 import iped.parsers.mail.RFC822Parser;
 import iped.parsers.mail.win10.Win10MailParser;
 import iped.parsers.python.PythonParser;
@@ -62,6 +63,7 @@ public class QueuesProcessingOrder {
 
         // handle wal logs
         mediaTypes.put(SQLite3Parser.MEDIA_TYPE, 2);
+        mediaTypes.put(MediaType.parse(LNKShortcutParser.LNK_MIME_TYPE), 2);
 
         // must be after sqlite processing to find storage_db.db
         mediaTypes.put(SkypeParser.SKYPE_MIME, 3);

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/lnk/LNKParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/lnk/LNKParser.java
@@ -640,6 +640,7 @@ public class LNKParser {
                 long indMft = toInt6(b, posTmp);
                 int seqNum = toSmall(b, posTmp + 6);
                 if (indMft > 0) {
+                    fEntry.setIndMft(indMft);
                     fEntry.setNtfsRef(
                             "MFT Entry Idx " + String.valueOf(indMft) + " - Seq.Numb. " + String.valueOf(seqNum)); //$NON-NLS-1$ //$NON-NLS-2$
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/lnk/LNKShellItemFileEntry.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/lnk/LNKShellItemFileEntry.java
@@ -9,6 +9,7 @@ public class LNKShellItemFileEntry {
     private long fileSize, modifiedDate, createDate, accessDate;
     private int fileAttributeFlags, tipoShell;
     private String primaryName, secondaryName, guidShellFolder, ntfsRef, unknown;
+    private long indMft;
     private StringBuffer extensionSigs, localizedNames;
 
     public int getTipoShell() {
@@ -174,5 +175,13 @@ public class LNKShellItemFileEntry {
         calendar.set(year, month, day, hours, minutes, seconds);
 
         return df.format(calendar.getTime());
+    }
+
+    public long getIndMft() {
+        return indMft;
+    }
+
+    public void setIndMft(long indMft) {
+        this.indMft = indMft;
     }
 }


### PR DESCRIPTION
Extracts some info from LNK to save as metadata. They are useful to order and groups LNK files.

Also, some info is used to make the reference to the original file, if found. The suggested code uses the following rule:
1) Use mft idx info to search in metaAddress metadata. If found, compares creationDate info between link file entry and found item to confirm the match.
2) If first search fails, use the path info to find a potential match and confirm also with creationDate info.

It is not implemented (yet) but maybe some timestamp info can be extracted if considered relevant. I am not sure if the timestamps in LNK files are correspondent to the item when it was last opened using the LNK or when the LNK was created the first time.