### PR TITLE
Add unit tests for EvtxParser (Windows Event Log)

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/evtx/AbstractPkgTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/evtx/AbstractPkgTest.java
@@ -1,0 +1,55 @@
+package iped.parsers.evtx;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.AbstractParser;
+import org.apache.tika.parser.AutoDetectParser;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.Parser;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import iped.parsers.standard.StandardParser;
+import iped.parsers.util.BaseItemSearchContext;
+
+public abstract class AbstractPkgTest extends BaseItemSearchContext {
+
+    protected ParseContext evtxContext;
+    protected EmbeddedEvtxParser evtxTracker;
+
+    protected ParseContext getContext(String file) throws IOException {
+        evtxContext = super.getContext(file);
+        evtxTracker = new EmbeddedEvtxParser();
+        evtxContext.set(Parser.class, evtxTracker);
+        return evtxContext;
+    }
+
+    @SuppressWarnings("serial")
+    protected static class EmbeddedEvtxParser extends AbstractParser {
+
+        protected List<String> contentTypes = new ArrayList<>();
+        protected List<String> titles = new ArrayList<>();
+        protected List<Metadata> metadataList = new ArrayList<>();
+
+        @Override
+        public Set<MediaType> getSupportedTypes(ParseContext context) {
+            return new AutoDetectParser().getSupportedTypes(context);
+        }
+
+        @Override
+        public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
+                throws IOException, SAXException, TikaException {
+            contentTypes.add(metadata.get(StandardParser.INDEXER_CONTENT_TYPE));
+            titles.add(metadata.get(TikaCoreProperties.TITLE));
+            metadataList.add(metadata);
+        }
+    }
+}

--- a/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/evtx/EvtxParserTest.java
+++ b/iped-parsers/iped-parsers-impl/src/test/java/iped/parsers/evtx/EvtxParserTest.java
@@ -1,0 +1,160 @@
+package iped.parsers.evtx;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.sax.ToTextContentHandler;
+import org.junit.Test;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import iped.properties.ExtraProperties;
+
+public class EvtxParserTest extends AbstractPkgTest {
+
+    private static final String TEST_FILE = "test-files/test_evtxLog.evtx";
+
+    // Fixture: Microsoft-Windows-Servicing log from hosts ARES05 and ARES01
+    private static final String EXPECTED_PROVIDER = "Microsoft-Windows-Servicing";
+    private static final String EXPECTED_GUID     = "BD12F3B8-FC40-4A61-A307-B7A013A069C1";
+    private static final int    EXPECTED_FOLDERS  = 1;
+    private static final int    EXPECTED_GROUPS   = 16;
+    private static final int    EXPECTED_TOTAL    = EXPECTED_FOLDERS + EXPECTED_GROUPS;
+
+    private void parse(int maxEventPerItem) throws IOException, SAXException, TikaException {
+        evtxContext = getContext(TEST_FILE);
+        EvtxParser parser = new EvtxParser();
+        // same groupBy as iped-app/resources/config/conf/ParserConfig.xml
+        parser.setGroupBy("Event/System/EventID;Event/System/Computer");
+        parser.setMaxEventPerItem(maxEventPerItem);
+        ContentHandler handler = new ToTextContentHandler();
+        try (InputStream stream = getStream(TEST_FILE)) {
+            parser.parse(stream, handler, new Metadata(), evtxContext);
+        }
+    }
+
+    // ── output structure ─────────────────────────────────────────────────────
+
+    @Test
+    public void testTotalDocumentCount() throws IOException, SAXException, TikaException {
+        parse(100);
+        assertEquals(EXPECTED_TOTAL, evtxTracker.metadataList.size());
+    }
+
+    @Test
+    public void testAllEmbeddedDocsHaveCorrectContentType() throws IOException, SAXException, TikaException {
+        parse(100);
+        for (String ct : evtxTracker.contentTypes) {
+            assertEquals("application/x-elf-record", ct);
+        }
+    }
+
+    @Test
+    public void testFolderCount() throws IOException, SAXException, TikaException {
+        parse(100);
+        long folders = evtxTracker.metadataList.stream()
+                .filter(m -> "true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .count();
+        assertEquals(EXPECTED_FOLDERS, folders);
+    }
+
+    @Test
+    public void testRecordGroupCount() throws IOException, SAXException, TikaException {
+        parse(100);
+        long groups = evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .count();
+        assertEquals(EXPECTED_GROUPS, groups);
+    }
+
+    // ── provider folder ───────────────────────────────────────────────────────
+
+    @Test
+    public void testProviderFolderTitle() throws IOException, SAXException, TikaException {
+        parse(100);
+        String title = evtxTracker.metadataList.stream()
+                .filter(m -> "true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .map(m -> m.get(TikaCoreProperties.TITLE))
+                .findFirst().orElse(null);
+        assertEquals(EXPECTED_PROVIDER, title);
+    }
+
+    @Test
+    public void testProviderFolderGUID() throws IOException, SAXException, TikaException {
+        parse(100);
+        String guid = evtxTracker.metadataList.stream()
+                .filter(m -> "true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .map(m -> m.get(EvtxParser.EVTX_METADATA_PREFIX + "ProviderGUID"))
+                .findFirst().orElse(null);
+        assertEquals(EXPECTED_GUID, guid);
+    }
+
+    // ── record groups ─────────────────────────────────────────────────────────
+
+    @Test
+    public void testRecordGroupTitlesContainEventIDAndComputer() throws IOException, SAXException, TikaException {
+        parse(100);
+        evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .forEach(m -> {
+                    String title = m.get(TikaCoreProperties.TITLE);
+                    assertNotNull(title);
+                    assertTrue(title.contains("Event/System/EventID:"));
+                    assertTrue(title.contains("Event/System/Computer:"));
+                });
+    }
+
+    @Test
+    public void testRecordGroupsHaveRecordCount() throws IOException, SAXException, TikaException {
+        parse(100);
+        evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .forEach(m -> assertNotNull(m.get(EvtxParser.EVTX_METADATA_PREFIX + "recordCount")));
+    }
+
+    @Test
+    public void testRecordCountDoesNotExceedMaxEventPerItem() throws IOException, SAXException, TikaException {
+        parse(100);
+        evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .forEach(m -> assertTrue(
+                        Integer.parseInt(m.get(EvtxParser.EVTX_METADATA_PREFIX + "recordCount")) <= 100));
+    }
+
+    @Test
+    public void testAllRecordGroupsHaveEventRecordIDs() throws IOException, SAXException, TikaException {
+        parse(100);
+        evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .forEach(m -> assertNotNull(m.get(EvtxParser.EVTX_METADATA_PREFIX + "eventRecordID")));
+    }
+
+    @Test
+    public void testAllDocsShareSameProviderGUID() throws IOException, SAXException, TikaException {
+        parse(100);
+        evtxTracker.metadataList.forEach(m ->
+                assertEquals(EXPECTED_GUID, m.get(EvtxParser.EVTX_METADATA_PREFIX + "ProviderGUID")));
+    }
+
+    // ── configuration ─────────────────────────────────────────────────────────
+
+    @Test
+    public void testSupportedTypes() {
+        EvtxParser parser = new EvtxParser();
+        assertEquals(1, parser.getSupportedTypes(null).size());
+        assertEquals("application/x-elf-file",
+                parser.getSupportedTypes(null).iterator().next().toString());
+    }
+
+    @Test
+    public void testMaxEventPerItemIsRespected() throws IOException, SAXException, TikaException {
+        parse(10);
+        evtxTracker.metadataList.stream()
+                .filter(m -> !"true".equals(m.get(ExtraProperties.EMBEDDED_FOLDER)))
+                .forEach(m -> assertTrue(
+                        Integer.parseInt(m.get(EvtxParser.EVTX_METADATA_PREFIX + "recordCount")) <= 10));
+    }
+}


### PR DESCRIPTION
Closes #2911

## What this PR does

Adds unit tests for `EvtxParser`, which parses Windows Event Log (`.evtx`) files. The parser has been in production since at least 2019 but had no automated test coverage. A test fixture (`test_evtxLog.evtx`, 1 MB) was committed in June 2022 as part of issue #1093 but the corresponding test class was never written — this PR completes that work.

## Files added

| File | Description |
|------|-------------|
| `iped-parsers/.../evtx/AbstractPkgTest.java` | Package test infrastructure, following the pattern of `usnjrnl/AbstractPkgTest`, `telegram/AbstractPkgTest`, etc. |
| `iped-parsers/.../evtx/EvtxParserTest.java` | 13 JUnit test cases |

No new binary files — the existing `test-files/test_evtxLog.evtx` fixture is reused.

## Test cases

The parser is configured with the same parameters as `iped-app/resources/config/conf/ParserConfig.xml` (`groupBy=Event/System/EventID;Event/System/Computer`, `maxEventPerItem=100`).

| Test | What is verified |
|------|-----------------|
| `testTotalDocumentCount` | Parser produces exactly 17 embedded documents from the fixture |
| `testAllEmbeddedDocsHaveCorrectContentType` | All docs have content-type `application/x-elf-record` |
| `testFolderCount` | Exactly 1 provider folder is created |
| `testRecordGroupCount` | Exactly 16 record groups are created |
| `testProviderFolderTitle` | Provider folder title is `Microsoft-Windows-Servicing` |
| `testProviderFolderGUID` | Provider GUID is `BD12F3B8-FC40-4A61-A307-B7A013A069C1` |
| `testRecordGroupTitlesContainEventIDAndComputer` | All group titles contain both `Event/System/EventID:` and `Event/System/Computer:` fields |
| `testRecordGroupsHaveRecordCount` | All groups have `WinEvt:recordCount` metadata |
| `testRecordCountDoesNotExceedMaxEventPerItem` | No group exceeds `maxEventPerItem=100` |
| `testAllRecordGroupsHaveEventRecordIDs` | All groups have `WinEvt:eventRecordID` metadata |
| `testAllDocsShareSameProviderGUID` | GUID is consistent across all documents (folder and groups) |
| `testSupportedTypes` | `getSupportedTypes` returns `application/x-elf-file` |
| `testMaxEventPerItemIsRespected` | With `maxEventPerItem=10`, no group exceeds 10 records |

## Tests

```
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Verified via `mvn test -pl iped-parsers/iped-parsers-impl -Dtest=EvtxParserTest`.