### PR TITLE
Avoid a NPE when msgstore.db is the input evidence (#2572)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/iped/parsers/whatsapp/WhatsAppParser.java
@@ -872,7 +872,7 @@ public class WhatsAppParser extends SQLite3DBParser {
     }
 
     private void fillAccountAvatar(WAAccount account, IItemSearcher searcher, String dbPath) {
-        if (account == null || account.getAvatar() != null || account.getAvatarPath() != null || dbPath == null) {
+        if (searcher == null || account == null || account.getAvatar() != null || account.getAvatarPath() != null || dbPath == null) {
             return;
         }
 


### PR DESCRIPTION
Fix #2572.