### PR TITLE
Handle WhatsApp status updates (#616) 

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Chat.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Chat.java
@@ -18,6 +18,7 @@ public class Chat {
     private String title;
     private boolean isGroupChat;
     private boolean isChannelChat;
+    private boolean isBroadcast;
     private boolean isDeleted;
 
     private String recoveredFrom;
@@ -26,6 +27,9 @@ public class Chat {
 
     public Chat(WAContact remote) {
         this.remote = remote;
+        if (remote != null && remote.getFullId().equals(WAContact.waStatusBroadcast)) {
+            setBroadcast(true);
+        }
     }
 
     /**
@@ -100,21 +104,34 @@ public class Chat {
     public boolean isGroupOrChannelChat() {
         return isGroupChat || isChannelChat;
     }
-    
+
+    public boolean isBroadcast() {
+        return isBroadcast;
+    }
+
+    public void setBroadcast(boolean isBroadcast) {
+        this.isBroadcast = isBroadcast;
+    }
+
     public String getTitle() {
         if (title == null) {
+            title = "WhatsApp ";
             if (isChannelChat()) {
-                title = "WhatsApp Channel";
+                title += "Channel";
                 if (getSubject() != null && !getSubject().isBlank()) {
                     title += " - " + getSubject().strip();
                 }
             } else if (isGroupChat()) {
-                title = "WhatsApp Group";
+                title += "Group";
                 if (getSubject() != null && !getSubject().isBlank()) {
                     title += " - " + getSubject().strip();
                 }
             } else {
-                title = "WhatsApp Chat"; //$NON-NLS-1$
+                if (isBroadcast()) {
+                    title += "Status";
+                } else {
+                    title += "Chat";
+                }
                 if (remote != null && remote.getName() != null
                         && (getPrintId() == null || !remote.getName().strip().equals(getPrintId().strip()))) {
                     title += " - " + remote.getName().strip(); //$NON-NLS-1$

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Chat.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Chat.java
@@ -76,7 +76,7 @@ public class Chat {
     public void add(Message message) {
         messages.add(message);
     }
-    
+
     /**
      * @param messages
      *            the messages to set
@@ -163,11 +163,11 @@ public class Chat {
     public void setGroupMembers(Set<WAContact> groupmembers) {
         this.groupMembers = groupmembers;
     }
-    
+
     public void setDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
-    
+
     public boolean isDeleted() {
         return isDeleted;
     }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroid.java
@@ -185,12 +185,10 @@ public class ExtractorAndroid extends Extractor {
                         c.setId(rs.getLong("id")); //$NON-NLS-1$
                         c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
                         c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                        if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                            if (recoverDeletedRecords) {
-                                activeChats.add(contactId);
-                            }
-                            list.add(c);
+                        if (recoverDeletedRecords) {
+                            activeChats.add(contactId);
                         }
+                        list.add(c);
                     }
                 } catch (SQLException ex) {
                     if (firstTry || !isSqliteCorruptException(ex)) {
@@ -271,15 +269,13 @@ public class ExtractorAndroid extends Extractor {
             
             for (SqliteRow row : undeleteChatListTable.getTableRows()) {
                 String contactId = row.getTextValue("key_remote_jid"); //$NON-NLS-1$
-                if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                    WAContact contact = contacts.getContact(contactId);
-                    Chat c = new Chat(contact);
-                    c.setId(row.getIntValue("_id"));
-                    c.setDeleted(row.isDeletedRow());
-                    c.setSubject(row.getTextValue("subject")); //$NON-NLS-1$
-                    c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                    result.add(c);
-                }
+                WAContact contact = contacts.getContact(contactId);
+                Chat c = new Chat(contact);
+                c.setId(row.getIntValue("_id"));
+                c.setDeleted(row.isDeletedRow());
+                c.setSubject(row.getTextValue("subject")); //$NON-NLS-1$
+                c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                result.add(c);
             }
         } else if (undeleteChatTable != null && undeleteChatTable.getTableRows() != null && !undeleteChatTable.getTableRows().isEmpty()) {
             if (undeleteJIDTable != null && undeleteJIDTable.getTableRows() != null && !undeleteJIDTable.getTableRows().isEmpty()) {
@@ -292,15 +288,13 @@ public class ExtractorAndroid extends Extractor {
                     if (jid_rows.containsKey(jid_row_id)) {
                         SqliteRow jid_row = jid_rows.get(jid_row_id).get(0);
                         String contactId = jid_row.getTextValue("raw_string"); //$NON-NLS-1$
-                        if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                            WAContact contact = contacts.getContact(contactId);
-                            Chat c = new Chat(contact);
-                            c.setId(row.getIntValue("_id"));
-                            c.setDeleted(true);
-                            c.setSubject(row.getTextValue("subject")); //$NON-NLS-1$
-                            c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                            result.add(c);
-                        }
+                        WAContact contact = contacts.getContact(contactId);
+                        Chat c = new Chat(contact);
+                        c.setId(row.getIntValue("_id"));
+                        c.setDeleted(true);
+                        c.setSubject(row.getTextValue("subject")); //$NON-NLS-1$
+                        c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                        result.add(c);
                     }
                 }
             }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroidNew.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroidNew.java
@@ -100,7 +100,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -108,7 +107,6 @@ import java.util.Map;
 
 import iped.parsers.sqlite.SQLite3DBParser;
 import iped.parsers.whatsapp.Message.MessageStatus;
-import iped.parsers.whatsapp.Message.MessageType;
 import iped.parsers.whatsapp.Message.MessageQuotedType;
 
 /**
@@ -135,8 +133,13 @@ public class ExtractorAndroidNew extends Extractor {
                     Chat c = new Chat(remote);
                     c.setId(rs.getLong("id"));
                     c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
-                    c.setGroupChat(contactId.endsWith("@g.us"));
-                    c.setChannelChat(contactId.endsWith("@newsletter"));
+                    if (contactId.endsWith(WAContact.waGroupSuffix)) {
+                        c.setGroupChat(true);
+                    } else if (contactId.endsWith(WAContact.waNewsletterSuffix)) {
+                        c.setChannelChat(true);
+                    } else if (contactId.endsWith(WAContact.waStatusSuffix)) {
+                        c.setBroadcast(true);
+                    }
                     list.add(c);
                     idToChat.put(c.getId(), c);
                 }

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroidNew.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorAndroidNew.java
@@ -137,10 +137,8 @@ public class ExtractorAndroidNew extends Extractor {
                     c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
                     c.setGroupChat(contactId.endsWith("@g.us"));
                     c.setChannelChat(contactId.endsWith("@newsletter"));
-                    if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                        list.add(c);
-                        idToChat.put(c.getId(), c);
-                    }
+                    list.add(c);
+                    idToChat.put(c.getId(), c);
                 }
 
                 extractMessages(conn, idToChat);
@@ -407,7 +405,7 @@ public class ExtractorAndroidNew extends Extractor {
 
                 m.setId(rs.getLong("id")); //$NON-NLS-1$
                 String remoteResource = rs.getString("remoteResource");
-                if (remoteResource == null || remoteResource.isEmpty() || !c.isGroupOrChannelChat()) {
+                if (remoteResource == null || remoteResource.isEmpty() || (!c.isGroupOrChannelChat() && !c.isBroadcast())) {
                     remoteResource = c.getRemote().getFullId();
                 }
                 m.setRemoteResource(remoteResource); // $NON-NLS-1$
@@ -585,9 +583,9 @@ public class ExtractorAndroidNew extends Extractor {
                                 mq.setId(fakeIds--);
                                 String remoteId = mq.getRemoteId();
                                 if (remoteId != null) {
-                                    if (remoteId.compareTo(Message.STATUS_BROADCAST) == 0) {
+                                    if (remoteId.equals(WAContact.waStatusBroadcast)) {
                                         mq.setMessageQuotedType(MessageQuotedType.QUOTE_STATUS);
-                                    } else if (remoteId.contains(Message.GROUP)) {
+                                    } else if (remoteId.endsWith(WAContact.waGroupSuffix)) {
                                         // Set it first in case if not found
                                         mq.setQuotePrivateGroupName(remoteId);
                                         boolean found = false;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
@@ -210,20 +210,18 @@ public class ExtractorIOS extends Extractor {
                 try (ResultSet rs = stmt.executeQuery(chatListQuery)) {
                     while (rs.next()) {
                         String contactId = rs.getString("contact"); //$NON-NLS-1$
-                        if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                            WAContact remote = contacts.getContact(contactId);
-                            Chat c = new Chat(remote);
-                            c.setId(rs.getLong("id")); //$NON-NLS-1$
-                            c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
-                            c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                            c.setChannelChat(contactId.endsWith("newsletter"));
-                            c.setDeleted(rs.getInt("ZREMOVED") != 0);
-                            remote.setAvatarPath(rs.getString("avatarPath")); //$NON-NLS-1$
-                            if (recoverDeletedRecords) {
-                                activeChats.add(c.getId());
-                            }
-                            list.add(c);
+                        WAContact remote = contacts.getContact(contactId);
+                        Chat c = new Chat(remote);
+                        c.setId(rs.getLong("id")); //$NON-NLS-1$
+                        c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
+                        c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                        c.setChannelChat(contactId.endsWith("newsletter"));
+                        c.setDeleted(rs.getInt("ZREMOVED") != 0);
+                        remote.setAvatarPath(rs.getString("avatarPath")); //$NON-NLS-1$
+                        if (recoverDeletedRecords) {
+                            activeChats.add(c.getId());
                         }
+                        list.add(c);
                     }
                 } catch (SQLException ex) {
                     if (firstTry || !isSqliteCorruptException(ex)) {
@@ -604,11 +602,10 @@ public class ExtractorIOS extends Extractor {
                             messageQuote.setRemoteResource(m.getRemoteResource());
                             // just set default case if does not match order cases ...
                             messageQuote.setMessageQuotedType(MessageQuotedType.QUOTE_PRIVACY_GROUP_NOT_FOUND);
-                            if (contactQuote.compareTo(Message.STATUS_BROADCAST) == 0) {
-
+                            if (contactQuote.equals(WAContact.waStatusBroadcast)) {
                                 messageQuote.setMessageQuotedType(MessageQuotedType.QUOTE_STATUS);
 
-                            } else if (contactQuote.contains(Message.GROUP)) {
+                            } else if (contactQuote.endsWith(WAContact.waGroupSuffix)) {
 
                                 // set it first in case if not found
                                 messageQuote.setQuotePrivateGroupName(contactQuote);
@@ -664,7 +661,7 @@ public class ExtractorIOS extends Extractor {
             m.setLocalResource(account.getId());
         m.setId(rs.getLong("id")); //$NON-NLS-1$
         String remoteResource = rs.getString("remoteResource");
-        if (remoteResource == null || remoteResource.isEmpty() || !chat.isGroupOrChannelChat()) {
+        if (remoteResource == null || remoteResource.isEmpty() || (!chat.isGroupOrChannelChat() && !chat.isBroadcast())) {
             remoteResource = chat.getRemote().getFullId();
         }
         m.setRemoteResource(remoteResource); // $NON-NLS-1$
@@ -1378,15 +1375,13 @@ public class ExtractorIOS extends Extractor {
         if (undeleteChatsSessions != null && !undeleteChatsSessions.getTableRows().isEmpty()) {
             for (SqliteRow row : undeleteChatsSessions.getTableRows()) {
                 String contactId = row.getTextValue("ZCONTACTJID"); //$NON-NLS-1$
-                if (!(contactId.endsWith("@status") || contactId.endsWith("@broadcast"))) { //$NON-NLS-1$ //$NON-NLS-2$
-                    WAContact contact = contacts.getContact(contactId);
-                    Chat c = new Chat(contact);
-                    c.setId(row.getIntValue("Z_PK")); //$NON-NLS-1$
-                    c.setDeleted(row.getIntValue("ZREMOVED") != 0 || row.isDeletedRow());
-                    c.setSubject(row.getTextValue("ZPARTNERNAME")); //$NON-NLS-1$
-                    c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                    result.add(c);
-                }
+                WAContact contact = contacts.getContact(contactId);
+                Chat c = new Chat(contact);
+                c.setId(row.getIntValue("Z_PK")); //$NON-NLS-1$
+                c.setDeleted(row.getIntValue("ZREMOVED") != 0 || row.isDeletedRow());
+                c.setSubject(row.getTextValue("ZPARTNERNAME")); //$NON-NLS-1$
+                c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                result.add(c);
             }
         }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ExtractorIOS.java
@@ -214,8 +214,13 @@ public class ExtractorIOS extends Extractor {
                         Chat c = new Chat(remote);
                         c.setId(rs.getLong("id")); //$NON-NLS-1$
                         c.setSubject(Util.getUTF8String(rs, "subject")); //$NON-NLS-1$
-                        c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
-                        c.setChannelChat(contactId.endsWith("newsletter"));
+                        if (contactId.endsWith(WAContact.waGroupSuffix)) {
+                            c.setGroupChat(true);
+                        } else if (contactId.endsWith(WAContact.waNewsletterSuffix)) {
+                            c.setChannelChat(true);
+                        } else if (contactId.endsWith(WAContact.waStatusSuffix)) {
+                            c.setBroadcast(true);
+                        }
                         c.setDeleted(rs.getInt("ZREMOVED") != 0);
                         remote.setAvatarPath(rs.getString("avatarPath")); //$NON-NLS-1$
                         if (recoverDeletedRecords) {
@@ -661,7 +666,7 @@ public class ExtractorIOS extends Extractor {
             m.setLocalResource(account.getId());
         m.setId(rs.getLong("id")); //$NON-NLS-1$
         String remoteResource = rs.getString("remoteResource");
-        if (remoteResource == null || remoteResource.isEmpty() || (!chat.isGroupOrChannelChat() && !chat.isBroadcast())) {
+        if (remoteResource == null || remoteResource.isEmpty() || !chat.isGroupOrChannelChat()) {
             remoteResource = chat.getRemote().getFullId();
         }
         m.setRemoteResource(remoteResource); // $NON-NLS-1$
@@ -1380,7 +1385,13 @@ public class ExtractorIOS extends Extractor {
                 c.setId(row.getIntValue("Z_PK")); //$NON-NLS-1$
                 c.setDeleted(row.getIntValue("ZREMOVED") != 0 || row.isDeletedRow());
                 c.setSubject(row.getTextValue("ZPARTNERNAME")); //$NON-NLS-1$
-                c.setGroupChat(contactId.endsWith("g.us")); //$NON-NLS-1$
+                if (contactId.endsWith(WAContact.waGroupSuffix)) {
+                    c.setGroupChat(true);
+                } else if (contactId.endsWith(WAContact.waNewsletterSuffix)) {
+                    c.setChannelChat(true);
+                } else if (contactId.endsWith(WAContact.waStatusSuffix)) {
+                    c.setBroadcast(true);
+                }
                 result.add(c);
             }
         }
@@ -1867,7 +1878,10 @@ public class ExtractorIOS extends Extractor {
                 }
 
                 String remoteId = row.getTextValue("ZFROMJID"); //$NON-NLS-1$
-                if (remoteId == null || !(remoteId.endsWith("whatsapp.net") || remoteId.endsWith("g.us"))) { //$NON-NLS-1$ //$NON-NLS-2$
+                if (remoteId == null
+                        || !(remoteId.endsWith(WAContact.waSuffix) || remoteId.endsWith(WAContact.waNewsletterSuffix)
+                                || remoteId.endsWith(WAContact.waStatusBroadcast)
+                                || remoteId.endsWith(WAContact.waStatusSuffix))) {
                     return false;
                 }
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/Message.java
@@ -29,9 +29,6 @@ public class Message implements Comparable<Message> {
     private static FileChannel fileChannel;
     private static AtomicLong fileOffset = new AtomicLong();
     private static AtomicInteger deletedCounter = new AtomicInteger();
-    public static String STATUS_BROADCAST = "status@broadcast";
-    public static String GROUP = "@g.us";
-    
 
     private long id;
     private int deletedId = -1;

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/ReportGenerator.java
@@ -199,8 +199,9 @@ public class ReportGenerator {
         ByteArrayOutputStream chatBytes = new ByteArrayOutputStream();
         PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(chatBytes, StandardCharsets.UTF_8)); // $NON-NLS-1$
 
-        printMessageFile(printWriter, c.getTitle(), c.getPrintId(), c.getRemote().getAvatar(), c.isDeleted(), () -> {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        printMessageFile(printWriter, c.getTitle(), c.getPrintId(), c.getRemote().getAvatar(), c.isDeleted(),
+                c.isBroadcast(), () -> {
+                    ByteArrayOutputStream bout = new ByteArrayOutputStream();
             PrintWriter out = new PrintWriter(new OutputStreamWriter(bout, StandardCharsets.UTF_8)); // $NON-NLS-1$
             if (c.getRecoveredFrom() != null) {
                 out.println("<div class=\"linha\"><div class=\"date\">" //$NON-NLS-1$
@@ -1631,7 +1632,7 @@ public class ReportGenerator {
     }
 
     private void printMessageFile(PrintWriter out, String title, String id, byte[] avatar, boolean isDeleted,
-            Supplier<String> messages) {
+            boolean isBroadcast, Supplier<String> messages) {
         String strAvatar;
         if (avatar == null || avatar.length == 0) {
             strAvatar = Util.getImageResourceAsEmbedded("img/avatar.png");
@@ -1657,6 +1658,8 @@ public class ReportGenerator {
                         return id;
                     case "avatar":
                         return strAvatar;
+                    case "topbarclass":
+                        return isBroadcast ? " class=\"status\"" : "";
                     case "messages":
                         return messages.get();
                     case "javascript":

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
@@ -3,6 +3,8 @@ package iped.parsers.whatsapp;
 public class WAContact {
 
     public static final String waSuffix = "@s.whatsapp.net";
+    public static final String waStatusBroadcast = "status@broadcast";
+    public static final String waGroupSuffix = "@g.us";
 
     private String id;
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WAContact.java
@@ -5,6 +5,8 @@ public class WAContact {
     public static final String waSuffix = "@s.whatsapp.net";
     public static final String waStatusBroadcast = "status@broadcast";
     public static final String waGroupSuffix = "@g.us";
+    public static final String waStatusSuffix = "@status";
+    public static final String waNewsletterSuffix = "@newsletter";
 
     private String id;
 

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
@@ -253,21 +253,21 @@ public class WhatsAppParser extends SQLite3DBParser {
                 if (mergeBackups || isDownloadMediaFilesEnabled())
                     parseAndCheckIfIsMainDb(stream, handler, metadata, context, new ExtractorAndroidFactory());
                 else
-                    parseWhatsappMessages(stream, handler, metadata, context, new ExtractorAndroidFactory());
+                    parseWhatsAppMessages(stream, handler, metadata, context, new ExtractorAndroidFactory());
             } else if (mimetype.equals(WA_DB.toString())) {
                 parseWhatsAppContacts(stream, handler, metadata, context, new ExtractorAndroidFactory());
             } else if (mimetype.equals(CHAT_STORAGE.toString())) {
                 if (isDownloadMediaFilesEnabled()) {
                     parseAndCheckIfIsMainDb(stream, handler, metadata, context, new ExtractorIOSFactory());
                 } else {
-                    parseWhatsappMessages(stream, handler, metadata, context, new ExtractorIOSFactory());
+                    parseWhatsAppMessages(stream, handler, metadata, context, new ExtractorIOSFactory());
                 }
             } else if (mimetype.equals(CONTACTS_V2.toString())) {
                 parseWhatsAppContacts(stream, handler, metadata, context, new ExtractorIOSFactory());
             } else if (mimetype.equals(MSG_STORE_2.toString())) {
                 mergeParsedDBsAndOutputResults(stream, handler, metadata, context, new ExtractorAndroidFactory());
             } else if (mimetype.equals(CHAT_STORAGE_2.toString())) {
-                parseWhatsappMessages(stream, handler, metadata, context, new ExtractorIOSFactory());
+                parseWhatsAppMessages(stream, handler, metadata, context, new ExtractorIOSFactory());
             }
 
         } catch (Exception e) {
@@ -377,7 +377,7 @@ public class WhatsAppParser extends SQLite3DBParser {
 
     }
 
-    private void parseWhatsappMessages(InputStream stream, ContentHandler handler, Metadata metadata,
+    private void parseWhatsAppMessages(InputStream stream, ContentHandler handler, Metadata metadata,
             ParseContext context, ExtractorFactory extFactory) throws IOException, SAXException, TikaException {
 
         EmbeddedDocumentExtractor extractor = context.get(EmbeddedDocumentExtractor.class,

--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
@@ -421,26 +421,16 @@ public class WhatsAppParser extends SQLite3DBParser {
     }
 
     private static void expandBroadcastChat(List<Chat> chatList, WAContactsDirectory contacts) {
-        System.err.println(">>chatList="+chatList.size());
         Map<String, Chat> statusChats = new HashMap<String, Chat>();
         for (int i = 0; i < chatList.size(); i++) {
             Chat c = chatList.get(i);
-            System.err.println("c.getRemote().getName() = " + c.getRemote().getFullId() + " : "  + i);
             if (c.getRemote().getFullId().equals(WAContact.waStatusBroadcast)) {
                 chatList.remove(i--);
                 for (Message m : c.getMessages()) {
                     String remote = m.getRemoteResource();
-                    System.err.println("remote="+remote);
-                    if (remote == null) {
-                        System.err.println("ID="+m.getId());
-                        System.err.println("1="+m.getRemoteId());
-                        System.err.println("2="+m.getLocalResource());
-                        System.err.println("3="+m.isFromMe());
-                    }
                     Chat newChat = statusChats.get(remote);
                     if (newChat == null) {
                         WAContact contact = contacts.getContact(remote);
-                        System.err.println("contact="+contact.getName());
                         newChat = new Chat(contact);
                         newChat.setBroadcast(true);
                         newChat.setDeleted(c.isDeleted());
@@ -449,7 +439,6 @@ public class WhatsAppParser extends SQLite3DBParser {
                         chatList.add(newChat);
                     }
                     newChat.add(m);
-                    System.err.println("m="+m.getData());
                 }
             }
         }

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -154,6 +154,10 @@ div.catalogIcon {
     z-index: 100;
 }
 
+#topbar.status {
+    background: #687272;
+}
+
 #topbar.telegram {
     background: #5682a3;
 }

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -155,7 +155,7 @@ div.catalogIcon {
 }
 
 #topbar.status {
-    background: #687272;
+    background: #7EF47E;
 }
 
 #topbar.telegram {

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/css/whatsapp.css
@@ -155,7 +155,7 @@ div.catalogIcon {
 }
 
 #topbar.status {
-    background: #7EF47E;
+    background: #8EA48E;
 }
 
 #topbar.telegram {

--- a/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/wachat-html-template.txt
+++ b/iped-parsers/iped-parsers-impl/src/main/resources/iped/parsers/whatsapp/wachat-html-template.txt
@@ -18,7 +18,7 @@
         </script>
     </head>
     <body>
-        <div id="topbar">
+        <div id="topbar"${topbarclass}>
             <div style="display: inline-block; padding: 6px 0px 2px 6px;">
                 <img src="${avatar}" width="72" height="72">
             </div>

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/whatsapp/WhatsAppParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/whatsapp/WhatsAppParserTest.java
@@ -122,10 +122,10 @@ public class WhatsAppParserTest extends AbstractPkgTest {
         try (InputStream stream = getStream(testFile)) {
             parser.parse(stream, handler, metadata, whatsappContext);
 
-            assertEquals(385, whatsapptracker.title.size());
-            assertEquals(385, whatsapptracker.username.size());
+            assertEquals(384, whatsapptracker.title.size());
+            assertEquals(384, whatsapptracker.username.size());
             assertEquals(365, whatsapptracker.userphone.size());
-            assertEquals(385, whatsapptracker.useraccount.size());
+            assertEquals(384, whatsapptracker.useraccount.size());
             assertEquals(166, whatsapptracker.usernotes.size());
             assertEquals(0, whatsapptracker.participants.size());
             assertEquals(0, whatsapptracker.messagefrom.size());
@@ -138,16 +138,16 @@ public class WhatsAppParserTest extends AbstractPkgTest {
             assertEquals("WhatsApp Contact: Hugo", whatsapptracker.title.get(2));
             assertEquals("WhatsApp Contact: Pedro Gonzaga", whatsapptracker.title.get(3));
             assertEquals("WhatsApp Contact: Vet", whatsapptracker.title.get(4));
-            assertEquals("WhatsApp Contact: 556186713007", whatsapptracker.title.get(382));
-            assertEquals("WhatsApp Contact: Cpf Mãe", whatsapptracker.title.get(383));
+            assertEquals("WhatsApp Contact: 556186713007", whatsapptracker.title.get(381));
+            assertEquals("WhatsApp Contact: Cpf Mãe", whatsapptracker.title.get(382));
 
             assertEquals("556192644086", whatsapptracker.username.get(0));
             assertEquals("Nwi Fibra Ótica", whatsapptracker.username.get(1));
             assertEquals("Hugo", whatsapptracker.username.get(2));
             assertEquals("Pedro Gonzaga", whatsapptracker.username.get(3));
             assertEquals("Vet", whatsapptracker.username.get(4));
-            assertEquals("556186713007", whatsapptracker.username.get(382));
-            assertEquals("Cpf Mãe", whatsapptracker.username.get(383));
+            assertEquals("556186713007", whatsapptracker.username.get(381));
+            assertEquals("Cpf Mãe", whatsapptracker.username.get(382));
 
             assertEquals("+556192644086", whatsapptracker.userphone.get(0));
             assertEquals("+556133223200", whatsapptracker.userphone.get(1));
@@ -162,8 +162,8 @@ public class WhatsAppParserTest extends AbstractPkgTest {
             assertEquals("556181680369@s.whatsapp.net", whatsapptracker.useraccount.get(2));
             assertEquals("556199351995@s.whatsapp.net", whatsapptracker.useraccount.get(3));
             assertEquals("556182227557@s.whatsapp.net", whatsapptracker.useraccount.get(4));
-            assertEquals("556186713007@s.whatsapp.net", whatsapptracker.useraccount.get(382));
-            assertEquals("5502163674092549@s.whatsapp.net", whatsapptracker.useraccount.get(383));
+            assertEquals("556186713007@s.whatsapp.net", whatsapptracker.useraccount.get(381));
+            assertEquals("5502163674092549@s.whatsapp.net", whatsapptracker.useraccount.get(382));
 
             assertEquals("|NWI TELECOM|", whatsapptracker.usernotes.get(0));
             assertEquals("†", whatsapptracker.usernotes.get(1));


### PR DESCRIPTION
Closes #616.

I still need to run more tests ~(and fix unit tests)~, so I am leaving this as draft for now.
The implemented code create a new item named "WhatsApp Status - XXX" for each contact that has status updates, as discussed in the issue.
The key method is `expandBroadcastChat()`. 
If we want to merge the status updates with the contact's chat (i.e. place status+messages from a given contact in a single place), it should be straightforward, rewriting the method mentioned above.