### PR TITLE
#2518 - Fix(iped-parsers-impl): force org.reflections to 0.10.2 to resolve transitive dependency issue

### DIFF
--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -242,6 +242,11 @@
           <artifactId>ofx4j</artifactId>
           <version>1.36</version>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.10.2</version>
+        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
### Summary

This PR fixes an issue caused by a transitive dependency in the iped-parsers-impl component.
The dependency com.webcohesion.ofx4j:ofx4j brings in org.reflections:reflections:0.9.10, which is outdated and triggers the error described in issue [#2518](https://github.com/sepinf-inc/IPED/discussions/2518).

### Fix

The fix forces the use of a newer version of org.reflections:

`org.reflections:reflections:0.10.2`

This resolves the compatibility issue for the affected functionality.

### Testing

- The fix was tested specifically for the functionality related to the reported error.
- I was not able to run the full build with all tests enabled, so further verification by maintainers is recommended.

### Notes
This change should be reviewed and tested in a full build before merging to ensure no regressions occur.