### PR TITLE
BpList parser

### DIFF
--- a/iped-app/resources/config/conf/CategoriesConfig.json
+++ b/iped-app/resources/config/conf/CategoriesConfig.json
@@ -69,6 +69,9 @@
 	      ]}
 	    ]}
     ]},
+    {"name": "Apple Artifacts", "categories":[
+        {"name": "Apple Configuration Files", "mimes": ["application/x-bplist"]}
+    ]},
     {"name": "Google Drive", "categories":[
       {"name": "GDrive Synced Files", "mimes": ["application/x-gdrive-cloud-graph", "application/x-gdrive-snapshot"]},
       {"name": "GDrive File Entries", "mimes": ["application/x-gdrive-cloud-graph-registry", "application/x-gdrive-snapshot-registry"]}

--- a/iped-app/resources/config/conf/CategoriesToExpand.txt
+++ b/iped-app/resources/config/conf/CategoriesToExpand.txt
@@ -19,6 +19,7 @@ OLE files
 Georeferenced Files
 Peer-to-peer
 Chrome Cache
+Apple Configuration Files
 #Event Files
 
 # Generates registry reports:

--- a/iped-app/resources/config/conf/MakePreviewConfig.txt
+++ b/iped-app/resources/config/conf/MakePreviewConfig.txt
@@ -8,6 +8,7 @@ supportedMimes = application/x-msaccess; application/x-lnk; application/x-firefo
 supportedMimes = application/x-sqlite3; application/sqlite-skype; application/x-win10-timeline; application/x-gdrive-cloud-graph; application/x-gdrive-snapshot
 supportedMimes = application/x-whatsapp-db; application/x-whatsapp-db-f; application/x-whatsapp-chatstorage; application/x-whatsapp-chatstorage-f; application/x-threema-chatstorage; application/x-shareaza-searches-dat; application/x-msie-cache
 supportedMimes = application/x-prefetch; text/x-vcard; application/x-emule-preferences-dat; application/vnd.android.package-archive; application/x-bittorrent-settings-dat
+supportedMimes = application/x-bplist;
 
 # List of mimetypes which parsers insert links to other case items into preview
 supportedMimesWithLinks = application/x-emule; application/x-emule-part-met; application/x-ares-galaxy; application/x-shareaza-library-dat; application/x-shareaza-download; application/x-bittorrent-resume-dat; application/x-bittorrent-resume-dat-entry; application/x-bittorrent

--- a/iped-app/resources/config/conf/ParserConfig.xml
+++ b/iped-app/resources/config/conf/ParserConfig.xml
@@ -23,7 +23,8 @@
         <parser class="iped.parsers.external.CompositeExternalParser"></parser>
 
         <parser class="org.apache.tika.parser.apple.AppleSingleFileParser"></parser>
-        <parser class="org.apache.tika.parser.apple.PListParser"></parser>
+        <parser class="iped.parsers.plist.parser.PListParser"></parser>
+        <!-- <parser class="org.apache.tika.parser.apple.PListParser"></parser> -->
         <parser class="org.apache.tika.parser.asm.ClassParser"></parser>
         <parser class="org.apache.tika.parser.audio.AudioParser"></parser>
         <parser class="org.apache.tika.parser.audio.MidiParser"></parser>

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/plist/parser/PListParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/plist/parser/PListParser.java
@@ -1,0 +1,192 @@
+package iped.parsers.plist.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.tika.detect.apple.BPListDetector;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.extractor.ParsingEmbeddedDocumentExtractor;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.AbstractParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.sax.XHTMLContentHandler;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import com.dd.plist.NSArray;
+import com.dd.plist.NSData;
+import com.dd.plist.NSDate;
+import com.dd.plist.NSDictionary;
+import com.dd.plist.NSNumber;
+import com.dd.plist.NSObject;
+import com.dd.plist.NSSet;
+import com.dd.plist.NSString;
+import com.dd.plist.PropertyListFormatException;
+import com.dd.plist.PropertyListParser;
+import com.dd.plist.UID;
+
+import iped.parsers.util.MetadataUtil;
+import iped.properties.BasicProps;
+import iped.utils.DateUtil;
+import iped.utils.IOUtil;
+
+/***
+ * 
+ * @author PCF Patrick Dalla Bernardina
+ *
+ *         This parser formats the bplist data in a expandable html tree,
+ *         extract binary data as subitens and NSDate objects as metadata.
+ */
+public class PListParser extends AbstractParser {
+
+    private static final Set<MediaType> SUPPORTED_TYPES = Collections.singleton(BPListDetector.BPLIST);
+    private static final String BPLIST_METADATA_SUFFIX = "bplist";
+
+    private static final String CSS = new String(readResourceAsBytes("/iped/parsers/css/treeview.css"), Charset.forName("UTF-8"));
+
+    @Override
+    public Set<MediaType> getSupportedTypes(ParseContext arg0) {
+        return SUPPORTED_TYPES;
+    }
+
+
+    @Override
+    public void parse(InputStream is, ContentHandler handler, Metadata metadata, ParseContext context) throws IOException, SAXException, TikaException {
+        if (is instanceof TikaInputStream) {
+            NSObject oc = null;
+            try {
+                if (is instanceof TikaInputStream && ((TikaInputStream) is).hasFile()) {
+                    oc = PropertyListParser.parse(((TikaInputStream) is).getFile());
+
+                } else {
+                    oc = PropertyListParser.parse(is);
+                }
+
+
+                XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
+                xhtml.startDocument();
+
+                xhtml.startElement("style");
+                xhtml.characters(PListParser.CSS);
+                xhtml.endElement("style");
+
+                try {
+                    EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class, new ParsingEmbeddedDocumentExtractor(context));
+
+                    xhtml.startElement("nav");
+                    parseNSObject(oc, xhtml, metadata, BPLIST_METADATA_SUFFIX, extractor);
+                    xhtml.endElement("nav");
+                } catch (Exception e) {
+                    // TODO: handle exception
+                }
+                xhtml.endDocument();
+            } catch (IOException | PropertyListFormatException | ParseException | ParserConfigurationException | SAXException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void parseNSObject(NSObject nso, XHTMLContentHandler xhtml, Metadata metadata, String path, EmbeddedDocumentExtractor extractor) throws SAXException {
+        xhtml.startElement("details", "open", "true");
+        if ((nso instanceof NSString) || (nso instanceof NSNumber) || (nso instanceof UID)) {
+            xhtml.startElement("summary", "class", "nochild");
+            xhtml.characters(nso.toString());
+            xhtml.endElement("summary");
+        }
+        if (nso instanceof NSDate) {
+            String dateStr = DateUtil.dateToString(((NSDate) nso).getDate());
+            xhtml.startElement("summary", "class", "nochild");
+            xhtml.characters(dateStr);
+            xhtml.endElement("summary");
+            MetadataUtil.setMetadataType(path, Date.class);
+            metadata.add(path, dateStr);
+        }
+        if ((nso instanceof NSData)) {
+            xhtml.startElement("summary", "class", "nochild");
+            xhtml.characters(((NSData) nso).getBase64EncodedData());
+            xhtml.endElement("summary");
+            try {
+                handleData(path, (NSData) nso, metadata, xhtml, extractor);
+            } catch (IOException | SAXException e) {
+                e.printStackTrace();
+            }
+        }
+        if (nso instanceof NSArray) {
+            if (((NSArray) nso).getArray().length > 0) {
+                xhtml.startElement("summary", "class", "is-expandable");
+                xhtml.characters("Array");
+                xhtml.endElement("summary");
+                for (NSObject ao : ((NSArray) nso).getArray()) {
+                    parseNSObject(ao, xhtml, metadata, path, extractor);
+                }
+            }
+        }
+        if (nso instanceof NSSet) {
+            if (((NSSet) nso).allObjects().length > 0) {
+                xhtml.startElement("summary", "class", "is-expandable");
+                xhtml.characters("Set");
+                xhtml.endElement("summary");
+                for (NSObject ao : ((NSSet) nso).allObjects()) {
+                    parseNSObject(ao, xhtml, metadata, path, extractor);
+                }
+            }
+        }
+        if (nso instanceof NSDictionary) {
+            if (((NSDictionary) nso).size() > 0) {
+                xhtml.startElement("summary", "class", "is-expandable");
+                xhtml.characters("Dict");
+                xhtml.endElement("summary");
+                for (Entry<String, NSObject> d : ((NSDictionary) nso).getHashMap().entrySet()) {
+                    xhtml.startElement("details");
+                    xhtml.startElement("summary", "class", "is-expandable");
+                    xhtml.characters(d.getKey());
+                    xhtml.endElement("summary");
+                    parseNSObject(d.getValue(), xhtml, metadata, path + ":" + d.getKey(), extractor);
+                    xhtml.endElement("details");
+
+                }
+            }
+        }
+        xhtml.endElement("details");
+    }
+
+    private void handleData(String path, NSData value, Metadata metadata, XHTMLContentHandler xhtml, EmbeddedDocumentExtractor extractor) throws IOException, SAXException {
+        if (!extractor.shouldParseEmbedded(metadata)) {
+            return;
+        }
+
+        try (TikaInputStream tis = TikaInputStream.get(value.bytes())) {
+            Metadata m2 = new Metadata();
+            String name = path.substring(BPLIST_METADATA_SUFFIX.length() + 1);
+            m2.add(BasicProps.NAME, name);
+            m2.add(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+            extractor.parseEmbedded(tis, xhtml, m2, true);
+        }
+    }
+
+    private static byte[] readResourceAsBytes(String resource) {
+        byte[] result = null;
+        try {
+            result = IOUtil.loadInputStream(PListParser.class.getResourceAsStream(resource));
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+}

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/ToXMLContentHandler.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/util/ToXMLContentHandler.java
@@ -79,6 +79,7 @@ public class ToXMLContentHandler extends ToTextContentHandler {
     private final String encoding;
 
     protected boolean inStartElement = false;
+    protected boolean inStyle = false;
 
     protected final Map<String, String> namespaces = new HashMap<String, String>();
 
@@ -142,6 +143,12 @@ public class ToXMLContentHandler extends ToTextContentHandler {
 
         currentElement = new ElementInfo(currentElement, namespaces);
 
+        if (localName.toLowerCase().equals("style")) {
+            inStyle = true;
+        } else {
+            inStyle = false;
+        }
+
         write('<');
         write(currentElement.getQName(uri, localName));
 
@@ -196,7 +203,11 @@ public class ToXMLContentHandler extends ToTextContentHandler {
     @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
         lazyCloseStartElement();
-        writeEscaped(ch, start, start + length, false);
+        if (inStyle) {
+            super.characters(ch, start, length);
+        } else {
+            writeEscaped(ch, start, start + length, false);
+        }
     }
 
     private void lazyCloseStartElement() throws SAXException {


### PR DESCRIPTION
Tika BPList parser converts binary plist files to XML and extracts some data.

This parser converts it to an XHTML expandable tree. 

Additionally, when NSDate objects are found inside BPList file, date metadata is created. 

When NSData object is found, they are extracted as subitems, with the name equals to the dictionary path name where the object was found.

@joao-fernando , could you test and suggest/implement improvements?

It would closes 1773.