### PR TITLE
Implementation of ThumbcacheParser for Metadata and Thumbnail Extraction

### DIFF
--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -306,7 +306,7 @@
                 <param name="extractMessages" type="bool">true</param>
                 <param name="mergeBackups" type="bool">true</param>
                 <param name="linkMediasByNameAndApproxSizeFallback" type="bool">true</param>
-                <!--Set as 0 to disable long path matching fallback-->                
+                <!--Set as 0 to disable long path matching fallback-->
                 <param name="linkMediasByLongPathFallback" type="int">40</param>
                 <param name="downloadConnectionTimeout" type="int">500</param>
                 <param name="downloadReadTimeout" type="int">1000</param>
@@ -377,6 +377,7 @@
         <parser class="iped.parsers.discord.DiscordParser"></parser>
         <parser class="iped.parsers.apk.APKParser"></parser>
         <parser class="iped.parsers.vlc.VLCIniParser"></parser>
+        <parser class="iped.parsers.misc.ThumbcacheParser"></parser>
 
     </parsers>
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -6,8 +6,6 @@ import org.apache.poi.poifs.filesystem.DocumentInputStream;
 import org.apache.poi.poifs.filesystem.Entry;
 import org.apache.poi.poifs.filesystem.DocumentNode;
 import org.apache.tika.exception.TikaException;
-import org.apache.tika.extractor.EmbeddedDocumentExtractor;
-import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -21,6 +19,8 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Set;
 
 public class ThumbcacheParser extends AbstractParser {
@@ -34,8 +34,7 @@ public class ThumbcacheParser extends AbstractParser {
 
     @Override
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException, TikaException {
-        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,
-            new ParsingEmbeddedDocumentExtractor(context));
+
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
 
@@ -46,28 +45,53 @@ public class ThumbcacheParser extends AbstractParser {
 
         // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image.
         // TODO: Implement recurseDir method
-        recurseDir(poiFS.getRoot(), extractor, xhtml);
+        recurseDir(poiFS.getRoot(), xhtml);
 
         xhtml.endDocument();
         tmp.close();
     }
 
-    private void recurseDir(DirectoryNode dir, EmbeddedDocumentExtractor extractor, XHTMLContentHandler xhtml) throws IOException, SAXException, TikaException {
+    private void recurseDir(DirectoryNode dir, XHTMLContentHandler xhtml) throws SAXException {
         for (Entry entry : dir) {
             if (entry instanceof DirectoryNode) {
-                recurseDir((DirectoryNode) entry, extractor, xhtml);
+                recurseDir((DirectoryNode) entry, xhtml);
             } else {
-                Metadata entrydata = new Metadata();
-                entrydata.set(Metadata.CONTENT_TYPE, "thumbcache-entry");
+                try (DocumentInputStream docStream = new DocumentInputStream((DocumentNode) entry)) {
+                    byte[] buffer = new byte[80];
+                    int bytesRead = docStream.read(buffer);
+                    if (bytesRead != buffer.length) {
+                        continue;
+                    }
 
-                xhtml.startElement("div", "class", "thumbcache-entry");
-                xhtml.element("h1", entry.getName());
-                xhtml.startElement("div", "class", "thumbcache-entry-content");
-                try (InputStream stream = new DocumentInputStream((DocumentNode) entry)) {
-                    extractor.parseEmbedded(stream, xhtml, entrydata, true);
+                    ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
+
+                    int size = bb.getInt();
+                    long entryHash = bb.getLong();
+                    int identifierStringSize = bb.getInt();
+                    int paddingSize = bb.getInt();
+                    int dataSize = bb.getInt();
+                    int unknown1 = bb.getInt();
+                    long dataChecksum = bb.getInt() & 0xFFFFFFFFL;
+                    long headerChecksum = bb.getLong();
+
+                    xhtml.startElement("pre");
+
+                    xhtml.characters("size                           : " + size + "\n");
+                    xhtml.characters("entry hash                     : 0x" + Long.toHexString(entryHash) + "\n");
+                    xhtml.characters("identifier string size         : " + identifierStringSize + "\n");
+                    xhtml.characters("padding size                   : " + paddingSize + "\n");
+                    xhtml.characters("data size                      : " + dataSize + "\n");
+                    xhtml.characters("unknown1                       : 0x" + Integer.toHexString(unknown1) + "\n");
+                    xhtml.characters("data checksum                  : 0x" + Long.toHexString(dataChecksum) + "\n");
+                    xhtml.characters("header checksum                : 0x" + Long.toHexString(headerChecksum) + "\n");
+
+                    xhtml.characters("\nidentifier string              : " + Long.toHexString(entryHash) + "\n");
+
+                    xhtml.endElement("pre");
+
+                } catch (IOException e) {
+                    xhtml.characters("Error processing entry: " + entry.getName() + "\n");
                 }
-                xhtml.endElement("div");
-                xhtml.endElement("div");
             }
         }
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -58,10 +58,7 @@ public class ThumbcacheParser extends AbstractParser {
                 recurseDir((DirectoryNode) entry, extractor, xhtml);
             } else {
                 Metadata entrydata = new Metadata();
-                entrydata.set(Metadata.SAMPLES_PER_PIXEL, "3"); // SAMPLES PER PIXEL é um metadado que indica a quantidade de canais de cor da imagem.
-                entrydata.set(Metadata.IMAGE_WIDTH, "100"); // IMAGE WIDTH é um metadado que indica a largura da imagem.
-                entrydata.set(Metadata.IMAGE_LENGTH, "100"); // IMAGE LENGTH é um metadado que indica a altura da imagem.
-                entrydata.set(Metadata.CONTENT_TYPE, "image/jpeg"); // CONTENT TYPE é um metadado que indica o tipo de conteúdo do arquivo.
+                entrydata.set(Metadata.CONTENT_TYPE, "thumbcache-entry");
 
                 xhtml.startElement("div", "class", "thumbcache-entry");
                 xhtml.element("h1", entry.getName());

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -1,6 +1,10 @@
 package iped.parsers.misc;
 
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.poifs.filesystem.DirectoryNode;
+import org.apache.poi.poifs.filesystem.DocumentInputStream;
+import org.apache.poi.poifs.filesystem.Entry;
+import org.apache.poi.poifs.filesystem.DocumentNode;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
@@ -42,9 +46,32 @@ public class ThumbcacheParser extends AbstractParser {
 
         // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image.
         // TODO: Implement recurseDir method
-        // recurseDir(poiFS.getRoot(), extractor, xhtml);
+        recurseDir(poiFS.getRoot(), extractor, xhtml);
 
         xhtml.endDocument();
         tmp.close();
+    }
+
+    private void recurseDir(DirectoryNode dir, EmbeddedDocumentExtractor extractor, XHTMLContentHandler xhtml) throws IOException, SAXException, TikaException {
+        for (Entry entry : dir) {
+            if (entry instanceof DirectoryNode) {
+                recurseDir((DirectoryNode) entry, extractor, xhtml);
+            } else {
+                Metadata entrydata = new Metadata();
+                entrydata.set(Metadata.SAMPLES_PER_PIXEL, "3"); // SAMPLES PER PIXEL é um metadado que indica a quantidade de canais de cor da imagem.
+                entrydata.set(Metadata.IMAGE_WIDTH, "100"); // IMAGE WIDTH é um metadado que indica a largura da imagem.
+                entrydata.set(Metadata.IMAGE_LENGTH, "100"); // IMAGE LENGTH é um metadado que indica a altura da imagem.
+                entrydata.set(Metadata.CONTENT_TYPE, "image/jpeg"); // CONTENT TYPE é um metadado que indica o tipo de conteúdo do arquivo.
+
+                xhtml.startElement("div", "class", "thumbcache-entry");
+                xhtml.element("h1", entry.getName());
+                xhtml.startElement("div", "class", "thumbcache-entry-content");
+                try (InputStream stream = new DocumentInputStream((DocumentNode) entry)) {
+                    extractor.parseEmbedded(stream, xhtml, entrydata, true);
+                }
+                xhtml.endElement("div");
+                xhtml.endElement("div");
+            }
+        }
     }
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -40,6 +40,8 @@ public class ThumbcacheParser extends AbstractParser {
         File file = tis.getFile();
         POIFSFileSystem poiFS = new POIFSFileSystem(file);
 
+        // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image
+        // TODO: Implement recurseDir method
         // recurseDir(poiFS.getRoot(), extractor, xhtml);
 
         xhtml.endDocument();

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -2,10 +2,12 @@ package iped.parsers.misc;
 
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
 import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -24,7 +26,10 @@ public class ThumbcacheParser extends AbstractParser {
 
     @Override
     public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException, TikaException {
-        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class);
+        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,
+            new ParsingEmbeddedDocumentExtractor(context));
+        XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
+        xhtml.startDocument();
     }
 
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -1,4 +1,30 @@
 package iped.parsers.misc;
 
-public class ThumbcacheParser {
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.AbstractParser;
+import org.apache.tika.parser.ParseContext;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+public class ThumbcacheParser extends AbstractParser {
+
+    public static final long serialVersionUID = 1L;
+
+    @Override
+    public Set<MediaType> getSupportedTypes(ParseContext context) {
+        return MediaType.set("application/x-thumbcache");
+    }
+
+    @Override
+    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException, TikaException {
+        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class);
+    }
+
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -1,0 +1,4 @@
+package iped.parsers.misc;
+
+public class ThumbcacheParser {
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public class ThumbcacheParser extends AbstractParser {
 
-    public static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     @Override
     public Set<MediaType> getSupportedTypes(ParseContext context) {
@@ -40,12 +40,11 @@ public class ThumbcacheParser extends AbstractParser {
         File file = tis.getFile();
         POIFSFileSystem poiFS = new POIFSFileSystem(file);
 
-        // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image
+        // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image.
         // TODO: Implement recurseDir method
         // recurseDir(poiFS.getRoot(), extractor, xhtml);
 
         xhtml.endDocument();
         tmp.close();
     }
-
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -48,32 +48,93 @@ public class ThumbcacheParser extends AbstractParser {
     }
 
     private void parseThumbcacheFile(InputStream stream, XHTMLContentHandler xhtml) throws IOException, SAXException {
-        byte[] buffer = new byte[80]; // Buffer para a leitura de cada entrada
+        byte[] buffer = new byte[56];
 
+        ByteBuffer fileHeader = ByteBuffer.allocate(24).order(ByteOrder.LITTLE_ENDIAN);
+        stream.read(fileHeader.array());
+
+        String signature = new String(fileHeader.array(), 0, 4);
+        if (!"CMMM".equals(signature)) {
+            xhtml.characters("Error processing cache file: Invalid header signature; expected 'CMMM'.\n");
+            return;
+        }
+
+        int formatVersion = fileHeader.getInt(4); //
+        int cacheType = fileHeader.getInt(8); //
+        int firstCacheEntryOffset = fileHeader.getInt(12);
+        int firstAvailableCacheEntryOffset = fileHeader.getInt(16);
+        int numberOfCacheEntries = fileHeader.getInt(20);
+
+        xhtml.startElement("pre");
+        xhtml.characters("Cache file format version      : " + formatVersion + "\n");
+        xhtml.characters("Cache type                    : " + cacheType + "\n");
+        xhtml.characters("Offset to first cache entry    : " + firstCacheEntryOffset + "\n");
+        xhtml.characters("Offset to first available entry: " + firstAvailableCacheEntryOffset + "\n");
+        xhtml.characters("Number of cache entries        : " + numberOfCacheEntries + "\n");
+
+        String windowsVersion = "";
+        switch (formatVersion) {
+            case 20:
+                windowsVersion = "Windows Vista";
+                break;
+            case 21:
+                windowsVersion = "Windows 7";
+                break;
+            case 30:
+                windowsVersion = "Windows 8.0";
+                break;
+            case 31:
+                windowsVersion = "Windows 8.1";
+                break;
+            case 32:
+                windowsVersion = "Windows 10 / 11";
+                break;
+            default:
+                windowsVersion = "Unknown version";
+        }
+        xhtml.characters("Seen on Windows version        : " + windowsVersion + "\n");
+        xhtml.endElement("pre");
+
+        // Processando as entradas de cache
         while (stream.read(buffer) == buffer.length) {
             ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
 
-            int size = bb.getInt();
-            long entryHash = bb.getLong();
-            int identifierStringSize = bb.getInt();
-            int paddingSize = bb.getInt();
-            int dataSize = bb.getInt();
-            int unknown1 = bb.getInt();
-            long dataChecksum = bb.getInt() & 0xFFFFFFFFL;
-            long headerChecksum = bb.getLong();
+            String entrySignature = new String(buffer, 0, 4); //
+            if (!"CMMM".equals(entrySignature)) {
+                xhtml.characters("Error: Invalid entry signature, expected 'CMMM'. Skipping entry.\n");
+                continue;
+            }
 
-            // Exibir os detalhes do cache
-            xhtml.startElement("pre");
-            xhtml.characters("size                           : " + size + "\n");
-            xhtml.characters("entry hash                     : 0x" + Long.toHexString(entryHash) + "\n");
-            xhtml.characters("identifier string size         : " + identifierStringSize + "\n");
-            xhtml.characters("padding size                   : " + paddingSize + "\n");
-            xhtml.characters("data size                      : " + dataSize + "\n");
-            xhtml.characters("unknown1                       : 0x" + Integer.toHexString(unknown1) + "\n");
-            xhtml.characters("data checksum                  : 0x" + Long.toHexString(dataChecksum) + "\n");
-            xhtml.characters("header checksum                : 0x" + Long.toHexString(headerChecksum) + "\n");
-            xhtml.characters("\nidentifier string              : " + Long.toHexString(entryHash) + "\n");
-            xhtml.endElement("pre");
+            int entrySize = bb.getInt(4);
+            long entryHash = bb.getLong(8);
+            int identifierStringSize = bb.getInt(16);
+            int paddingSize = bb.getInt(20);
+            int dataSize = bb.getInt(24); //
+            long dataChecksum = bb.getLong(40);
+            long headerChecksum = bb.getLong(48);
+
+            if (dataSize > 0 && identifierStringSize > 0) {
+                byte[] identifierBytes = new byte[identifierStringSize];
+                stream.read(identifierBytes);
+                String identifierString = new String(identifierBytes, "UTF-16LE");
+
+                xhtml.startElement("pre");
+                xhtml.characters("Entry hash                    : 0x" + Long.toHexString(entryHash) + "\n");
+                xhtml.characters("Entry size                    : " + entrySize + "\n");
+                xhtml.characters("Identifier string             : " + identifierString + "\n");
+                xhtml.characters("Data size                     : " + dataSize + "\n");
+                xhtml.characters("Data checksum                 : 0x" + Long.toHexString(dataChecksum) + "\n");
+                xhtml.characters("Header checksum               : 0x" + Long.toHexString(headerChecksum) + "\n");
+                xhtml.endElement("pre");
+            }
+
+            if (paddingSize > 0) {
+                stream.skip(paddingSize);
+            }
+
+            if (dataSize > 0) {
+                stream.skip(dataSize);
+            }
         }
     }
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -5,9 +5,6 @@ import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.poifs.filesystem.DocumentInputStream;
 import org.apache.poi.poifs.filesystem.Entry;
 import org.apache.poi.poifs.filesystem.DocumentNode;
-import org.apache.tika.exception.TikaException;
-import org.apache.tika.extractor.EmbeddedDocumentExtractor;
-import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
 import org.apache.tika.io.TemporaryResources;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -21,6 +18,8 @@ import org.xml.sax.SAXException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Set;
 
 public class ThumbcacheParser extends AbstractParser {
@@ -33,41 +32,63 @@ public class ThumbcacheParser extends AbstractParser {
     }
 
     @Override
-    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException, TikaException {
-        EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,
-            new ParsingEmbeddedDocumentExtractor(context));
+    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException {
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
 
         TemporaryResources tmp = new TemporaryResources();
-        TikaInputStream tis = TikaInputStream.get(stream, tmp);
-        File file = tis.getFile();
-        POIFSFileSystem poiFS = new POIFSFileSystem(file);
-
-        // Placeholder for the recursive method that will navigate through directories and process files extracting metadata and image.
-        // TODO: Implement recurseDir method
-        recurseDir(poiFS.getRoot(), extractor, xhtml);
-
-        xhtml.endDocument();
-        tmp.close();
+        try (TikaInputStream tis = TikaInputStream.get(stream, tmp)) {
+            File file = tis.getFile();
+            try (POIFSFileSystem poiFS = new POIFSFileSystem(file)) {
+                recurseDir(poiFS.getRoot(), xhtml);
+            }
+        } finally {
+            xhtml.endDocument();
+            tmp.close();
+        }
     }
 
-    private void recurseDir(DirectoryNode dir, EmbeddedDocumentExtractor extractor, XHTMLContentHandler xhtml) throws IOException, SAXException, TikaException {
+    private void recurseDir(DirectoryNode dir, XHTMLContentHandler xhtml) throws SAXException {
         for (Entry entry : dir) {
             if (entry instanceof DirectoryNode) {
-                recurseDir((DirectoryNode) entry, extractor, xhtml);
+                recurseDir((DirectoryNode) entry, xhtml);
             } else {
-                Metadata entrydata = new Metadata();
-                entrydata.set(Metadata.CONTENT_TYPE, "thumbcache-entry");
+                try (DocumentInputStream docStream = new DocumentInputStream((DocumentNode) entry)) {
+                    byte[] buffer = new byte[80];
+                    int bytesRead = docStream.read(buffer);
+                    if (bytesRead != buffer.length) {
+                        continue;
+                    }
 
-                xhtml.startElement("div", "class", "thumbcache-entry");
-                xhtml.element("h1", entry.getName());
-                xhtml.startElement("div", "class", "thumbcache-entry-content");
-                try (InputStream stream = new DocumentInputStream((DocumentNode) entry)) {
-                    extractor.parseEmbedded(stream, xhtml, entrydata, true);
+                    ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
+
+                    int size = bb.getInt();
+                    long entryHash = bb.getLong();
+                    int identifierStringSize = bb.getInt();
+                    int paddingSize = bb.getInt();
+                    int dataSize = bb.getInt();
+                    int unknown1 = bb.getInt();
+                    long dataChecksum = bb.getInt() & 0xFFFFFFFFL;
+                    long headerChecksum = bb.getLong();
+
+                    xhtml.startElement("pre");
+
+                    xhtml.characters("size                           : " + size + "\n");
+                    xhtml.characters("entry hash                     : 0x" + Long.toHexString(entryHash) + "\n");
+                    xhtml.characters("identifier string size         : " + identifierStringSize + "\n");
+                    xhtml.characters("padding size                   : " + paddingSize + "\n");
+                    xhtml.characters("data size                      : " + dataSize + "\n");
+                    xhtml.characters("unknown1                       : 0x" + Integer.toHexString(unknown1) + "\n");
+                    xhtml.characters("data checksum                  : 0x" + Long.toHexString(dataChecksum) + "\n");
+                    xhtml.characters("header checksum                : 0x" + Long.toHexString(headerChecksum) + "\n");
+
+                    xhtml.characters("\nidentifier string              : " + Long.toHexString(entryHash) + "\n");
+
+                    xhtml.endElement("pre");
+
+                } catch (IOException e) {
+                    xhtml.characters("Error processing entry: " + entry.getName() + "\n");
                 }
-                xhtml.endElement("div");
-                xhtml.endElement("div");
             }
         }
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -1,8 +1,11 @@
 package iped.parsers.misc;
 
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
+import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AbstractParser;
@@ -11,6 +14,7 @@ import org.apache.tika.sax.XHTMLContentHandler;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
@@ -30,6 +34,16 @@ public class ThumbcacheParser extends AbstractParser {
             new ParsingEmbeddedDocumentExtractor(context));
         XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
         xhtml.startDocument();
+
+        TemporaryResources tmp = new TemporaryResources();
+        TikaInputStream tis = TikaInputStream.get(stream, tmp);
+        File file = tis.getFile();
+        POIFSFileSystem poiFS = new POIFSFileSystem(file);
+
+        // recurseDir(poiFS.getRoot(), extractor, xhtml);
+
+        xhtml.endDocument();
+        tmp.close();
     }
 
 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/misc/ThumbcacheParser.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 public class ThumbcacheParser extends AbstractParser {
@@ -59,8 +60,8 @@ public class ThumbcacheParser extends AbstractParser {
             return;
         }
 
-        int formatVersion = fileHeader.getInt(4); //
-        int cacheType = fileHeader.getInt(8); //
+        int formatVersion = fileHeader.getInt(4);
+        int cacheType = fileHeader.getInt(8);
         int firstCacheEntryOffset = fileHeader.getInt(12);
         int firstAvailableCacheEntryOffset = fileHeader.getInt(16);
         int numberOfCacheEntries = fileHeader.getInt(20);
@@ -95,13 +96,12 @@ public class ThumbcacheParser extends AbstractParser {
         xhtml.characters("Seen on Windows version        : " + windowsVersion + "\n");
         xhtml.endElement("pre");
 
-        // Processando as entradas de cache
         while (stream.read(buffer) == buffer.length) {
             ByteBuffer bb = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
 
-            String entrySignature = new String(buffer, 0, 4); //
+            String entrySignature = new String(buffer, 0, 4);
+
             if (!"CMMM".equals(entrySignature)) {
-                xhtml.characters("Error: Invalid entry signature, expected 'CMMM'. Skipping entry.\n");
                 continue;
             }
 
@@ -116,7 +116,7 @@ public class ThumbcacheParser extends AbstractParser {
             if (dataSize > 0 && identifierStringSize > 0) {
                 byte[] identifierBytes = new byte[identifierStringSize];
                 stream.read(identifierBytes);
-                String identifierString = new String(identifierBytes, "UTF-16LE");
+                String identifierString = new String(identifierBytes, StandardCharsets.UTF_16LE);
 
                 xhtml.startElement("pre");
                 xhtml.characters("Entry hash                    : 0x" + Long.toHexString(entryHash) + "\n");


### PR DESCRIPTION
This Pull Request introduces the initial implementation of the ThumbcacheParser class, designed to process thumbcache files for metadata extraction and image conversion to Base64.

Note: The most important information to be extracted from thumbcache files is the embedded image thumbnails, which still needs to be implemented. I appreciate any feedback and suggestions on how to improve this implementation!