### PR TITLE
Properly invalidates internal unions cache after bookmark

### DIFF
--- a/iped-engine/src/main/java/iped/engine/data/BitmapBookmarks.java
+++ b/iped-engine/src/main/java/iped/engine/data/BitmapBookmarks.java
@@ -185,6 +185,7 @@ public class BitmapBookmarks implements IBookmarks {
         RoaringBitmap bookmarkBitmap = bookmarks.get(bookmark);
         for (Integer id : ids) {
             bookmarkBitmap.add(id);
+            //updates cache
             if (unionAll != null) {
                 unionAll.add(id);
             }
@@ -265,6 +266,8 @@ public class BitmapBookmarks implements IBookmarks {
             bookmarkColors = new TreeMap<Integer, Color>();
         bookmarkColors.put(bookmarkId, null);
 
+        unionAll = null;// invalidates unionAll
+        
         return bookmarkId;
     }
 
@@ -279,6 +282,7 @@ public class BitmapBookmarks implements IBookmarks {
         bookmarkColors.remove(bookmark);
         reportBookmarks.remove(bookmark);
         bookmarks.remove(bookmark);
+        unionAll = null;// invalidates unionAll
     }
 
     public synchronized void renameBookmark(int bookmarkId, String newBookmark) {

--- a/iped-engine/src/main/java/iped/engine/data/MultiBitmapBookmarks.java
+++ b/iped-engine/src/main/java/iped/engine/data/MultiBitmapBookmarks.java
@@ -185,6 +185,7 @@ public class MultiBitmapBookmarks implements Serializable, IMultiBookmarks {
     public void newBookmark(String bookmarkName) {
         for (IBookmarks m : map.values())
             m.newBookmark(bookmarkName);
+        invalidadeCaches();
     }
 
     public void delBookmark(String bookmarkName) {
@@ -192,6 +193,7 @@ public class MultiBitmapBookmarks implements Serializable, IMultiBookmarks {
             int bookmarkId = m.getBookmarkId(bookmarkName);
             m.delBookmark(bookmarkId);
         }
+        invalidadeCaches();
     }
 
     public void renameBookmark(String oldBookmark, String newBookmark) {


### PR DESCRIPTION
Properly invalidates internal unions cache after bookmark deletion and creation.

Closes #2311.