### PR TITLE
Adjust face rectangle to improve age detection (#2665)

### DIFF
--- a/iped-app/resources/scripts/tasks/AgeEstimationTask.py
+++ b/iped-app/resources/scripts/tasks/AgeEstimationTask.py
@@ -41,6 +41,11 @@ maxThreadsProp = 'maxThreads'
 from java.util.concurrent import ConcurrentHashMap
 cache = ConcurrentHashMap()
 
+# Margins proportions added to the face rectangle before submitting to the age estimation model.
+topMargin = 0.50
+bottomMargin = 0.20
+sidesMargin = 0.05
+
 # variables related to statistics
 classificationSuccess = 0
 classificationFail = 0
@@ -319,8 +324,22 @@ class AgeEstimationTask:
                     for face_location in face_locations:
                         logger.debug('AgeEstimationTask: face_location: ' + str(face_location))
 
-                        # extract the portion of the image corresponding to the face
-                        top, right, bottom, left = face_location                            
+                        # get face locaction and image dimensions
+                        top, right, bottom, left = face_location
+                        width, height = img.size
+
+                        # calculate margins, as proportions of the face rectangle
+                        mTop = int(topMargin * (bottom - top))
+                        mBottom = int(bottomMargin * (bottom - top))
+                        mSides = int(sidesMargin * (right - left))
+
+                        # add margins, trying to include the whole person's head
+                        top = max(0, top - mTop)
+                        bottom = min(img.height, bottom + mBottom)
+                        left = max(0, left - mSides)
+                        right = min(img.width, right + mSides)
+
+                        # extract the portion of the image corresponding to the face + border
                         face_img = img.crop((left, top, right, bottom))
                         
                         # add face item and face image to the corresponding lists


### PR DESCRIPTION
Closes #2665.

I tried other setups, like forcing a squared area (width = height), but results were worse.

The margin proportions were defined as constants in AgeEstimationTask.py. I thought about creating new entries in the configuration file, but these values aren't something the user would need to adjust.
If a developer or an advanced user wants to try other values, they can directly edit the Python file, which is already in the scripts folder (there is no need to rebuild everything).