### PR TITLE
Update telegram-decoder to 1.0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <java.dbx.version>1.1-p6</java.dbx.version>
         <xerial.sqlite.version>3.41.2.2</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>
-        <telegram.version>release~1.0.15-SNAPSHOT</telegram.version>
+        <telegram.version>1.0.15</telegram.version>
         <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
         <bencode.version>1.4.1</bencode.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <java.dbx.version>1.1-p6</java.dbx.version>
         <xerial.sqlite.version>3.41.2.2</xerial.sqlite.version>
         <dockingframes.version>1.1.2</dockingframes.version>
-        <telegram.version>1.0.14</telegram.version>
+        <telegram.version>release~1.0.15-SNAPSHOT</telegram.version>
         <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
         <bencode.version>1.4.1</bencode.version>
     </properties>


### PR DESCRIPTION
Updates described in https://github.com/sepinf-inc/telegram-decoder/pull/7.

Note 1: `release~1.0.15-SNAPSHOT` means the branch `release/1.0.15`of https://github.com/sepinf-inc/telegram-decoder is being used. 

Note 2: Before merging, a tag `1.0.15` must be created in [sepinf-inc/telegram-decoder](https://github.com/sepinf-inc/telegram-decoder) AND the version must be changed to `1.0.15` in this pom.xml