### PR TITLE
Review WhatsApp Message compareTo() to avoid "Comparison method violates its general contract" exceptions.

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -637,7 +637,7 @@ public class Message implements Comparable<Message> {
     }
 
     public long getSortId() {
-        return sortId == 0 ? id : sortId;
+        return sortId == 0 ? timeStamp == null ? 0 : timeStamp.getTime() : sortId;
     }
 
     public void setSortId(long sortId) {
@@ -690,14 +690,6 @@ public class Message implements Comparable<Message> {
 
     @Override
     public int compareTo(Message o) {
-        int comp = Long.compare(getSortId(), o.getSortId());
-        if (comp != 0) {
-            return comp;
-        }
-        return Long.compare(getTime(), o.getTime());
-    }
-
-    private long getTime() {
-        return timeStamp == null ? 0 : timeStamp.getTime();
+        return Long.compare(getSortId(), o.getSortId());
     }
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -637,7 +637,7 @@ public class Message implements Comparable<Message> {
     }
 
     public long getSortId() {
-        return sortId == 0 ? timeStamp == null ? 0 : timeStamp.getTime() : sortId;
+        return sortId == 0 ? timeStamp == null ? 0 : timeStamp.getTime() : id;
     }
 
     public void setSortId(long sortId) {

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -637,7 +637,7 @@ public class Message implements Comparable<Message> {
     }
 
     public long getSortId() {
-        return sortId;
+        return sortId == 0 ? id : sortId;
     }
 
     public void setSortId(long sortId) {
@@ -690,18 +690,14 @@ public class Message implements Comparable<Message> {
 
     @Override
     public int compareTo(Message o) {
-        if (getSortId() != 0 && o.getSortId() != 0) {
-            int comp = Long.compare(getSortId(), o.getSortId());
-            if (comp != 0) {
-                return comp;
-            }
+        int comp = Long.compare(getSortId(), o.getSortId());
+        if (comp != 0) {
+            return comp;
         }
-        if (getTimeStamp() != null && o.getTimeStamp() != null) {
-            int comp = getTimeStamp().compareTo(o.getTimeStamp());
-            if (comp != 0) {
-                return comp;
-            }
-        }
-        return Long.compare(getId(), o.getId());
+        return Long.compare(getTime(), o.getTime());
+    }
+
+    private long getTime() {
+        return timeStamp == null ? 0 : timeStamp.getTime();
     }
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -637,7 +637,7 @@ public class Message implements Comparable<Message> {
     }
 
     public long getSortId() {
-        return sortId == 0 ? timeStamp == null ? 0 : timeStamp.getTime() : id;
+        return sortId != 0 ? sortId : timeStamp != null ? timeStamp.getTime() : id;
     }
 
     public void setSortId(long sortId) {


### PR DESCRIPTION
Fix #2337.