### PR TITLE
Create an image view for configured types (#262)

### DIFF
--- a/iped-app/resources/config/conf/ImageThumbsConfig.txt
+++ b/iped-app/resources/config/conf/ImageThumbsConfig.txt
@@ -46,7 +46,7 @@ logGalleryRendering = false
 
 # Create view images (to speed up rendering) for the following mime types.
 # Used only for images that require external conversion. Use ";" as separator. 
-mimesToCreateView = image/heic
+mimesToCreateView = image/heic; image/heif
 
 # Maximum size (in pixels) of generated view image
 maxViewImageSize = 2400

--- a/iped-app/resources/config/conf/ImageThumbsConfig.txt
+++ b/iped-app/resources/config/conf/ImageThumbsConfig.txt
@@ -43,3 +43,10 @@ galleryThreads = default
 # Logs rendering of each image in gallery. Could generate huge logs or
 # slow down gallery rendering depending on log location.
 logGalleryRendering = false
+
+# Create view images (to speed up rendering) for the following mime types.
+# Used only for images that require external conversion. Use ";" as separator. 
+mimesToCreateView = image/heic
+
+# Maximum size (in pixels) of generated view image
+maxViewImageSize = 2400

--- a/iped-app/resources/scripts/tasks/FaceRecognitionTask.py
+++ b/iped-app/resources/scripts/tasks/FaceRecognitionTask.py
@@ -222,7 +222,10 @@ class FaceRecognitionTask:
         isVideo = False
         mediaType = item.getMediaType().toString()
         if mediaType.startswith('image'):
-            img_path = item.getTempFile().getAbsolutePath()
+            if item.getViewFile() is not None and os.path.exists(item.getViewFile().getAbsolutePath()):
+                img_path = item.getViewFile().getAbsolutePath()
+            else:
+                img_path = item.getTempFile().getAbsolutePath()
         elif mediaType.startswith('video') and not FaceRecognitionTask.videoSubitems:
             img_path = item.getViewFile().getAbsolutePath()
             isVideo = True

--- a/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
@@ -1,5 +1,9 @@
 package iped.engine.config;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import iped.utils.UTF8Properties;
 
 public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
@@ -24,6 +28,8 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
     private int lowResDensity = 96;
     private int highResDensity = 250;
     private int maxMPixelsInMemory = 32;
+    private int maxViewImageSize = 3000;
+    private final Set<String> mimesToCreateView = new HashSet<String>();
 
     public boolean isEnableExternalConv() {
         return enableExternalConv;
@@ -67,6 +73,14 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
 
     public int getMaxMPixelsInMemory() {
         return maxMPixelsInMemory;
+    }
+
+    public int getMaxViewImageSize() {
+        return maxViewImageSize;
+    }
+
+    public Set<String> getMimesToCreateView() {
+        return Collections.unmodifiableSet(mimesToCreateView);
     }
 
     @Override
@@ -141,6 +155,17 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
             maxMPixelsInMemory = Integer.valueOf(value.trim());
         }
 
-    }
+        value = properties.getProperty("mimesToCreateView");
+        if (value != null) {
+            String[] mimes = value.split(";");
+            for (String mime : mimes) {
+                mimesToCreateView.add(mime.trim());
+            }
+        }
 
+        value = properties.getProperty("maxViewImageSize");
+        if (value != null && !value.trim().isEmpty()) {
+            maxViewImageSize = Integer.valueOf(value.trim());
+        }
+    }
 }

--- a/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
@@ -25,7 +25,7 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
     private int lowResDensity = 96;
     private int highResDensity = 250;
     private int maxMPixelsInMemory = 32;
-    private int maxViewImageSize = 3000;
+    private int maxViewImageSize = 2400;
     private final Set<String> mimesToCreateView = new HashSet<String>();
 
     public boolean isEnableExternalConv() {

--- a/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
@@ -8,9 +8,6 @@ import iped.utils.UTF8Properties;
 
 public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = 1L;
 
     private static final String ENABLE_PROP = "enableImageThumbs"; //$NON-NLS-1$

--- a/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
@@ -39,7 +39,7 @@ import iped.viewers.util.ImageMetadataUtil;
 public class ImageThumbTask extends ThumbTask {
 
     public static final String THUMB_TIMEOUT = "thumbTimeout"; //$NON-NLS-1$
-    
+
     private static final int TIMEOUT_DELTA = 5;
 
     private static final int samplingRatio = 3;
@@ -90,7 +90,7 @@ public class ImageThumbTask extends ThumbTask {
                     System.setProperty(ExternalImageConverter.winToolPathPrefixProp,
                             Configuration.getInstance().appRoot);
                 }
-                
+
                 File tmpDir = new File(System.getProperty("java.io.tmpdir"), "ext-conv"); //$NON-NLS-1$ //$NON-NLS-2$
                 tmpDir.mkdirs();
                 System.setProperty(ExternalImageConverter.tmpDirProp, tmpDir.getAbsolutePath());

--- a/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
@@ -287,8 +287,13 @@ public class ImageThumbTask extends ThumbTask {
     }
 
     private void createImageThumb(IItem evidence, File thumbFile) {
-        long[] performanceStats = new long[numStats];
         try {
+            if (evidence.getLength() != null && evidence.getLength().longValue() == 0) {
+                // If evidence length is zero, don't even try to create a thumb 
+                saveThumb(evidence, thumbFile);
+                return;
+            }
+            long[] performanceStats = new long[numStats];
             BufferedImage img = null;
             if (imgThumbConfig.isExtractThumb() && isJpeg(evidence)) { // $NON-NLS-1$
                 long t = System.currentTimeMillis();


### PR DESCRIPTION
Create an image view for configured types (initially only HEIC) that are handle by the external graphics tool.
Closes #262.

I added this feature as an option inside ImageThumbTask, because it was much simpler in terms of code changes. And I regret not doing this before, as it was a small change that should help a lot viewing HEIC's in the analysis application.

I also included a minor change in FaceRecognitionTask, to use the item's view when available, which will allow recognizing faces in HEIC images.

It would also be possible to avoid conversion from HEIC during OCR, but OCR is done inside a parser, which runs before ImageThumbTask.