### PR TITLE
'#2438: Fix sendToNext control in RemoteImageClassifierTask.

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/RemoteImageClassifierTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/RemoteImageClassifierTask.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,7 +110,7 @@ public class RemoteImageClassifierTask extends AbstractTask {
 
     // Queue to store 'name' to 'evidence' mapping
     private Map<String, IItem> queue = new TreeMap<>();
-    private ArrayList<IItem> sendToNext = new ArrayList<>();
+    private LinkedList<IItem> sendToNext = new LinkedList<>();
 
     // Zip archive holding files to be sent for classification
     private ZipFile zip;
@@ -350,13 +351,10 @@ public class RemoteImageClassifierTask extends AbstractTask {
             super.sendToNextTask(item);
             return;
         }
-        if (!sendToNext.isEmpty()) {
-            for (IItem it : sendToNext) {
-                super.sendToNextTask(it);
-            }
-            sendToNext.clear();
+        while (!sendToNext.isEmpty()) {
+            IItem it = sendToNext.removeFirst();
+            super.sendToNextTask(it);
         }
-
         if (!queue.containsValue(item) || item.isQueueEnd()) {
             super.sendToNextTask(item);
         }


### PR DESCRIPTION
Fix #2438.
See https://github.com/sepinf-inc/IPED/pull/2652#issuecomment-3395737226.