### PR TITLE
#2344 gallery enhancement

### DIFF
--- a/iped-app/src/main/java/iped/app/ui/GalleryCellEditor.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellEditor.java
@@ -42,15 +42,14 @@ public class GalleryCellEditor extends AbstractCellEditor implements TableCellEd
 
     private static final long serialVersionUID = 1L;
 
-    int row, col;
-    JPanel top = new JPanel(), panel = new JPanel();
-    // JLayeredPane panel = new JLayeredPane();
-    JLabel label = new JLabel(), cLabel = new JLabel();
-    JCheckBox check = new JCheckBox();
-    Border selBorder;
-    Color selColor;
-    Color background;
-    Color warningColor;
+    private int row, col;
+    private final JPanel top = new JPanel(), panel = new JPanel();
+    private final GalleryIcon label = new GalleryIcon();
+    private final JLabel cLabel = new JLabel();
+    private final JCheckBox check = new JCheckBox();
+    private Border selBorder;
+    private Color selColor;
+    private Color background;
 
     public GalleryCellEditor() {
         super();
@@ -80,10 +79,6 @@ public class GalleryCellEditor extends AbstractCellEditor implements TableCellEd
         if (selBorderColor == null)
             selBorderColor = new Color(20, 50, 80);
         selBorder = BorderFactory.createLineBorder(selBorderColor, 1);
-
-        warningColor = UIManager.getColor("Gallery.warning");
-        if (warningColor == null)
-            warningColor = Color.red;
     }
 
     @Override
@@ -110,7 +105,7 @@ public class GalleryCellEditor extends AbstractCellEditor implements TableCellEd
         cLabel.setToolTipText(itemBookmarksStr.isEmpty() ? null : itemBookmarksStr);
         cLabel.setIcon(BookmarkIcon.getIcon(bookmarks, itemBookmarksStr));
 
-        GalleryCellRenderer.adjustGalleryCellContent(cellValue, label, warningColor, table);
+        label.setValue(cellValue);
 
         panel.setBackground(selColor);
         top.setBackground(selColor);
@@ -132,5 +127,4 @@ public class GalleryCellEditor extends AbstractCellEditor implements TableCellEd
         this.stopCellEditing();
 
     }
-
 }

--- a/iped-app/src/main/java/iped/app/ui/GalleryCellEditor.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellEditor.java
@@ -44,7 +44,7 @@ public class GalleryCellEditor extends AbstractCellEditor implements TableCellEd
 
     private int row, col;
     private final JPanel top = new JPanel(), panel = new JPanel();
-    private final GalleryIcon label = new GalleryIcon();
+    private final GalleryThumbLabel label = new GalleryThumbLabel();
     private final JLabel cLabel = new JLabel();
     private final JCheckBox check = new JCheckBox();
     private Border selBorder;

--- a/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
@@ -130,9 +130,6 @@ class GalleryIcon extends JLabel {
 
     // Limit how much images can be enlarged (usually thumbs are down sized, but
     // small images may be enlarged).
-    // Thumbnail's dimensions are used instead of the original ones, to speed up
-    // (avoid querying original dimension), to reduce stored information (in gallery
-    // objects) and to simplify the code.
     private static final double maxEnlargeFactor = 2;
 
     private static final String unsupportedIconText = "<html><center>"

--- a/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
@@ -21,6 +21,12 @@ package iped.app.ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.RenderingHints.Key;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
@@ -34,28 +40,18 @@ import javax.swing.table.TableCellRenderer;
 import iped.app.ui.bookmarks.BookmarkIcon;
 import iped.data.IMultiBookmarks;
 import iped.engine.util.Util;
-import iped.utils.QualityIcon;
 
 public class GalleryCellRenderer implements TableCellRenderer {
 
-    JPanel top = new JPanel(), panel = new JPanel();
-    JLabel label = new JLabel(), cLabel = new JLabel();
-    JCheckBox check = new JCheckBox();
-    Border selBorder;
-    Border border;
-    Color selColor;
-    Color color;
-    Color background;
-    Color warningColor;
-    private static int labelH;
-    static final String unsupportedIconText = "<html><center>" + Messages.getString("UnsupportedIcon.Unavailable") + "</center></html>";
-
-    // Limit how much images can be enlarged (usually thumbs are down sized, but
-    // small images may be enlarged).
-    // Thumbnail's dimensions are used instead of the original ones, to speed up
-    // (avoid querying original dimension), to reduce stored information (in gallery
-    // objects) and to simplify the code.
-    private static final double maxEnlargeFactor = 2;
+    private final JPanel top = new JPanel(), panel = new JPanel();
+    private final GalleryIcon label = new GalleryIcon();
+    private final JLabel cLabel = new JLabel();
+    private final JCheckBox check = new JCheckBox();
+    private Border selBorder;
+    private Border border;
+    private Color selColor;
+    private Color color;
+    private Color background;
 
     public GalleryCellRenderer() {
         super();
@@ -92,14 +88,11 @@ public class GalleryCellRenderer implements TableCellRenderer {
         if (selBorderColor == null)
             selBorderColor = new Color(20, 50, 80);
         selBorder = BorderFactory.createLineBorder(selBorderColor, 1);
-
-        warningColor = UIManager.getColor("Gallery.warning");
-        if (warningColor == null)
-            warningColor = Color.red;
     }
 
     @Override
-    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int col) {
+    public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+            int row, int col) {
 
         GalleryValue cellValue = (GalleryValue) value;
         if (cellValue == null || cellValue.id == null) {
@@ -115,8 +108,7 @@ public class GalleryCellRenderer implements TableCellRenderer {
         cLabel.setToolTipText(itemBookmarksStr.isEmpty() ? null : itemBookmarksStr);
         cLabel.setIcon(BookmarkIcon.getIcon(bookmarks, itemBookmarksStr));
 
-        labelH = label.getHeight();
-        adjustGalleryCellContent(cellValue, label, warningColor, table);
+        label.setValue(cellValue);
 
         Color c = null;
         if (isSelected) {
@@ -131,43 +123,92 @@ public class GalleryCellRenderer implements TableCellRenderer {
 
         return panel;
     }
+}
 
-    public static void adjustGalleryCellContent(GalleryValue cellValue, JLabel label, Color warningColor, JTable table) {
-        if (cellValue.icon == null && cellValue.image == null) {
-            label.setForeground(null);
-            label.setText("..."); //$NON-NLS-1$
-            label.setIcon(null);
-        } else if (cellValue.icon != null && cellValue.unsupportedType) {
-            label.setForeground(warningColor);
-            label.setText(unsupportedIconText);
-            label.setIcon(cellValue.icon);
+class GalleryIcon extends JLabel {
+    private static final long serialVersionUID = 1L;
+
+    // Limit how much images can be enlarged (usually thumbs are down sized, but
+    // small images may be enlarged).
+    // Thumbnail's dimensions are used instead of the original ones, to speed up
+    // (avoid querying original dimension), to reduce stored information (in gallery
+    // objects) and to simplify the code.
+    private static final double maxEnlargeFactor = 2;
+
+    private static final String unsupportedIconText = "<html><center>"
+            + Messages.getString("UnsupportedIcon.Unavailable") + "</center></html>";
+
+    private Color warningColor;
+
+    private GalleryValue value;
+
+    private static final RenderingHints renderingHints;
+    static {
+        Map<Key, Object> hints = new HashMap<Key, Object>();
+        hints.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+        renderingHints = new RenderingHints(hints);
+    }
+
+    public void updateUI() {
+        warningColor = UIManager.getColor("Gallery.warning");
+        if (warningColor == null)
+            warningColor = Color.red;
+    }
+
+    public void setValue(GalleryValue value) {
+        this.value = value;
+        if (value.icon == null && value.image == null) {
+            setForeground(null);
+            setText("...");
+            setIcon(null);
+        } else if (value.icon != null && value.unsupportedType) {
+            setForeground(warningColor);
+            setText(unsupportedIconText);
+            setIcon(value.icon);
         } else {
-            label.setText(null);
-            if (cellValue.image != null) {
-                int labelW = table.getWidth() / table.getColumnCount() - 2;
-                int w = cellValue.image.getWidth();
-                int h = cellValue.image.getHeight();
-                if (w * labelH < labelW * h) {
-                    if (h * maxEnlargeFactor < labelH) {
-                        h *= maxEnlargeFactor;
-                        w *= maxEnlargeFactor;
-                    } else {
-                        w = w * labelH / h;
-                        h = labelH;
-                    }
-                } else {
-                    if (w * maxEnlargeFactor < labelW) {
-                        h *= maxEnlargeFactor;
-                        w *= maxEnlargeFactor;
-                    } else {
-                        h = h * labelW / w;
-                        w = labelW;
-                    }
-                }
-                label.setIcon(new QualityIcon(cellValue.image, w, h));
+            setText(null);
+            if (value.image != null) {
+                setIcon(null);
             } else {
-                label.setIcon(cellValue.icon);
+                setIcon(value.icon);
             }
+        }
+        repaint();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        if (value != null && value.image != null) {
+            int labelW = getWidth();
+            int labelH = getHeight();
+            int w = value.image.getWidth();
+            int h = value.image.getHeight();
+            if (w * labelH < labelW * h) {
+                if (h * maxEnlargeFactor < labelH) {
+                    h *= maxEnlargeFactor;
+                    w *= maxEnlargeFactor;
+                } else {
+                    w = w * labelH / h;
+                    h = labelH;
+                }
+            } else {
+                if (w * maxEnlargeFactor < labelW) {
+                    h *= maxEnlargeFactor;
+                    w *= maxEnlargeFactor;
+                } else {
+                    h = h * labelW / w;
+                    w = labelW;
+                }
+            }
+            Graphics2D g2 = (Graphics2D) g;
+            RenderingHints oldHints = g2.getRenderingHints();
+            g2.setRenderingHints(renderingHints);
+            g2.drawImage(value.image, (labelW - w) / 2, (labelH - h) / 2, w, h, null);
+            g2.setRenderingHints(oldHints);
+        } else {
+            super.paintComponent(g);
         }
     }
 }

--- a/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
@@ -44,7 +44,7 @@ import iped.engine.util.Util;
 public class GalleryCellRenderer implements TableCellRenderer {
 
     private final JPanel top = new JPanel(), panel = new JPanel();
-    private final GalleryIcon label = new GalleryIcon();
+    private final GalleryThumbLabel label = new GalleryThumbLabel();
     private final JLabel cLabel = new JLabel();
     private final JCheckBox check = new JCheckBox();
     private Border selBorder;
@@ -125,7 +125,7 @@ public class GalleryCellRenderer implements TableCellRenderer {
     }
 }
 
-class GalleryIcon extends JLabel {
+class GalleryThumbLabel extends JLabel {
     private static final long serialVersionUID = 1L;
 
     // Limit how much images can be enlarged (usually thumbs are down sized, but

--- a/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryCellRenderer.java
@@ -149,6 +149,7 @@ class GalleryThumbLabel extends JLabel {
     }
 
     public void updateUI() {
+        super.updateUI();
         warningColor = UIManager.getColor("Gallery.warning");
         if (warningColor == null)
             warningColor = Color.red;

--- a/iped-app/src/main/java/iped/app/ui/GalleryModel.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryModel.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -76,8 +75,15 @@ public class GalleryModel extends AbstractTableModel {
     private boolean logRendering = false;
     private ImageThumbTask imgThumbTask;
 
-    public final Map<IItemId, GalleryValue> cache = new LinkedHashMap<IItemId, GalleryValue>();
-    private int maxCacheSize = 1000;
+    private static final int maxCacheSize = 1000;
+    public final Map<IItemId, GalleryValue> cache = new LinkedHashMap<IItemId, GalleryValue>() {
+        private static final long serialVersionUID = 1L;
+
+        protected boolean removeEldestEntry(Map.Entry<IItemId,GalleryValue> eldest) {
+            return size() > maxCacheSize;
+        }
+    };
+
     private ErrorIcon errorIcon = new ErrorIcon();
     private static final BufferedImage errorImg = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_BINARY);
     public static final ImageIcon unsupportedIcon = new ImageIcon();
@@ -304,15 +310,6 @@ public class GalleryModel extends AbstractTableModel {
                         App.get().galleryModel.fireTableCellUpdated(row, col);
                     }
                 });
-
-                synchronized (cache) {
-                    Iterator<IItemId> i = cache.keySet().iterator();
-                    while (cache.size() > maxCacheSize) {
-                        i.next();
-                        i.remove();
-                    }
-
-                }
             }
         });
 

--- a/iped-app/src/main/java/iped/app/ui/GalleryModel.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryModel.java
@@ -175,8 +175,9 @@ public class GalleryModel extends AbstractTableModel {
         final IItemId id = App.get().ipedResult.getItem(idx);
 
         synchronized (cache) {
-            if (cache.containsKey(id)) {
-                return cache.get(id);
+            GalleryValue value = cache.get(id);
+            if (value != null) {
+                return value;
             }
         }
 

--- a/iped-app/src/main/java/iped/app/ui/GalleryModel.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryModel.java
@@ -84,6 +84,8 @@ public class GalleryModel extends AbstractTableModel {
         }
     };
 
+    private static final GalleryValue emptyValue = new GalleryValue("", null, null);
+
     private ErrorIcon errorIcon = new ErrorIcon();
     private static final BufferedImage errorImg = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_BINARY);
     public static final ImageIcon unsupportedIcon = new ImageIcon();
@@ -168,7 +170,7 @@ public class GalleryModel extends AbstractTableModel {
 
         int idx = row * colCount + col;
         if (idx >= App.get().ipedResult.getLength()) {
-            return new GalleryValue("", null, null); //$NON-NLS-1$
+            return emptyValue;
         }
 
         idx = App.get().resultsTable.convertRowIndexToModel(idx);

--- a/iped-app/src/main/java/iped/app/ui/GalleryModel.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryModel.java
@@ -228,44 +228,48 @@ public class GalleryModel extends AbstractTableModel {
                         }
                     }
 
-                    String hash = doc.get(IndexItem.HASH);
-                    if (image == null && hash != null && !hash.isEmpty()) {
-                        image = getViewImage(docId, hash, isSupportedVideo(mediaType) || isAnimationImage(doc, mediaType));
-                    }
+                    if (image == null) {
+                        String hash = doc.get(IndexItem.HASH);
+                        if (image == null && hash != null && !hash.isEmpty()) {
+                            image = getViewImage(docId, hash,
+                                    isSupportedVideo(mediaType) || isAnimationImage(doc, mediaType));
+                        }
 
-                    if (Boolean.valueOf(doc.get(IndexItem.ISDIR))) {
-                        value.unsupportedType = true;
-                        value.icon = IconManager.getFolderIconGallery();
+                        if (Boolean.valueOf(doc.get(IndexItem.ISDIR))) {
+                            value.unsupportedType = true;
+                            value.icon = IconManager.getFolderIconGallery();
 
-                    } else if (image == null && !isSupportedImage(mediaType) && !isSupportedVideo(mediaType)) {
-                        value.unsupportedType = true;
-                        String type = doc.get(IndexItem.TYPE);
-                        String contentType = doc.get(IndexItem.CONTENTTYPE);
-                        value.icon = IconManager.getFileIconGallery(contentType, type);
-                    }
+                        } else if (image == null && !isSupportedImage(mediaType) && !isSupportedVideo(mediaType)) {
+                            value.unsupportedType = true;
+                            String type = doc.get(IndexItem.TYPE);
+                            String contentType = doc.get(IndexItem.CONTENTTYPE);
+                            value.icon = IconManager.getFileIconGallery(contentType, type);
+                        }
 
-                    if (image == null && value.icon == null && stream == null && isSupportedImage(mediaType)) {
-                        stream = App.get().appCase.getItemByLuceneID(docId).getBufferedInputStream();
-                    }
+                        if (image == null && value.icon == null && stream == null && isSupportedImage(mediaType)) {
+                            stream = App.get().appCase.getItemByLuceneID(docId).getBufferedInputStream();
+                        }
 
-                    if (stream != null) {
-                        stream.mark(10000000);
-                    }
+                        if (stream != null) {
+                            stream.mark(10000000);
+                        }
 
-                    if (image == null && stream != null && imgThumbTask.getImageThumbConfig().isExtractThumb() && mediaType.equals("image/jpeg")) { //$NON-NLS-1$
-                        image = ImageMetadataUtil.getThumb(CloseShieldInputStream.wrap(stream));
-                        stream.reset();
-                    }
+                        if (image == null && stream != null && imgThumbTask.getImageThumbConfig().isExtractThumb()
+                                && mediaType.equals("image/jpeg")) { //$NON-NLS-1$
+                            image = ImageMetadataUtil.getThumb(CloseShieldInputStream.wrap(stream));
+                            stream.reset();
+                        }
 
-                    if (image == null && stream != null) {
-                        image = ImageUtil.getSubSampledImage(stream, thumbSize);
-                        stream.reset();
-                    }
+                        if (image == null && stream != null) {
+                            image = ImageUtil.getSubSampledImage(stream, thumbSize);
+                            stream.reset();
+                        }
 
-                    if (image == null && stream != null) {
-                        String sizeStr = doc.get(IndexItem.LENGTH);
-                        Long size = sizeStr == null ? null : Long.parseLong(sizeStr);
-                        image = externalImageConverter.getImage(stream, thumbSize, false, size);
+                        if (image == null && stream != null) {
+                            String sizeStr = doc.get(IndexItem.LENGTH);
+                            Long size = sizeStr == null ? null : Long.parseLong(sizeStr);
+                            image = externalImageConverter.getImage(stream, thumbSize, false, size);
+                        }
                     }
 
                     if (image == null || image == errorImg) {

--- a/iped-app/src/main/java/iped/app/ui/GalleryModel.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryModel.java
@@ -76,7 +76,7 @@ public class GalleryModel extends AbstractTableModel {
     private boolean logRendering = false;
     private ImageThumbTask imgThumbTask;
 
-    public Map<IItemId, GalleryValue> cache = Collections.synchronizedMap(new LinkedHashMap<IItemId, GalleryValue>());
+    public final Map<IItemId, GalleryValue> cache = new LinkedHashMap<IItemId, GalleryValue>();
     private int maxCacheSize = 1000;
     private ErrorIcon errorIcon = new ErrorIcon();
     private static final BufferedImage errorImg = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_BINARY);
@@ -97,12 +97,16 @@ public class GalleryModel extends AbstractTableModel {
 
     public void setBlurFilter(boolean newBlurFilter) {
         blurFilter = newBlurFilter;
-        cache.clear();
+        synchronized (cache) {
+            cache.clear();
+        }
     }
 
     public void setGrayFilter(boolean newGrayFilter) {
         grayFilter = newGrayFilter;
-        cache.clear();
+        synchronized (cache) {
+            cache.clear();
+        }
     }
 
     @Override
@@ -184,8 +188,10 @@ public class GalleryModel extends AbstractTableModel {
                 Document doc = null;
                 GalleryValue value = new GalleryValue("", null, id);
                 try {
-                    if (cache.containsKey(id)) {
-                        return;
+                    synchronized (cache) {
+                        if (cache.containsKey(id)) {
+                            return;
+                        }
                     }
 
                     if (!App.get().gallery.getVisibleRect().intersects(App.get().gallery.getCellRect(row, col, false))) {
@@ -288,7 +294,9 @@ public class GalleryModel extends AbstractTableModel {
                     value.image = image;
                 }
 
-                cache.put(id, value);
+                synchronized (cache) {
+                    cache.put(id, value);
+                }
 
                 SwingUtilities.invokeLater(new Runnable() {
                     @Override

--- a/iped-app/src/main/java/iped/app/ui/GalleryTable.java
+++ b/iped-app/src/main/java/iped/app/ui/GalleryTable.java
@@ -11,7 +11,6 @@ import javax.swing.InputMap;
 import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.UIManager;
-import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableModel;
 
 public class GalleryTable extends JTable {
@@ -38,17 +37,6 @@ public class GalleryTable extends JTable {
     public void updateUI() {
         setBackground(UIManager.getColor("Gallery.background"));
         super.updateUI();
-    }
-
-    @Override
-    public void repaint() {
-        // When repainting the gallery table, sometimes the current selected cell was
-        // not repainted. Stopping the cell editing seems to minimize (fix?) this issue.
-        TableCellEditor editor = getCellEditor();
-        if (editor != null) {
-            editor.stopCellEditing();
-        }
-        super.repaint();
     }
 
     @Override


### PR DESCRIPTION
Closes #2344.

IndexReader/IndexSearcher.doc(id) calls are heavy, moving them from AWT thread to thread pool makes gallery cell rendering parallel and non AWT blocking on spinning disks.

@wladimirleite if you could confirm it improved rendering on spinning disk, I would appreciate very much. I also copied your improvements on other classes.