### PR TITLE
Fix ImageMagick thumbnail timeouts on machines without ImageMagick installed (#2905)

### DIFF
--- a/iped-utils/src/main/java/iped/utils/ExternalImageConverter.java
+++ b/iped-utils/src/main/java/iped/utils/ExternalImageConverter.java
@@ -46,6 +46,7 @@ public class ExternalImageConverter implements Closeable {
     private static final String IM_TEMP_PATH = "MAGICK_TEMPORARY_PATH"; //$NON-NLS-1$
     private static final String GM_TEMP_PATH = "MAGICK_TMPDIR"; //$NON-NLS-1$
     private static final String MAGICK_AREA_LIMIT = "MAGICK_AREA_LIMIT"; //$NON-NLS-1$
+    private static final String MAGICK_CONFIGURE_PATH = "MAGICK_CONFIGURE_PATH"; //$NON-NLS-1$
     private static final String DENSITY = "DENSITY"; //$NON-NLS-1$
     private static final String INPUT = "INPUT"; //$NON-NLS-1$
 
@@ -206,13 +207,32 @@ public class ExternalImageConverter implements Closeable {
         }
     }
 
+    /**
+     * Sets up the environment of a magick {@link ProcessBuilder}.
+     *
+     * ImageMagick "installed-mode" Windows builds locate their configuration files
+     * (delegates.xml, policy.xml, colors.xml, ...) through the Windows registry (written by the
+     * installer) or through the MAGICK_CONFIGURE_PATH environment variable. IPED ships a portable
+     * binary and installs no registry keys, so without this variable magick probes and fails to
+     * find its config on every launch (~0.5s per process), and that startup cost serializes across
+     * the many concurrent magick processes IPED spawns (one per worker), causing thousands of
+     * thumbnail timeouts on high-core machines (see sepinf-inc/IPED#2905). Pointing it at the
+     * bundled tools/imagemagick folder fixes it. On Linux toolPath is empty and the
+     * system-installed magick finds its own config, so this is a no-op there.
+     */
+    private void setProcessEnvironment(ProcessBuilder pb) {
+        pb.environment().put(useGM ? GM_TEMP_PATH : IM_TEMP_PATH, tmpDir.getAbsolutePath());
+        pb.environment().put(MAGICK_AREA_LIMIT, magickAreaLimit);
+        if (!useGM && !toolPath.isEmpty())
+            pb.environment().put(MAGICK_CONFIGURE_PATH, toolPath);
+    }
+
     public Dimension getDimension(InputStream in) {
         if (!enabled)
             return null;
 
         ProcessBuilder pb = new ProcessBuilder();
-        pb.environment().put(MAGICK_AREA_LIMIT, magickAreaLimit);
-        pb.environment().put(MAGICK_AREA_LIMIT, magickAreaLimit);
+        setProcessEnvironment(pb);
 
         String[] cmd = { CMD[0], "identify", "-ping", "-format", "%w %h", "-" };
         try {
@@ -244,8 +264,7 @@ public class ExternalImageConverter implements Closeable {
             return null;
 
         ProcessBuilder pb = new ProcessBuilder();
-        pb.environment().put(useGM ? GM_TEMP_PATH : IM_TEMP_PATH, tmpDir.getAbsolutePath());
-        pb.environment().put(MAGICK_AREA_LIMIT, magickAreaLimit);
+        setProcessEnvironment(pb);
 
         pb.command(getCmd(maxDim, highRes, objIn));
         Process p = null;


### PR DESCRIPTION
## Summary

Fixes the thousands of thumbnail-generation timeouts investigated in #2905. Full root-cause analysis, benchmarks and the regression bisect are in that issue; this PR implements the recommended code fix.

> Note: this is an independent **side fix** found while working on an unrelated Tika upgrade — it has **no relation to Tika** and touches only `ExternalImageConverter`.

## Problem

The bundled ImageMagick build (`7.1.1-43-q8`, an "installed-mode" Windows build) locates its configuration files (`delegates.xml`, `policy.xml`, `colors.xml`, ...) **only** via the Windows registry written by its installer, or via the `MAGICK_CONFIGURE_PATH` environment variable. IPED ships a **portable** binary and installs no registry keys, so on a machine that does not have ImageMagick installed system-wide, `magick` probes and fails to find its config on **every launch** (~0.5s per process).

Because IPED spawns one `magick` process per worker, that per-process startup cost **serializes across all the concurrent conversions**, so on a high-core-count machine per-conversion latency crosses `imgConvTimeout` and produces thousands of `Timeout creating thumb` warnings (and greatly inflated processing time). Machines that happen to have ImageMagick installed don't see it, because the registry key the installed build falls back to acts as the missing config anchor — which is why it reproduced only on a clean machine despite identical hardware.

This is a regression from #2414 (`7.1.1-19` → `7.1.1-43`): the previous bundled build resolved its config relative to the executable and needed no anchor.

## Fix

Set `MAGICK_CONFIGURE_PATH` to the bundled `tools/imagemagick` folder when spawning `magick`, alongside the existing `MAGICK_TEMPORARY_PATH` / `MAGICK_AREA_LIMIT` setup. The logic is factored into a small helper used by both spawn sites (`getDimension` and `doGetImage`), which also removes a duplicated `MAGICK_AREA_LIMIT` line in `getDimension`.

`toolPath` is already computed as `<winToolPathPrefix>/tools/imagemagick`. On Linux `toolPath` is empty and the system-installed `magick` finds its own config, so the change is a no-op there (guarded by `!toolPath.isEmpty()`). It is also skipped for GraphicsMagick (`useGM`).

This is version-independent: it fixes the current bundled binary and any future "installed-mode" build without relying on ImageMagick being installed on the analyst's machine.

## Measured impact

On a 48-core Windows machine, real SVG→thumbnail conversion with 48 concurrent `magick` processes:

| | per-process startup | throughput @ K=48 |
|---|---|---|
| before | ~0.54s | ~1.3 conv/s |
| after (`MAGICK_CONFIGURE_PATH` set) | ~0.04s | ~72 conv/s |

## Testing

- `mvn -pl iped-utils -am -DskipTests compile` — BUILD SUCCESS.
- Verified via the standalone binary that setting `MAGICK_CONFIGURE_PATH` to the bundled config folder drops `magick` startup from ~0.5s to ~0.04s and eliminates the config-probing warning, taking 48 concurrent SVG conversions from ~1.3/s to ~72/s.
