### PR TITLE
Do not calculate image similarity features again, if already present (#2346)

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/similarity/ImageSimilarityTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/similarity/ImageSimilarityTask.java
@@ -95,6 +95,11 @@ public class ImageSimilarityTask extends AbstractTask {
             return;
         }
 
+        Object prev = evidence.getExtraAttribute(IMAGE_FEATURES);
+        if (prev != null && prev instanceof byte[]) {
+            return;
+        }
+
         try {
             byte[] thumb = evidence.getThumb();
             if (thumb == null) {


### PR DESCRIPTION
Closes #2346.