### PR TITLE
Fix AD1Extractor.close() to close all channels on failure

### DIFF
--- a/iped-engine/src/main/java/iped/engine/datasource/ad1/AD1Extractor.java
+++ b/iped-engine/src/main/java/iped/engine/datasource/ad1/AD1Extractor.java
@@ -398,8 +398,21 @@ public class AD1Extractor implements Closeable {
 
     @Override
     public void close() throws IOException {
-        for (Closeable c : channels)
-            c.close();
+        IOException first = null;
+        for (Closeable c : channels) {
+            try {
+                c.close();
+            } catch (IOException e) {
+                if (first == null) {
+                    first = e;
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        if (first != null) {
+            throw first;
+        }
     }
 
     /**


### PR DESCRIPTION
### Problem
`AD1Extractor.close()` closes the `FileChannel`s sequentially. If one `close()` throws an `IOException`, the method exits early and remaining channels are not closed.

### Fix
Update `close()` to attempt closing all channels, collect the first `IOException`, suppress subsequent close failures, and throw after cleanup is complete.
