### PR TITLE
Limit video frame dimension (not width) and compress JPG video views and image thumbnails (#2470 and #2471)

### DIFF
--- a/iped-app/resources/config/conf/ImageThumbsConfig.txt
+++ b/iped-app/resources/config/conf/ImageThumbsConfig.txt
@@ -32,6 +32,10 @@ imgConvTimeoutPerMB = 2
 # Pixel size of generated thumbnails.
 imgThumbSize = 256
 
+# Compression level of the generated thumbnail image.
+# From 0 to 100, 0 - is very high compression and very low quality, 100 - higher quality and minimum compression.
+compression = 50
+
 # Extract embedded thumbs from exif, faster than generating them again.
 # Eventually these thumbs may have lower quality or be different of the original image.
 extractThumb = true

--- a/iped-app/resources/config/conf/VideoThumbsConfig.txt
+++ b/iped-app/resources/config/conf/VideoThumbsConfig.txt
@@ -10,8 +10,8 @@
 Layout = 320,4,5
 
 # Compression level of the generated image file.
-# From 0 to 100, 0 - is very high compression and very low quality; 1 - higher quality and minimum compression.
-Compression = 50
+# From 0 to 100, 0 - is very high compression and very low quality, 100 - higher quality and minimum compression.
+compression = 50
 
 # Timeouts (in seconds) used by the mplayer monitor.
 # Change with caution, because high values can slow down processing of corrupted videos.

--- a/iped-app/resources/config/conf/VideoThumbsConfig.txt
+++ b/iped-app/resources/config/conf/VideoThumbsConfig.txt
@@ -5,9 +5,13 @@
 # MPlayer for Windows is already distributed side by side with this software
 # For Linux, mplayer must be compiled and installed on system path.
 
-# Thumbs extraction configuration, format: <frame pixel width>,<columns>,<rows>. 
+# Thumbs extraction configuration, format: <frame maximum size in pixels>,<columns>,<rows>. 
 # The higher the resolution or number of thumbs, the slower the extraction.
-Layout = 256,4,5
+Layout = 320,4,5
+
+# Compression level of the generated image file.
+# From 0 to 100, 0 - is very high compression and very low quality; 1 - higher quality and minimum compression.
+Compression = 50
 
 # Timeouts (in seconds) used by the mplayer monitor.
 # Change with caution, because high values can slow down processing of corrupted videos.
@@ -22,7 +26,7 @@ Verbose = false
 
 # Gallery thumbnail configuration for videos.
 # Comment to disable (full video preview image will be shown in the gallery).
-# Format: <gallery image width in pixels, minimum number of frames, maximum of frames frames>.
+# Format: <gallery image maximum size in pixels, minimum number of frames, maximum of frames frames>.
 GalleryThumbs = 320,2,3
 
 # Enables video frames extraction as video subitems.

--- a/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/ImageThumbTaskConfig.java
@@ -26,6 +26,7 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
     private int highResDensity = 250;
     private int maxMPixelsInMemory = 32;
     private int maxViewImageSize = 2400;
+    private int compression = 50;
     private final Set<String> mimesToCreateView = new HashSet<String>();
 
     public boolean isEnableExternalConv() {
@@ -74,6 +75,10 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
 
     public int getMaxViewImageSize() {
         return maxViewImageSize;
+    }
+
+    public int getCompression() {
+        return compression;
     }
 
     public Set<String> getMimesToCreateView() {
@@ -150,6 +155,11 @@ public class ImageThumbTaskConfig extends AbstractTaskPropertiesConfig {
         value = properties.getProperty("maxMPixelsInMemory"); //$NON-NLS-1$
         if (value != null && !value.trim().isEmpty()) {
             maxMPixelsInMemory = Integer.valueOf(value.trim());
+        }
+
+        value = properties.getProperty("compression");
+        if (value != null && !value.trim().isEmpty()) {
+            compression = Integer.valueOf(value.trim());
         }
 
         value = properties.getProperty("mimesToCreateView");

--- a/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
+++ b/iped-engine/src/main/java/iped/engine/config/VideoThumbsConfig.java
@@ -32,10 +32,12 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     private static final String NUM_FRAMES_EQUATION = "numFramesEquation";
 
+    private static final String COMPRESSION = "compression";
+
     /**
-     * Image width of extracted frame.
+     * Maximum size (width/height) of extracted frames.
      */
-    private int width = 200;
+    private int size = 240;
 
     /**
      * Number of image columns.
@@ -67,9 +69,11 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
      */
     private int timeoutProcess = 15000;
 
-    private int galleryThumbWidth = -1;
+    private int galleryThumbSize = -1;
     private int galleryMinThumbs = -1;
     private int galleryMaxThumbs = -1;
+
+    private int compression = 50;
 
     /**
      * Extracts video frames using original video resolution.
@@ -94,9 +98,8 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
      */
     private String numFramesEquation;
 
-
-    public int getWidth() {
-        return width;
+    public int getSize() {
+        return size;
     }
 
     public int getColumns() {
@@ -123,8 +126,8 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         return timeoutProcess;
     }
 
-    public int getGalleryThumbWidth() {
-        return galleryThumbWidth;
+    public int getGalleryThumbSize() {
+        return galleryThumbSize;
     }
 
     public int getGalleryMinThumbs() {
@@ -145,6 +148,10 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
 
     public int getMaxDimensionSize() {
         return maxDimensionSize;
+    }
+
+    public int getCompression() {
+        return compression;
     }
 
     public String getNumFramesEquation() {
@@ -169,7 +176,7 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         if (value != null) {
             String[] vals = value.trim().split(","); //$NON-NLS-1$
             if (vals.length == 3) {
-                width = Integer.parseInt(vals[0].trim());
+                size = Integer.parseInt(vals[0].trim());
                 columns = Integer.parseInt(vals[1].trim());
                 rows = Integer.parseInt(vals[2].trim());
             }
@@ -209,7 +216,7 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         if (value != null) {
             String[] vals = value.trim().split(","); //$NON-NLS-1$
             if (vals.length == 3) {
-                galleryThumbWidth = Integer.parseInt(vals[0].trim());
+                galleryThumbSize = Integer.parseInt(vals[0].trim());
                 galleryMinThumbs = Integer.parseInt(vals[1].trim());
                 galleryMaxThumbs = Integer.parseInt(vals[2].trim());
             }
@@ -219,7 +226,17 @@ public class VideoThumbsConfig extends AbstractTaskPropertiesConfig {
         if (value != null) {
             maxDimensionSize = Integer.parseInt(value.trim());
         }
-        
+
+        value = properties.getProperty(COMPRESSION);
+        if (value != null) {
+            compression = Integer.parseInt(value.trim());
+            if (compression < 0) {
+                compression = 0;
+            } else if (compression > 100) {
+                compression = 100;
+            }
+        }
+
         value = properties.getProperty(NUM_FRAMES_EQUATION);
         if (value != null) {
             numFramesEquation = value.trim();

--- a/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ImageThumbTask.java
@@ -59,6 +59,7 @@ public class ImageThumbTask extends ThumbTask {
     private ExternalImageConverter externalImageConverter;
     private static final AtomicBoolean extConvPropInit = new AtomicBoolean(false);
 
+    private int compression;
     private int thumbSize;
     private int maxViewImageSize;
     private Set<String> mimesToCreateView;
@@ -102,6 +103,7 @@ public class ImageThumbTask extends ThumbTask {
 
         externalImageConverter = new ExternalImageConverter(executor);
         thumbSize = imgThumbConfig.getThumbSize();
+        compression = imgThumbConfig.getCompression();
         maxViewImageSize = imgThumbConfig.getMaxViewImageSize();
         mimesToCreateView = imgThumbConfig.getMimesToCreateView();
 
@@ -386,7 +388,7 @@ public class ImageThumbTask extends ThumbTask {
                 t = System.currentTimeMillis();
                 performanceStats[18]++;
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                ImageIO.write(img, "jpg", baos); //$NON-NLS-1$
+                ImageUtil.writeCompressedJPG(img, baos, compression);
                 evidence.setThumb(baos.toByteArray());
                 performanceStats[19] += System.currentTimeMillis() - t;
             }

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbTask.java
@@ -272,12 +272,13 @@ public class VideoThumbTask extends ThumbTask {
         videoThumbsMaker.setTimeoutProcess(videoConfig.getTimeoutProcess());
         videoThumbsMaker.setTimeoutInfo(videoConfig.getTimeoutInfo());
         videoThumbsMaker.setVideoThumbsOriginalDimension(videoConfig.getVideoThumbsOriginalDimension());
+        videoThumbsMaker.setCompression(videoConfig.getCompression()); 
         videoThumbsMaker.setMaxDimensionSize(videoConfig.getMaxDimensionSize());
         videoThumbsMaker.setNumFramesEquation(videoConfig.getNumFramesEquation());
 
         // Cria configurações de extração de cenas
         configs = new ArrayList<VideoThumbsOutputConfig>();
-        configs.add(mainConfig = new VideoThumbsOutputConfig(null, videoConfig.getWidth(), videoConfig.getColumns(), videoConfig.getRows(), 2));
+        configs.add(mainConfig = new VideoThumbsOutputConfig(null, videoConfig.getSize(), videoConfig.getColumns(), videoConfig.getRows(), 2));
 
         // Inicializa diretório de saída
         baseFolder = new File(output, "view"); //$NON-NLS-1$
@@ -460,24 +461,23 @@ public class VideoThumbTask extends ThumbTask {
 
             // If enabled (galleryThumbWidth > 0) create a thumb to be shown in the gallery,
             // with fewer frames
-            int galleryThumbWidth = videoConfig.getGalleryThumbWidth();
-            if (galleryThumbWidth > 0 && r.isSuccess()) {
+            int galleryThumbSize = videoConfig.getGalleryThumbSize();
+            if (galleryThumbSize > 0 && r.isSuccess()) {
                 try {
                     long t = System.currentTimeMillis();
                     Object[] read = ImageUtil.readJpegWithMetaData(mainOutFile);
                     BufferedImage fullImg = (BufferedImage) read[0];
                     String comment = (String) read[1];
-                    int galleryThumbHeight = galleryThumbWidth / 30 * 29;
-                    BufferedImage img = ImageUtil.getBestFramesFit(fullImg, comment, galleryThumbWidth,
-                            galleryThumbHeight, videoConfig.getGalleryMinThumbs(), videoConfig.getGalleryMaxThumbs());
+                    BufferedImage img = ImageUtil.getBestFramesFit(fullImg, comment, galleryThumbSize,
+                            galleryThumbSize, videoConfig.getGalleryMinThumbs(), videoConfig.getGalleryMaxThumbs());
 
                     if (img != null && !img.equals(fullImg)) {
-                        if (img.getWidth() > galleryThumbWidth || img.getHeight() > galleryThumbHeight) {
-                            img = ImageUtil.resizeImage(img, galleryThumbWidth, galleryThumbHeight);
+                        if (img.getWidth() > galleryThumbSize || img.getHeight() > galleryThumbSize) {
+                            img = ImageUtil.resizeImage(img, galleryThumbSize, galleryThumbSize);
                         }
                         img = ImageUtil.getOpaqueImage(img);
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        ImageIO.write(img, "jpg", baos); //$NON-NLS-1$
+                        ImageUtil.writeCompressedJPG(img, baos, videoConfig.getCompression());
                         evidence.setThumb(baos.toByteArray());
                         File thumbFile = getThumbFile(evidence);
                         saveThumb(evidence, thumbFile);
@@ -554,8 +554,13 @@ public class VideoThumbTask extends ThumbTask {
             w = dimension.width;
             h = dimension.height;
         } else {
-            w = config.getThumbWidth();
-            h = dimension.height * w / dimension.width;
+            if (dimension.width >= dimension.height) {
+                w = config.getThumbSize();
+                h = dimension.height * w / dimension.width;
+            } else {
+                h = config.getThumbSize();
+                w = dimension.width * h / dimension.height;
+            }
         }
         if (w > videoConfig.getMaxDimensionSize()) {
             w = videoConfig.getMaxDimensionSize();
@@ -568,6 +573,7 @@ public class VideoThumbTask extends ThumbTask {
 
         List<Double> framesNudityScore = new ArrayList<>();
 
+        int compression = videoConfig.getCompression();
         for (int i = 0; i < frames.size(); i++) {
 
             File frame = frames.get(i);
@@ -600,7 +606,7 @@ public class VideoThumbTask extends ThumbTask {
             }
             img = adjustFrameDimension(img, w, h);
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(img, "jpg", baos);
+            ImageUtil.writeCompressedJPG(img, baos, compression);
             ByteArrayInputStream is = new ByteArrayInputStream(baos.toByteArray());
             extractor.extractFile(is, newItem, item.getLength());
 

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsMaker.java
@@ -41,6 +41,7 @@ public class VideoThumbsMaker {
     private String mplayer = "mplayer.exe"; //$NON-NLS-1$
     private Boolean videoThumbsOriginalDimension = false;
     private int maxDimensionSize = 1024;
+    private int compression = 50;
     private String numFramesEquation;
     private ScriptEngine scriptEngine;
     private int timeoutProcess = 45000;
@@ -182,8 +183,8 @@ public class VideoThumbsMaker {
             if (maxThumbs < curr) {
                 maxThumbs = curr;
             }
-            if (maxSize < config.getThumbWidth()) {
-                maxSize = config.getThumbWidth();
+            if (maxSize < config.getThumbSize()) {
+                maxSize = config.getThumbSize();
             }
         }
 
@@ -463,8 +464,14 @@ public class VideoThumbsMaker {
         int border = config.getBorder();
         int w, h;
         // setting dimension for gallery thumbs
-        w = config.getThumbWidth();
-        h = dimension.height * w / dimension.width;
+        int size = config.getThumbSize();
+        if (dimension.width >= dimension.height) {
+            w = size;
+            h = dimension.height * w / dimension.width;
+        } else {
+            h = size;
+            w = dimension.width * h / dimension.height;
+        }
         if (w > maxDimensionSize) {
             w = maxDimensionSize;
         }
@@ -496,7 +503,7 @@ public class VideoThumbsMaker {
         }
         g2.dispose();
         ImageUtil.saveJpegWithMetadata(img, config.getOutFile(),
-                "Frames=" + config.getRows() + "x" + config.getColumns()); //$NON-NLS-1$ //$NON-NLS-2$
+                "Frames=" + config.getRows() + "x" + config.getColumns(), compression);
     }
 
     private final ExecResult run(String[] cmds, int timeout, File currDir) {
@@ -598,6 +605,10 @@ public class VideoThumbsMaker {
 
     public void setMaxDimensionSize(int maxDimensionSize) {
         this.maxDimensionSize = maxDimensionSize;
+    }
+
+    public void setCompression(int compression) {
+        this.compression = compression;
     }
 
     public Boolean getVideoThumbsOriginalDimension() {

--- a/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsOutputConfig.java
+++ b/iped-engine/src/main/java/iped/engine/task/video/VideoThumbsOutputConfig.java
@@ -29,11 +29,11 @@ import java.io.File;
 public class VideoThumbsOutputConfig {
 
     private File outFile;
-    private int thumbWidth, rows, columns, border;
+    private int thumbSize, rows, columns, border;
 
-    public VideoThumbsOutputConfig(File outFile, int thumbWidth, int columns, int rows, int border) {
+    public VideoThumbsOutputConfig(File outFile, int thumbSize, int columns, int rows, int border) {
         this.outFile = outFile;
-        this.thumbWidth = thumbWidth;
+        this.thumbSize = thumbSize;
         this.rows = rows;
         this.columns = columns;
         this.border = border;
@@ -43,8 +43,8 @@ public class VideoThumbsOutputConfig {
         return border;
     }
 
-    public int getThumbWidth() {
-        return thumbWidth;
+    public int getThumbSize() {
+        return thumbSize;
     }
 
     public File getOutFile() {
@@ -63,8 +63,8 @@ public class VideoThumbsOutputConfig {
         this.outFile = outFile;
     }
 
-    public void setThumbWidth(int thumbWidth) {
-        this.thumbWidth = thumbWidth;
+    public void setThumbSize(int thumbSize) {
+        this.thumbSize = thumbSize;
     }
 
     public void setRows(int rows) {
@@ -83,8 +83,8 @@ public class VideoThumbsOutputConfig {
         StringBuilder builder = new StringBuilder();
         builder.append("VideoThumbsOutputConfig [imageFile="); //$NON-NLS-1$
         builder.append(outFile);
-        builder.append(", thumbWidth="); //$NON-NLS-1$
-        builder.append(thumbWidth);
+        builder.append(", thumbSize="); //$NON-NLS-1$
+        builder.append(thumbSize);
         builder.append(", rows="); //$NON-NLS-1$
         builder.append(rows);
         builder.append(", columns="); //$NON-NLS-1$

--- a/iped-utils/src/main/java/iped/utils/ImageUtil.java
+++ b/iped-utils/src/main/java/iped/utils/ImageUtil.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -25,12 +26,13 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
+import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
-import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
 
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -601,10 +603,12 @@ public class ImageUtil {
     /**
      * Grava uma imagem JPEG e insere um comentário nos metadados da imagem.
      */
-    public static void saveJpegWithMetadata(BufferedImage img, File outFile, String data) throws IOException {
+    public static void saveJpegWithMetadata(BufferedImage img, File outFile, String data, int compression) throws IOException {
         ImageWriter writer = ImageIO.getImageWritersBySuffix("jpeg").next(); //$NON-NLS-1$
-        JPEGImageWriteParam jpegParams = (JPEGImageWriteParam) writer.getDefaultWriteParam();
-        IIOMetadata imageMetadata = writer.getDefaultImageMetadata(new ImageTypeSpecifier(img), jpegParams);
+        ImageWriteParam jpgWriteParam = writer.getDefaultWriteParam();
+        jpgWriteParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        jpgWriteParam.setCompressionQuality(compression / 100f);
+        IIOMetadata imageMetadata = writer.getDefaultImageMetadata(new ImageTypeSpecifier(img), jpgWriteParam);
 
         Element tree = (Element) imageMetadata.getAsTree("javax_imageio_jpeg_image_1.0"); //$NON-NLS-1$
         NodeList comNL = tree.getElementsByTagName("com"); //$NON-NLS-1$
@@ -622,7 +626,7 @@ public class ImageUtil {
         IIOImage iioimage = new IIOImage(img, null, imageMetadata);
         ImageOutputStream os = ImageIO.createImageOutputStream(outFile);
         writer.setOutput(os);
-        writer.write(null, iioimage, jpegParams);
+        writer.write(null, iioimage, jpgWriteParam);
         os.close();
         writer.dispose();
     }
@@ -755,5 +759,16 @@ public class ImageUtil {
             return op.filter(image, null);
         }
         return getImageFromType(image, BufferedImage.TYPE_BYTE_GRAY);
+    }
+    
+    public static void writeCompressedJPG(BufferedImage img, OutputStream baos, int compression) throws IOException {
+        ImageWriter jpgWriter = ImageIO.getImageWritersByFormatName("jpg").next();
+        ImageWriteParam jpgWriteParam = jpgWriter.getDefaultWriteParam();
+        jpgWriteParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        jpgWriteParam.setCompressionQuality(compression / 100f);
+        jpgWriter.setOutput(new MemoryCacheImageOutputStream(baos));
+        IIOImage outputImage = new IIOImage(img, null, null);
+        jpgWriter.write(null, outputImage, jpgWriteParam);
+        jpgWriter.dispose();        
     }
 }


### PR DESCRIPTION
Closes #2470. 
Closes #2471.