### PR TITLE
bump version to 4.4.0-snapshot

### DIFF
--- a/iped-api/pom.xml
+++ b/iped-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>iped-api</artifactId>

--- a/iped-app/pom.xml
+++ b/iped-app/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>iped-app</artifactId>

--- a/iped-carvers/iped-ahocorasick/pom.xml
+++ b/iped-carvers/iped-ahocorasick/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-carvers</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>iped-ahocorasick</artifactId>
 	<version>1.1</version>

--- a/iped-carvers/iped-carvers-api/pom.xml
+++ b/iped-carvers/iped-carvers-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-carvers</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>iped-carvers-api</artifactId>
 

--- a/iped-carvers/iped-carvers-impl/pom.xml
+++ b/iped-carvers/iped-carvers-impl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
     	<groupId>iped</groupId>
         <artifactId>iped-carvers</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>iped-carvers-impl</artifactId>

--- a/iped-carvers/pom.xml
+++ b/iped-carvers/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>iped-carvers</artifactId>

--- a/iped-engine/pom.xml
+++ b/iped-engine/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>iped-engine</artifactId>

--- a/iped-engine/src/main/java/iped/engine/Version.java
+++ b/iped-engine/src/main/java/iped/engine/Version.java
@@ -23,7 +23,7 @@ package iped.engine;
  */
 public class Version {
 
-    public static String APP_VERSION = "4.3.0"; //$NON-NLS-1$
+    public static String APP_VERSION = "4.4.0-snapshot"; //$NON-NLS-1$
     public static String APP_NAME_PREFIX = "Indexador e Processador de Evidências Digitais"; //$NON-NLS-1$
     public static String APP_NAME = APP_NAME_PREFIX + " " + APP_VERSION; //$NON-NLS-1$
     public static String APP_EXT = "IPED"; //$NON-NLS-1$

--- a/iped-geo/pom.xml
+++ b/iped-geo/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>iped-geo</artifactId>

--- a/iped-parsers/iped-parsers-impl/pom.xml
+++ b/iped-parsers/iped-parsers-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-parsers</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>iped-parsers-impl</artifactId>
     <packaging>jar</packaging>

--- a/iped-parsers/java-dbf/pom.xml
+++ b/iped-parsers/java-dbf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-parsers</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-dbf</artifactId>
     <version>1.0-patched</version>

--- a/iped-parsers/pom.xml
+++ b/iped-parsers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>iped-parsers</artifactId>

--- a/iped-utils/pom.xml
+++ b/iped-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>iped-utils</artifactId>

--- a/iped-viewers/iped-viewers-api/pom.xml
+++ b/iped-viewers/iped-viewers-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>iped</groupId>
     <artifactId>iped-viewers</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>iped-viewers-api</artifactId>

--- a/iped-viewers/iped-viewers-impl/pom.xml
+++ b/iped-viewers/iped-viewers-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>iped</groupId>
 		<artifactId>iped-viewers</artifactId>
-		<version>4.3.0</version>
+		<version>4.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>iped-viewers-impl</artifactId>
 

--- a/iped-viewers/pom.xml
+++ b/iped-viewers/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
         <groupId>iped</groupId>
         <artifactId>iped-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     
 	<artifactId>iped-viewers</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>iped</groupId>
     <artifactId>iped-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <modules>


### PR DESCRIPTION
To start a new development cycle and avoid having multiple 4.3.0 tarballs in the wild, I suggest updating the version in the `pom.xml` files.