### PR TITLE
Scale Lucene RAM buffer with the available heap

### DIFF
--- a/iped-engine/src/main/java/iped/engine/core/Manager.java
+++ b/iped-engine/src/main/java/iped/engine/core/Manager.java
@@ -424,7 +424,7 @@ public class Manager {
          * 512MB Lucene gains little.
          */
         long heapMB = Runtime.getRuntime().maxMemory() / (1024 * 1024);
-        conf.setRAMBufferSizeMB(Math.min(Math.max(64, heapMB / 16), 512));
+        conf.setRAMBufferSizeMB(Math.min(Math.max(64, heapMB / 32), 512));
         TieredMergePolicy tieredPolicy = new TieredMergePolicy();
         /*
          * Seta tamanho máximo dos subíndices. Padrão é 5GB. Poucos subíndices grandes

--- a/iped-engine/src/main/java/iped/engine/core/Manager.java
+++ b/iped-engine/src/main/java/iped/engine/core/Manager.java
@@ -417,7 +417,14 @@ public class Manager {
             mergeScheduler.setMaxMergesAndThreads(8, 4);
         }
         conf.setMergeScheduler(mergeScheduler);
-        conf.setRAMBufferSizeMB(64);
+        /*
+         * Scale the RAM buffer with the heap: fewer flushes and small-segment
+         * merges on large cases. 64MB (the old fixed value) stays as the floor
+         * so memory-constrained machines keep the previous behavior; above
+         * 512MB Lucene gains little.
+         */
+        long heapMB = Runtime.getRuntime().maxMemory() / (1024 * 1024);
+        conf.setRAMBufferSizeMB(Math.min(Math.max(64, heapMB / 16), 512));
         TieredMergePolicy tieredPolicy = new TieredMergePolicy();
         /*
          * Seta tamanho máximo dos subíndices. Padrão é 5GB. Poucos subíndices grandes


### PR DESCRIPTION
getIndexWriterConfig() sets a fixed 64MB RAM buffer regardless of the heap size. On large cases running with large heaps this causes frequent segment flushes and many small-segment merges during indexing.

This change scales the buffer to heap/16, keeping the previous 64MB as the floor and 512MB as a conservative cap (Lucene gains little beyond that). Examples: 1GB heap -> 64MB (unchanged), 4GB -> 256MB, 8GB and above -> 512MB.

Machines with small heaps keep exactly the previous behavior, so low-end hardware is unaffected. Pure Java, no new dependencies.