### PR TITLE
Put image:exif:DateTimeUTCOffset with local timezone info 

### DIFF
--- a/iped-engine/src/main/java/iped/engine/task/index/ElasticSearchIndexTask.java
+++ b/iped-engine/src/main/java/iped/engine/task/index/ElasticSearchIndexTask.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.http.HttpHost;
@@ -652,6 +653,10 @@ public class ElasticSearchIndexTask extends AbstractTask {
                     builder.array(key, locations.toArray());
                 } else {
                     builder.array(key.replaceAll("\\.", "_"), values);
+                    if (key.contains("image:exif:DateTimeOriginal")) {
+                        builder.field("image:exif:DateTimeUTCOffset", TimeZone.getDefault().getRawOffset() / (1000 * 60));
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
'#2677 Put image:exif:DateTimeUTCOffset with local timezone info when item has 'image:exif:DateTimeOriginal'.

Currently image:exif:DateTimeOriginal metadata is formatted in processing machine configured TimeZone when sent to Elastic without timezone info, losing timezone information.

It seems to relate to https://issues.apache.org/jira/browse/TIKA-3815, and may be removed when Tika version is upgraded.