### PR TITLE
fix #2598: enqueue subitems to don't run workers from parsing threads

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/ParsingTask.java
@@ -694,6 +694,7 @@ public class ParsingTask extends ThumbTask implements EmbeddedDocumentExtractor 
                     // because we have at least 2 workers and a maximum of workers/2 expanding
                     // containers, so at least 1 worker is consuming items from the queue.
                     Manager.getInstance().getProcessingQueues().addItem(subItem);
+                    caseData.incDiscoveredEvidences(1);
                     Statistics.get().incSubitemsDiscovered();
                     numSubitems++;
 


### PR DESCRIPTION
Fix #2598.

Alternative much simpler fix for #2598. Please @gmdalpian and @aberenguel, test if it is working as expected.