### PR TITLE
Sort before generating WA chat report (another fix related to #2337)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
@@ -285,6 +285,9 @@ public class WhatsAppParser extends SQLite3DBParser {
         int chatVirtualId = 0;
         HashMap<String, String> cache = new HashMap<>();
         for (Chat c : chatList) {
+            // sort messages before generating the report
+            Message.sort(c.getMessages());
+
             getAvatar(searcher, c.getRemote());
             searchMediaFilesForMessagesInBatches(c.getMessages(), searcher, handler, extractor, dbPath, context, null);
             int frag = 0;
@@ -733,11 +736,6 @@ public class WhatsAppParser extends SQLite3DBParser {
             if (!wcontext.isMainDB() && !wcontext.isBackup()) {
                 // if this is a "backup" but its main db was not found
                 logger.info("Creating separate report for {}", DB.getPath()); //$NON-NLS-1$
-            }
-
-            // sort messages
-            for (Chat chat : dbChatList) {
-                Message.sort(chat.getMessages());
             }
 
             // create report for main dbs and backups which main db was not found


### PR DESCRIPTION
Fix #2337.

@lfcnassif, unfortunately I detected another issue related to #2337 in a real case, with a variety of conditions (backup merged, backups without the main database, databases without backups, multiple WA instances in a single device).

I just moved the call to `Message.sort()`, so now it will sort messages before generating the chat preview in all situations (before some cases were not covered). 